### PR TITLE
Implements plugin parameters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -66,10 +66,15 @@ ViewModel.use = function (plugin) {
             return utils.warn('Cannot find plugin: ' + plugin)
         }
     }
-    if (typeof plugin === 'function') {
-        plugin(ViewModel)
-    } else if (plugin.install) {
-        plugin.install(ViewModel)
+
+    // additional parameters
+    var args = [].slice.call(arguments, 1)
+    args.unshift(ViewModel)
+
+    if (typeof plugin.install === 'function') {
+        plugin.install.apply(plugin, args)
+    } else {
+        plugin.apply(null, args)
     }
 }
 

--- a/test/unit/specs/api.js
+++ b/test/unit/specs/api.js
@@ -61,13 +61,43 @@ describe('UNIT: API', function () {
             assert.ok(called)
         })
 
-        it('should install a plugin if its a function itself', function () {
+        it('should install a plugin if it’s a function itself', function () {
             var called = false
             Vue.use(function (vue) {
                 called = true
                 assert.strictEqual(vue, Vue)
             })
             assert.ok(called)
+        })
+
+        it('should pass any additional parameter', function () {
+            var param1 = 'a',
+                param2 = { b: 'c' }
+
+            Vue.use(function (vue, p1, p2) {
+                assert.strictEqual(p1, param1)
+                assert.strictEqual(p2, param2)
+            }, param1, param2)
+
+            Vue.use({
+                install: function (vue, p1, p2) {
+                    assert.strictEqual(p1, param1)
+                    assert.strictEqual(p2, param2)
+                }
+            }, param1, param2)
+        })
+
+        it('should properly set the value of this', function () {
+            var plugin = {
+                install: function () {
+                    assert.strictEqual(this, plugin)
+                }
+            }
+            Vue.use(plugin)
+
+            Vue.use(function () {
+                assert.strictEqual(this, global)
+            })
         })
 
     })

--- a/test/unit/utils/prepare.js
+++ b/test/unit/utils/prepare.js
@@ -43,3 +43,5 @@ var testDiv = document.createElement('div')
 testDiv.id = 'test'
 testDiv.style.display = 'none'
 document.body.appendChild(testDiv)
+
+var global = this


### PR DESCRIPTION
Small change: every additional parameters is passed to the function instead of a single `options` param. As a consequence, `this` is set to the current ViewModel if the plugin is a function.

Tell me if that’s OK, otherwise I will change it to respect what you said in #88. I will also make a pull request on https://github.com/vuejs/vuejs.org.
