### PR TITLE
make utils.extend() return the extended object

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -89,6 +89,7 @@ var utils = module.exports = {
             if (protective && obj[key]) continue
             obj[key] = ext[key]
         }
+        return obj
     },
 
     /**

--- a/test/unit/specs/utils.js
+++ b/test/unit/specs/utils.js
@@ -137,6 +137,12 @@ describe('UNIT: Utils', function () {
             assert.strictEqual(a.b, b.b)
         })
 
+        it('should always return the extended object', function () {
+            var a = {a: 1}, b = {a: {}, b: 2}
+            assert.strictEqual(a, utils.extend(a, b))
+            assert.strictEqual(a, utils.extend(a, undefined))
+        })
+
     })
 
     describe('unique', function () {


### PR DESCRIPTION
It would allow to do this:

``` js
function foo (options) {
    options = utils.extend({
        a: 1 // default option
    }, options)
}
```

Instead of this:

``` js
function foo (optionsExt) {
    var options = {
        a: 1 // default option
    }
    utils.extend(options, optionsExt)
}
```
