### PR TITLE
add coerce option for component props

### DIFF
--- a/src/directives/internal/prop.js
+++ b/src/directives/internal/prop.js
@@ -5,7 +5,7 @@
 
 import Watcher from '../../watcher'
 import config from '../../config'
-import { assertProp, initProp } from '../../util/index'
+import { assertProp, initProp, coerceProp } from '../../util/index'
 
 const bindingModes = config._propBindingModes
 
@@ -25,6 +25,7 @@ export default {
       parent,
       parentKey,
       function (val) {
+        val = coerceProp(prop, val)
         if (assertProp(prop, val)) {
           child[childKey] = val
         }

--- a/src/util/component.js
+++ b/src/util/component.js
@@ -76,6 +76,7 @@ function getIsBinding (el) {
 
 export function initProp (vm, prop, value) {
   const key = prop.path
+  value = coerceProp(prop, value)
   vm[key] = vm._data[key] = assertProp(prop, value)
     ? value
     : undefined
@@ -141,6 +142,23 @@ export function assertProp (prop, value) {
     }
   }
   return true
+}
+
+/**
+ * Force parsing value with coerce option.
+ *
+ * @param {*} value
+ * @param {Object} options
+ * @return {*}
+ */
+
+export function coerceProp (prop, value) {
+  var coerce = prop.options.coerce
+  if (!coerce) {
+    return value
+  }
+  // coerce is a function
+  return coerce(value)
 }
 
 function formatType (val) {

--- a/test/unit/specs/directives/internal/prop_spec.js
+++ b/test/unit/specs/directives/internal/prop_spec.js
@@ -295,7 +295,7 @@ describe('prop', function () {
 
   describe('assertions', function () {
 
-    function makeInstance (value, type, validator) {
+    function makeInstance (value, type, validator, coerce) {
       return new Vue({
         el: document.createElement('div'),
         template: '<test :test="val"></test>',
@@ -307,7 +307,8 @@ describe('prop', function () {
             props: {
               test: {
                 type: type,
-                validator: validator
+                validator: validator,
+                coerce: coerce
               }
             }
           }
@@ -389,6 +390,17 @@ describe('prop', function () {
         return v === 123
       })
       expect(hasWarned('Expected String')).toBe(true)
+    })
+
+    it('type check + coerce', function () {
+      makeInstance(123, String, null, String)
+      expect(getWarnCount()).toBe(0)
+      makeInstance('123', Number, null, Number)
+      expect(getWarnCount()).toBe(0)
+      makeInstance('123', Boolean, null, function (val) {
+        return val === '123'
+      })
+      expect(getWarnCount()).toBe(0)
     })
 
     it('required', function () {


### PR DESCRIPTION
Add a force convert option for component. Here is an example:

```html
<!-- Component Avatar -->
<script>
export default {
  props: {
    size: {
      type: Number,
      coerce: 'number',
      default: 48,
    }
  }
}
</script>
```

And then I can use:

```html
<avatar size="38"></avatar>
```

Otherwise, size will always be String, it won't pass the validation.