### PR TITLE
Added support for properties which were created with defineProperty o…

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,14 @@ module.exports = {
   warnExpressionErrors: true,
 
   /**
+   * Whether or not to handle fully object properties which
+   * are already backed by getters and seters. Depending on
+   * use case and environment, this might introduce non-neglible
+   * performance penalties.
+   */
+  convertAllProperties: true,
+
+  /**
    * Internal flag to indicate the delimiters have been
    * changed.
    *

--- a/src/config.js
+++ b/src/config.js
@@ -36,7 +36,7 @@ module.exports = {
    * use case and environment, this might introduce non-neglible
    * performance penalties.
    */
-  convertAllProperties: true,
+  convertAllProperties: false,
 
   /**
    * Internal flag to indicate the delimiters have been

--- a/src/observer/index.js
+++ b/src/observer/index.js
@@ -182,8 +182,8 @@ function defineReactive (obj, key, val) {
     var property = Object.getOwnPropertyDescriptor(obj, key)
     if (property && property.get && property.set) {
       Object.defineProperty(target, 'val', {
-        get: property.get.bind(obj),
-        set: property.set.bind(obj)
+        get: _.bind(property.get, obj),
+        set: _.bind(property.set, obj)
       })
     }
   }
@@ -193,14 +193,15 @@ function defineReactive (obj, key, val) {
     enumerable: true,
     configurable: true,
     get: function metaGetter () {
+      var val = target.val
       if (Dep.target) {
         dep.depend()
         if (childOb) {
           childOb.dep.depend()
         }
-        if (_.isArray(target.val)) {
-          for (var e, i = 0, l = target.val.length; i < l; i++) {
-            e = target.val[i]
+        if (_.isArray(val)) {
+          for (var e, i = 0, l = val.length; i < l; i++) {
+            e = val[i]
             e && e.__ob__ && e.__ob__.dep.depend()
           }
         }

--- a/test/unit/lib/util.js
+++ b/test/unit/lib/util.js
@@ -2,15 +2,6 @@ var scope = typeof window === 'undefined'
   ? global
   : window
 
-// Some versions of phantomjs doesn't have bind defined. 
-// See https://github.com/ariya/phantomjs/issues/10522
-Function.prototype.bind = Function.prototype.bind || function (thisp) {
-  var fn = this;
-  return function () {
-    return fn.apply(thisp, arguments);
-  };
-};
-
 scope.hasWarned = function (_, msg, silent) {
   var count = _.warn.calls.count()
   while (count--) {

--- a/test/unit/lib/util.js
+++ b/test/unit/lib/util.js
@@ -2,6 +2,15 @@ var scope = typeof window === 'undefined'
   ? global
   : window
 
+// Some versions of phantomjs doesn't have bind defined. 
+// See https://github.com/ariya/phantomjs/issues/10522
+Function.prototype.bind = Function.prototype.bind || function (thisp) {
+  var fn = this;
+  return function () {
+    return fn.apply(thisp, arguments);
+  };
+};
+
 scope.hasWarned = function (_, msg, silent) {
   var count = _.warn.calls.count()
   while (count--) {

--- a/test/unit/specs/observer/observer_spec.js
+++ b/test/unit/specs/observer/observer_spec.js
@@ -1,6 +1,7 @@
 var Observer = require('../../../../src/observer')
 var Dep = require('../../../../src/observer/dep')
 var _ = require('../../../../src/util')
+var config = require('../../../../src/config')
 
 describe('Observer', function () {
 
@@ -39,6 +40,9 @@ describe('Observer', function () {
   })
 
   it('create on already observed object', function () {
+    var previousConvertAllProperties = config.convertAllProperties
+    config.convertAllProperties = true
+
     // on object
     var obj = {}
     var val = 0
@@ -65,6 +69,8 @@ describe('Observer', function () {
     // should call underlying setter
     obj.a = 10
     expect(val).toBe(10)
+
+    config.convertAllProperties = previousConvertAllProperties
   })
 
   it('create on array', function () {
@@ -112,6 +118,9 @@ describe('Observer', function () {
   })
 
   it('observing object prop change on defined property', function () {
+    var previousConvertAllProperties = config.convertAllProperties
+    config.convertAllProperties = true
+
     var obj = { val: 2 }
     Object.defineProperty(obj, 'a', {
       configurable: true,
@@ -143,6 +152,8 @@ describe('Observer', function () {
     expect(obj.val).toBe(3) // make sure 'setter' was called
     obj.val = 5
     expect(obj.a).toBe(5) // make sure 'getter' was called
+
+    config.convertAllProperties = previousConvertAllProperties
   })
 
   it('observing set/delete', function () {

--- a/test/unit/specs/observer/observer_spec.js
+++ b/test/unit/specs/observer/observer_spec.js
@@ -112,16 +112,16 @@ describe('Observer', function () {
   })
 
   it('observing object prop change on defined property', function () {
-    var obj = { }
-    var val = { b: 2 }
+    var obj = { val: 2 }
     Object.defineProperty(obj, 'a', {
       configurable: true,
       enumerable: true,
       get: function () {
-        return val
+        return this.val
       },
       set: function (v) {
-        val = v
+        this.val = v
+        return this.val
       }
     })
 
@@ -137,22 +137,12 @@ describe('Observer', function () {
     }
     // collect dep
     Dep.target = watcher
-    obj.a.b
+    expect(obj.a).toBe(2) // Make sure 'this' is preserved
     Dep.target = null
-    expect(watcher.deps.length).toBe(3) // obj.a + a.b + b
-    obj.a.b = 3
-    expect(watcher.update.calls.count()).toBe(1)
-    // swap object
-    obj.a = { b: 4 }
-    expect(watcher.update.calls.count()).toBe(2)
-    watcher.deps = []
-    Dep.target = watcher
-    obj.a.b
-    Dep.target = null
-    expect(watcher.deps.length).toBe(3)
-    // set on the swapped object
-    obj.a.b = 5
-    expect(watcher.update.calls.count()).toBe(3)
+    obj.a = 3
+    expect(obj.val).toBe(3) // make sure 'setter' was called
+    obj.val = 5
+    expect(obj.a).toBe(5) // make sure 'getter' was called
   })
 
   it('observing set/delete', function () {


### PR DESCRIPTION
…utside of vue.

Previously objects with properties with get/set defined outside of vue wouldn't propagate value changes after being made reactive in vue. This uses getOwnPropertyDescriptor to detect that case and account for it. 

Since it seems like every browser with supports defineProperty also supports getOwnPropertyDescriptor, I didn't add any logic to detect/work without it. 

Also added are two test cases testing the concept. 

If this addition gets pulled, it'd also probably be worthwhile checking the 'configurable' property. If configurable is set to false, defineReactive currently just throws an error. I imagine the correct behavior would be just to return out without changing anything; but this patch doesn't address it. 