### PR TITLE
v-on: add $target like $event

### DIFF
--- a/src/directives/public/on.js
+++ b/src/directives/public/on.js
@@ -95,8 +95,10 @@ module.exports = {
 
     this.reset()
     var scope = this._scope || this.vm
+    var self = this
     this.handler = function (e) {
       scope.$event = e
+      scope.$target = self.el
       var res = handler(e)
       scope.$event = null
       return res


### PR DESCRIPTION
v-on: Let the eventHander can find the real DOM where binded. 
now：the event.target is the DOM where happend, can not find the DOM where binded……

    <span class="tit" @click="toggleLi($event, $target)">
        <i class="i fa fa-bar-chart"></i>
        <i class="arrow fa fa-angle-right"></i>
        菜单一
     </span>