### PR TITLE
fixed currency filter for negative numbers

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -38,11 +38,11 @@ filters.currency = function (value, sign) {
     value = parseFloat(value)
     if (!value && value !== 0) return ''
     sign = sign || '$'
-    var s = Math.floor(value).toString(),
+    var s = Math.floor(Math.abs(value)).toString(),
         i = s.length % 3,
         h = i > 0 ? (s.slice(0, i) + (s.length > 3 ? ',' : '')) : '',
         f = '.' + value.toFixed(2).slice(-2)
-    return sign + h + s.slice(i).replace(/(\d{3})(?=\d)/g, '$1,') + f
+    return (value < 0 ? '-' : '') + sign + h + s.slice(i).replace(/(\d{3})(?=\d)/g, '$1,') + f
 }
 
 /**

--- a/test/unit/specs/filters.js
+++ b/test/unit/specs/filters.js
@@ -82,6 +82,15 @@ describe('Filters', function () {
             assert.strictEqual(res3, '$123,443,434.43')
         })
 
+        it('should format a negative number correctly', function () {
+            var res1 = filter(-50),
+                res2 = filter(-150.43),
+                res3 = filter(-1500.4343434)
+            assert.strictEqual(res1, '-$50.00')
+            assert.strictEqual(res2, '-$150.43')
+            assert.strictEqual(res3, '-$1,500.43')
+        })
+
         it('should use the arg for the currency sign', function () {
             var res = filter(2134, '@')
             assert.strictEqual(res, '@2,134.00')


### PR DESCRIPTION
negative numbers are not correctly formatted with currency filter

-100 => $-,100,00

see example http://jsfiddle.net/xrado/HQ7JL/1/
