### PR TITLE
Suppressed warnings on <component :is=something></component>

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -230,7 +230,9 @@ export function compileRoot (el, options, contextOptions) {
           // allow event listeners
           !onRE.test(attr.name) &&
           // allow slots
-          attr.name !== 'slot'
+          attr.name !== 'slot' &&
+          //allow container with :is
+          (attr.name !== 'is' && attr.name !== ':is' && el.tagName !== 'COMPONENT')
       })
       .map(function (attr) {
         return '"' + attr.name + '"'


### PR DESCRIPTION
When using the next code:

```
<component :is="something></component>
```

The warning occured on second time initialisation. 