### PR TITLE
Add click listener into checkbox directive to bind value

### DIFF
--- a/src/directives/model/checkbox.js
+++ b/src/directives/model/checkbox.js
@@ -8,6 +8,7 @@ module.exports = {
     this.listener = function () {
       self.set(el.checked, true)
     }
+    _.on(el, 'click', this.listener)
     _.on(el, 'change', this.listener)
     if (el.checked) {
       this._initValue = el.checked
@@ -19,6 +20,7 @@ module.exports = {
   },
 
   unbind: function () {
+    _.off(this.el, 'click', this.listener)
     _.off(this.el, 'change', this.listener)
   }
 


### PR DESCRIPTION
Ignition order of `click` event and `change` event is dependent on implementation of browsers.

For example;
- Google Chrome:   `change` -> `click`
- Mozilla Firefox: `click` -> `change`

If `click` event is used on Firefox with `v-on` of current vue.js, it cannot use bound value by click.
So added click listener.

Could you review this?
