### PR TITLE
Fixed transitions on some Android 4.1 devices

### DIFF
--- a/src/transition.js
+++ b/src/transition.js
@@ -208,9 +208,9 @@ function sniffEndEvents () {
     var el = document.createElement('vue'),
         defaultEvent = 'transitionend',
         events = {
+            'webkitTransition' : 'webkitTransitionEnd',
             'transition'       : defaultEvent,
-            'mozTransition'    : defaultEvent,
-            'webkitTransition' : 'webkitTransitionEnd'
+            'mozTransition'    : defaultEvent
         },
         ret = {}
     for (var name in events) {


### PR DESCRIPTION
On some devices (tested on a Samsung Galaxy S2), the Android 4.1 browser erroneously reports to support unprefixed transitions events, while it’s in fact not implemented.

The solution is to test for the prefixed version first. The WebKit-prefixed event has been moved on top of the tested events, and while the Object properties order is not guaranteed in JavaScript (ES3, section 4.3.3), it is the case in the targeted browser.

More information:
https://github.com/Modernizr/Modernizr/issues/897
https://bugs.dojotoolkit.org/ticket/17164
