### PR TITLE
Support boolean attributes

### DIFF
--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -12,7 +12,11 @@ module.exports = {
     style     : require('./style'),
 
     attr: function (value) {
-        this.el.setAttribute(this.arg, value)
+        if (value || value === 0) {
+            this.el.setAttribute(this.arg, value)
+        } else {
+            this.el.removeAttribute(this.arg)
+        }
     },
 
     text: function (value) {

--- a/test/unit/specs/directives.js
+++ b/test/unit/specs/directives.js
@@ -2,13 +2,42 @@ describe('UNIT: Directives', function () {
     
     describe('attr', function () {
 
-        var dir = mockDirective('attr')
-        dir.arg = 'href'
+        var dir = mockDirective('attr', 'input'),
+            el = dir.el
 
-        it('should set an attribute', function () {
-            var url = 'http://a.b.com'
-            dir.update(url)
-            assert.strictEqual(dir.el.getAttribute('href'), url)
+        it('should set a truthy attribute value', function () {
+            var value = 'Arrrrrr!'
+
+            dir.arg = 'value'
+            dir.update(value)
+            assert.strictEqual(el.getAttribute('value'), value)
+        })
+
+        it('should set attribute value to `0`', function () {
+            dir.arg = 'value'
+            dir.update(0)
+            assert.strictEqual(el.getAttribute('value'), '0')
+        })
+
+        it('should remove an attribute if value is `false`', function () {
+            dir.arg = 'disabled'
+            el.setAttribute('disabled', 'disabled')
+            dir.update(false)
+            assert.strictEqual(el.getAttribute('disabled'), null)
+        })
+
+        it('should remove an attribute if value is `null`', function () {
+            dir.arg = 'disabled'
+            el.setAttribute('disabled', 'disabled')
+            dir.update(null)
+            assert.strictEqual(el.getAttribute('disabled'), null)
+        })
+
+        it('should remove an attribute if value is `undefined`', function () {
+            dir.arg = 'disabled'
+            el.setAttribute('disabled', 'disabled')
+            dir.update(undefined)
+            assert.strictEqual(el.getAttribute('disabled'), null)
         })
 
     })


### PR DESCRIPTION
Current `v-attr` implementation doesn't support boolean attributes (e.g. `disabled`).
Here is the common use-case:

```
<button type="submit" v-attr="disabled: !submittionAllowed">
```

It doesn't work because `v-attr` uses `this.el.setAttribute` method. So, when `submittionAllowed` equals to `true`, then submit button will look like this:

```
<button type="submit" disabled="false">
```

...which is treated by browser as disabled button.
My proposal is to remove current attribute if it's value is falsy (except zero).
