### PR TITLE
Namespaced attributes 

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -525,17 +525,18 @@ CompilerProto.compileElement = function (node, root) {
         var prefix = config.prefix + '-',
             attrs = slice.call(node.attributes),
             params = this.options.paramAttributes,
-            attr, isDirective, exp, directives, directive, dirname
+            attr, attrname, isDirective, exp, directives, directive, dirname
 
         for (i = 0, l = attrs.length; i < l; i++) {
 
             attr = attrs[i]
+            attrname = attr.name
             isDirective = false
 
-            if (attr.name.indexOf(prefix) === 0) {
+            if (attrname.indexOf(prefix) === 0) {
                 // a directive - split, parse and bind it.
                 isDirective = true
-                dirname = attr.name.slice(prefix.length)
+                dirname = attrname.slice(prefix.length)
                 // build with multiple: true
                 directives = this.parseDirective(dirname, attr.value, node, true)
                 // loop through clauses (separated by ",")
@@ -552,8 +553,11 @@ CompilerProto.compileElement = function (node, root) {
                 // non directive attribute, check interpolation tags
                 exp = TextParser.parseAttr(attr.value)
                 if (exp) {
-                    directive = this.parseDirective('attr', attr.name + ':' + exp, node)
-                    if (params && params.indexOf(attr.name) > -1) {
+                    if (attrname.indexOf(':') > -1) {
+                        attrname = attrname.replace(/\:/g, '\\:')
+                    }
+                    directive = this.parseDirective('attr', attrname + ':' + exp, node)
+                    if (params && params.indexOf(attrname) > -1) {
                         // a param attribute... we should use the parent binding
                         // to avoid circular updates like size={{size}}
                         this.bindDirective(directive, this.parent)
@@ -564,7 +568,7 @@ CompilerProto.compileElement = function (node, root) {
             }
 
             if (isDirective && dirname !== 'cloak') {
-                node.removeAttribute(attr.name)
+                node.removeAttribute(attrname)
             }
         }
 

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,5 +1,5 @@
 var dirId           = 1,
-    ARG_RE          = /^[\w\$-]+$/,
+    ARG_RE          = /^[\w\$\-(?:\\:)]+$/,
     FILTER_TOKEN_RE = /[^\s'"]+|'[^']+'|"[^"]+"/g,
     NESTING_RE      = /^\$(parent|root)\./,
     SINGLE_VAR_RE   = /^[\w\.$]+$/,
@@ -157,12 +157,13 @@ Directive.parse = function (str) {
             // reset & skip the comma
             dir = {}
             begin = argIndex = lastFilterIndex = i + 1
-        } else if (c === ':' && !dir.key && !dir.arg) {
+        } else if (c === ':' && str.charAt(i - 1) !== '\\' && !dir.key && !dir.arg) {
             // argument
             arg = str.slice(begin, i).trim()
+            if (arg.indexOf('\\:') > -1) arg = arg.replace(/\\:/g, ':');
             if (ARG_RE.test(arg)) {
                 argIndex = i + 1
-                dir.arg = str.slice(begin, i).trim()
+                dir.arg = arg
             }
         } else if (c === '|' && str.charAt(i + 1) !== '|' && str.charAt(i - 1) !== '|') {
             if (dir.key === undefined) {

--- a/test/unit/specs/directive.js
+++ b/test/unit/specs/directive.js
@@ -44,6 +44,14 @@ describe('Directive', function () {
             assert.equal(res[0].expression, 'arg:key')
         })
 
+        it('a\\:arg:key', function () {
+            var res = Directive.parse('a\\:arg:key')
+            assert.equal(res.length , 1)
+            assert.equal(res[0].key, 'key')
+            assert.equal(res[0].arg, 'a:arg')
+            assert.equal(res[0].expression, 'a\\:arg:key')
+        })
+
         it('arg : key | abc', function () {
             var res = Directive.parse(' arg : key | abc de')
             assert.equal(res.length , 1)


### PR DESCRIPTION
Just a suggestion for #253, don’t hesitate to close it if it does not fit your vision.

The compiler now replaces every `:` in an attribute name to escape it: `\:`.

If a directive name contains an escaped colon (`\:`), it won’t be considered as a separator.
