### PR TITLE
IE title binding issue

### DIFF
--- a/src/compiler/compile-props.js
+++ b/src/compiler/compile-props.js
@@ -21,7 +21,7 @@ module.exports = function compileProps (el, propOptions) {
   var props = []
   var names = Object.keys(propOptions)
   var i = names.length
-  var options, name, attr, value, path, parsed, prop
+  var options, name, attr, value, path, parsed, prop, isTitleBinding
   while (i--) {
     name = names[i]
     options = propOptions[name] || empty
@@ -50,10 +50,16 @@ module.exports = function compileProps (el, propOptions) {
       mode: propBindingModes.ONE_WAY
     }
 
+    // IE title issues
+    isTitleBinding = false
+    if (name === 'title' && (el.getAttribute(':title') || el.getAttribute('v-bind:title'))) {
+      isTitleBinding = true
+    }
+
     // first check literal version
     attr = _.hyphenate(name)
     value = prop.raw = _.attr(el, attr)
-    if (value === null) {
+    if (value === null || isTitleBinding) {
       // then check dynamic version
       if ((value = _.getBindAttr(el, attr)) === null) {
         if ((value = _.getBindAttr(el, attr + '.sync')) !== null) {

--- a/test/unit/specs/misc_spec.js
+++ b/test/unit/specs/misc_spec.js
@@ -269,4 +269,48 @@ describe('Misc', function () {
     })
     expect(hasWarned(__, 'Unknown custom element')).toBe(true)
   })
+
+  it('prefer bound title over static title', function (done) {
+    var el = document.createElement('div')
+    var count = 0
+    var expected = [
+      'bound',
+      'bound',
+      'static',
+      'bound',
+      'bound'
+    ]
+    function check (title) {
+      expect(title).toBe(expected[count])
+      count++
+      if (count === 4) {
+        done()
+      }
+    }
+
+    document.body.appendChild(el)
+
+    new Vue({
+      el: el,
+      template:
+        '<div>\
+          <comp v-bind:title="title"></comp>\
+          <comp title="static" v-bind:title="title"></comp>\
+          <comp title="static"></comp>\
+          <comp :title="title"></comp>\
+          <comp title="static" :title="title"></comp>\
+        </div>',
+      data: {
+        title: 'bound'
+      },
+      components: {
+        comp: {
+          props: ['title'],
+          ready: function () {
+            check(this.title)
+          }
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
With IE 10 & 11 (haven't tested on Edge yet), we cannot use title as a prop. Using `:title` or `v-bind:title`, IE seems to convert it to a static title attribute, which Vue will pick up instead of the bound attribute. Example:
http://codepen.io/anon/pen/epryMp

In this PR, a bound `title` attribute is preferred over a static title attribute. 

Perhaps all bound attributes should be preferred over static if both are specified on an element?