### PR TITLE
Remove incorrect nodeType check in fragment.js

### DIFF
--- a/src/fragment.js
+++ b/src/fragment.js
@@ -59,9 +59,7 @@ module.exports = function (templateString) {
     var child
     /* jshint boss: true */
     while (child = node.firstChild) {
-        if (node.nodeType === 1) {
-            frag.appendChild(child)
-        }
+        frag.appendChild(child)
     }
     return frag
 }


### PR DESCRIPTION
As mentioned in PR #389:

"When appending multiple child nodes to the fragment, there is a check for each node to ensure it has a `nodeType === 1`, however, the check was being performed repeatedly on the wrapper node instead."

We decided to remove the check altogether, since there will be support for several different `nodeType` values.
