### PR TITLE
fix #161: event delegation does not properly handle event.stopPropagation()

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -739,10 +739,15 @@ CompilerProto.addListener = function (listener) {
             targets: [],
             handler: function (e) {
                 var i = delegator.targets.length,
-                    target
+                    target,
+                    stopPropagation = e.stopPropagation
+                e.stopPropagation = function () {
+                    this.isPropagationStopped = true
+                    stopPropagation.call(e)
+                }
                 while (i--) {
                     target = delegator.targets[i]
-                    if (target.el.contains(e.target) && target.handler) {
+                    if (target.el.contains(e.target) && target.handler && !e.isPropagationStopped) {
                         target.handler(e)
                     }
                 }


### PR DESCRIPTION
I'm not quite sure where to begin on test cases for this, but will happily add them with a little direction.
