### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,19 @@
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.5",
     "karma-coffee-preprocessor": "~0.1.2"
+  },
+  "spm": {
+    "main": "src/main.js",
+    "ignore": [
+      ".*",
+      "examples",
+      "test",
+      "tasks",
+      "dist",
+      "Gruntfile.js",
+      "bower.json",
+      "component.json",
+      "*.md"
+    ]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/vue

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of vue in spmjs, I can add it for your account after signing in http://spmjs.io.
