### PR TITLE
fix an event propagate bug

### DIFF
--- a/src/api/events.js
+++ b/src/api/events.js
@@ -98,6 +98,8 @@ exports.$emit = function (event) {
       var res = cbs[i].apply(this, args)
       if (res === true) {
         this._shouldPropagate = true
+      } else {
+        this._shouldPropagate = false
       }
     }
   }


### PR DESCRIPTION
英文实在不好，还是用中文解释一下吧，请见谅
在events里面最近我的项目遇到了一个小坑，大概是这个样一个结构:
````javascript
// child1 events
events: {
    'confirm-ok' () {
        let {
            olaplink, isOperate
        } = this.needToDelete;
        if (!olaplink.value && isOperate) {
            this.$dispatch('refreshComponent', this.componentId);
            this.olaplinkSettings.operationColumn.$remove(olaplink);
        }
       
    }
}

// child2 events
events: {
    'refreshComponent' () {
        // something       
    }
}

// parent events
events: {
    'refreshComponent'(...args) {
        this.$broadcast('refreshComponent', ...args);
    },
    'confirm-ok'() {
        // something
    }
}
````
目前表现现状是当child1的`confirm-ok`事件触发时，parent的`confirm-ok`事件也被同步触发（这里的代码按照官网说明理应不被触发才对）

在这样一个需要父级中转的事件中，在child1被触发`confirm-ok`时，需要先触发`refreshComponent`事件，通过父级中转会之后，因为之前在`events.js`中98行得到是否继续向上触发的结果之前，本身又被父级转发的`refreshComponet`事件导致自身`_shouldPropagate`为true(`events.js`第91行).
事件`refreshComponent`触发完毕后，执行到`events.js`99行时，此时的`_shouldPropagate`结果本应该是fase，但是由于上一次事件传递的影响这里的`_shouldPropagate`并不是正确的值。

故我认为应该在这里增加一下对`_shouldPropagate`的重新赋值以得到正确的结果

谢谢