### PR TITLE
Update viewmodel.js

### DIFF
--- a/src/viewmodel.js
+++ b/src/viewmodel.js
@@ -17,7 +17,7 @@ var Compiler   = require('./compiler'),
  */
 function ViewModel (options) {
     // compile if options passed, if false return. options are passed directly to compiler
-    if( options === false ) return;
+    if (options === false) return;
     new Compiler(this, options)
 }
 


### PR DESCRIPTION
Allow passing false to constructor to bypass compilation. Add vue.init( config ) to defer setting configuration after construction has completed.
