### PR TITLE
fixed `v-repeat` directive where collection has 1

### DIFF
--- a/src/directives/repeat.js
+++ b/src/directives/repeat.js
@@ -149,26 +149,28 @@ module.exports = {
             targetNext = vms[i + 1]
             if (vm.$reused) {
                 nextEl = vm.$el.nextSibling
-                // destroyed VMs' element might still be in the DOM
-                // due to transitions
-                while (!nextEl.vue_vm && nextEl !== this.ref) {
-                    nextEl = nextEl.nextSibling
-                }
-                currentNext = nextEl.vue_vm
-                if (currentNext !== targetNext) {
-                    if (!targetNext) {
-                        ctn.insertBefore(vm.$el, this.ref)
-                    } else {
-                        nextEl = targetNext.$el
-                        // new VMs' element might not be in the DOM yet
-                        // due to transitions
-                        while (!nextEl.parentNode) {
-                            targetNext = vms[nextEl.vue_vm.$index + 1]
-                            nextEl = targetNext
-                                ? targetNext.$el
-                                : this.ref
+                if (nextEl) {
+                    // destroyed VMs' element might still be in the DOM
+                    // due to transitions
+                    while (!nextEl.vue_vm && nextEl !== this.ref) {
+                        nextEl = nextEl.nextSibling
+                    }
+                    currentNext = nextEl.vue_vm
+                    if (currentNext !== targetNext) {
+                        if (!targetNext) {
+                            ctn.insertBefore(vm.$el, this.ref)
+                        } else {
+                            nextEl = targetNext.$el
+                            // new VMs' element might not be in the DOM yet
+                            // due to transitions
+                            while (!nextEl.parentNode) {
+                                targetNext = vms[nextEl.vue_vm.$index + 1]
+                                nextEl = targetNext
+                                    ? targetNext.$el
+                                    : this.ref
+                            }
+                            ctn.insertBefore(vm.$el, nextEl)
                         }
-                        ctn.insertBefore(vm.$el, nextEl)
                     }
                 }
                 delete vm.$reused


### PR DESCRIPTION
If there is only 1 item in the collection, don't bother checking for other elements. `nextEl` does not exists and causes an exception.

I assume this would not affect a change in the model where a new collection also has a size of one, but it's a different object.  As the `vm.$reused` would not have been set?
