### PR TITLE
fix attr directive condition for setAttribute

### DIFF
--- a/src/directives/attr.js
+++ b/src/directives/attr.js
@@ -16,7 +16,7 @@ module.exports = {
 }
 
 function defaultHandler (value) {
-  if (value != null) {
+  if (value || value === 0) {
     this.el.setAttribute(this.arg, value)
   } else {
     this.el.removeAttribute(this.arg)
@@ -24,7 +24,7 @@ function defaultHandler (value) {
 }
 
 function xlinkHandler (value) {
-  if (value != null) {
+  if (value || value === 0) {
     this.el.setAttributeNS(xlinkNS, this.arg, value)
   } else {
     this.el.removeAttributeNS(xlinkNS, 'href')


### PR DESCRIPTION
on tag 0.11.0-rc

``` javascript
template: "<input type='text' v-attr='readonly: readonly' />",
data: {
    readonly: false
}
```

will be rendered like this and will be readonly

``` html
<input type="text" readonly="false" />
```

update with condition from here https://github.com/yyx990803/vue/blob/v0.10.6/src/directives/index.js#L35
