### PR TITLE
IE should prefer bound props over static props other than class

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "karma-commonjs": "^0.0.13",
     "karma-coverage": "^0.5.0",
     "karma-firefox-launcher": "^0.1.6",
+    "karma-ie-launcher": "^0.2.0",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-safari-launcher": "^0.1.1",

--- a/src/compiler/compile-props.js
+++ b/src/compiler/compile-props.js
@@ -8,15 +8,6 @@ var empty = {}
 var identRE = require('../parsers/path').identRE
 var settablePathRE = /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*|\[[^\[\]]+\])*$/
 
-// feature detect browsers (IE) that have trouble
-// with binding syntax on certain attributes
-var div, preferBinding
-if (_.inBrowser) {
-  div = document.createElement('div')
-  div.setAttribute(':title', '')
-  preferBinding = div.getAttribute('title') !== null
-}
-
 /**
  * Compile props on a root element and return
  * a props link function.
@@ -60,7 +51,7 @@ module.exports = function compileProps (el, propOptions) {
     }
 
     attr = _.hyphenate(name)
-    hasBinding = preferBinding && checkBindingAttr(el, attr) !== null
+    hasBinding = _.preferBinding && hasBindingAttr(el, attr)
 
     // first check literal version
     value = prop.raw = _.attr(el, attr)
@@ -131,18 +122,14 @@ module.exports = function compileProps (el, propOptions) {
  * @return {String} attr
  */
 
-function checkBindingAttr (el, attr) {
+function hasBindingAttr (el, attr) {
   if (attr === 'class') {
-    return null
+    return false
   }
 
   return (
-    el.getAttribute(':' + attr) ||
-    el.getAttribute(':' + attr + '.once') ||
-    el.getAttribute(':' + attr + '.sync') ||
-    el.getAttribute('v-bind:' + attr) ||
-    el.getAttribute('v-bind:' + attr + '.once') ||
-    el.getAttribute('v-bind:' + attr + '.sync')
+    el.hasAttribute(':' + attr) ||
+    el.hasAttribute('v-bind:' + attr)
   )
 }
 

--- a/src/util/env.js
+++ b/src/util/env.js
@@ -83,3 +83,14 @@ exports.nextTick = (function () {
     timerFunc(nextTickHandler, 0)
   }
 })()
+
+// feature detect browsers (IE) that have trouble
+// with binding syntax on certain attributes
+var div
+var preferBinding = false
+if (inBrowser) {
+  div = document.createElement('div')
+  div.setAttribute(':title', '')
+  preferBinding = div.getAttribute('title') !== null
+}
+exports.preferBinding = preferBinding

--- a/test/unit/specs/misc_spec.js
+++ b/test/unit/specs/misc_spec.js
@@ -270,7 +270,7 @@ describe('Misc', function () {
     expect(hasWarned(__, 'Unknown custom element')).toBe(true)
   })
 
-  it('prefer bound title over static title', function (done) {
+  it('prefer bound attributes over static attributes', function (done) {
     var el = document.createElement('div')
     var count = 0
     var expected = [
@@ -289,6 +289,13 @@ describe('Misc', function () {
     }
 
     document.body.appendChild(el)
+    
+    el.setAttribute(':title', '')
+    if(el.getAttribute('title') === null) {
+      // this browser does not need this test
+      done()
+      return
+    }
 
     new Vue({
       el: el,


### PR DESCRIPTION
A follow on from: https://github.com/vuejs/vue/pull/1639

There are more attributes other than `title` which IE has issues with. (`id`, `lang`, `language`,`dir`, etc)
e.g: http://codepen.io/anon/pen/yYxBPy

In this PR, we feature detect binding syntax issues, if the current browser does have this issue, we check every prop for a bound alternative, (`:`, `v-bind:`, `*.sync`, `*.once`) and if present, use the bound prop over a static prop.

`class` is ignored. Buy ignoring it the behavior matches other browsers (bound classes get passed down to component root element)