### PR TITLE
v-transition: remove .v-leave if a transition is aborted (fixes #127)

### DIFF
--- a/src/transition.js
+++ b/src/transition.js
@@ -76,6 +76,7 @@ function applyTransitionClass (el, stage, changeState) {
         // cancel unfinished leave transition
         if (lastLeaveCallback) {
             el.removeEventListener(endEvent, lastLeaveCallback)
+            classList.remove(config.leaveClass)
             el.vue_trans_cb = null
         }
 

--- a/test/unit/specs/transition.js
+++ b/test/unit/specs/transition.js
@@ -74,7 +74,16 @@ describe('UNIT: Transition', function () {
                 el.dispatchEvent(e)
                 assert.notOk(cbCalled)
             })
-            
+
+            it('should remove the v-leave class if the leave callback exists', function () {
+                var el = mockEl('css')
+                document.body.appendChild(el)
+                el.style.width = '1px'
+                code = transition(el, -1, function(){}, compiler)
+                code = transition(el, 1, function(){}, compiler)
+                assert.notOk(el.classList.contains(leaveClass))
+            })
+
             it('should remove the class afterwards', function () {
                 assert.notOk(el.classList.contains(enterClass))
             })


### PR DESCRIPTION
Updated demo: http://jsfiddle.net/PnHak/2/
