### PR TITLE
Fix nodeType check in fragment.js

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -59,7 +59,7 @@ module.exports = function (templateString) {
     var child
     /* jshint boss: true */
     while (child = node.firstChild) {
-        if (node.nodeType === 1) {
+        if (child.nodeType === 1) {
             frag.appendChild(child)
         }
     }


### PR DESCRIPTION
When appending multiple child nodes to the fragment, there is a check for each node to ensure it has a `nodeType === 1`, however, the check was being performed repeatedly on the wrapper `node` instead.
