### PR TITLE
Occurred TypeError in Observer.create

### DIFF
--- a/src/observer/index.js
+++ b/src/observer/index.js
@@ -47,7 +47,7 @@ Observer.create = function (value, vm) {
   }
   var ob
   if (
-    '__ob__' in value &&
+    Object.prototype.hasOwnProperty.call(value, '__ob__') &&
     value.__ob__ instanceof Observer
   ) {
     ob = value.__ob__

--- a/src/observer/index.js
+++ b/src/observer/index.js
@@ -47,7 +47,7 @@ Observer.create = function (value, vm) {
   }
   var ob
   if (
-    value.hasOwnProperty('__ob__') &&
+    '__ob__' in value &&
     value.__ob__ instanceof Observer
   ) {
     ob = value.__ob__

--- a/test/unit/specs/observer/observer_spec.js
+++ b/test/unit/specs/observer/observer_spec.js
@@ -38,6 +38,23 @@ describe('Observer', function () {
     expect(ob2).toBe(ob)
   })
 
+  it('create on null', function () {
+    // on null
+    var obj = Object.create(null)
+    obj.a = {}
+    obj.b = {}
+    var ob = Observer.create(obj)
+    expect(ob instanceof Observer).toBe(true)
+    expect(ob.value).toBe(obj)
+    expect(obj.__ob__).toBe(ob)
+    // should've walked children
+    expect(obj.a.__ob__ instanceof Observer).toBe(true)
+    expect(obj.b.__ob__ instanceof Observer).toBe(true)
+    // should return existing ob on already observed objects
+    var ob2 = Observer.create(obj)
+    expect(ob2).toBe(ob)
+  })
+
   it('create on array', function () {
     // on object
     var arr = [{}, {}]


### PR DESCRIPTION
I create the object with `Object.create(null)` for plugin, and when it would try to define as reactivity object with `Vue.util.defineReactive`, occured the `TypeError` in `Observer.create`.

Please see the following jsfiddle:
https://jsfiddle.net/kazupon/yo2cmsLp/1/

In Vue.js, Can I define the reactity object was created with `Object.create(null)` ?

If this is bug, I hope that you will check PR.