### PR TITLE
Allow Vue.nextTick to be passed a context

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -247,8 +247,13 @@ var utils = module.exports = {
     /**
      *  used to defer batch updates
      */
-    nextTick: function (cb) {
-        defer(cb, 0)
+    nextTick: function (cb, context) {
+        if (context) {
+            defer(utils.bind(cb, context), 0)
+        }
+        else {
+            defer(cb, 0)
+        }
     },
 
     /**
@@ -310,7 +315,7 @@ function enableDebug () {
             console.log(msg)
         }
     }
-    
+
     /**
      *  warnings, traces by default
      *  can be suppressed by `silent` option.


### PR DESCRIPTION
I always end up doing
`Vue.nextTick(this.someFunction.bind(this))` which use the slow, native bind() function.

This PR enables to to:
`Vue.nextTick(this.someFunction, this)` which uses the fast bind function (and saves a few keystrokes if you're into that).
