### PR TITLE
fix #176: set textarea `v-model` initial value with compiled text node children

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -537,6 +537,11 @@ CompilerProto.bindDirective = function (directive, bindingOwner) {
     }
     // set initial value
     directive.update(value, true)
+
+    // handle textarea initial value
+    if (directive.el.tagName === 'TEXTAREA' && directive.el.hasChildNodes) {
+        directive._dirty = true;
+    }
 }
 
 /**

--- a/src/directives/model.js
+++ b/src/directives/model.js
@@ -139,6 +139,9 @@ module.exports = {
             el.checked = value == el.value
         } else if (el.type === 'checkbox') { // checkbox
             el.checked = !!value
+        } else if (el.type === 'textarea' && this._dirty) {
+            this._set()
+            this._dirty = false
         } else {
             el[this.attr] = utils.guard(value)
         }


### PR DESCRIPTION
The test suite shows a number of failing tests, but I'm not sure they're from this change.
