### PR TITLE
fix #176: set v-model initial value from compile child text nodes

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -537,6 +537,11 @@ CompilerProto.bindDirective = function (directive, bindingOwner) {
     }
     // set initial value
     directive.update(value, true)
+
+    // handle textarea initial value
+    if (directive.el.tagName === 'TEXTAREA' && directive.el.hasChildNodes()) {
+        directive._dirty = true;
+    }
 }
 
 /**

--- a/src/directives/model.js
+++ b/src/directives/model.js
@@ -139,6 +139,9 @@ module.exports = {
             el.checked = value == el.value
         } else if (el.type === 'checkbox') { // checkbox
             el.checked = !!value
+        } else if (el.type === 'textarea' && this._dirty) {
+            this._set()
+            this._dirty = false
         } else {
             el[this.attr] = utils.guard(value)
         }


### PR DESCRIPTION
You haven't weighed in on this issue yet, but I though I would take a crack at it.  There are a number of failing test cases, but I'm not sure there from this change.
