### PR TITLE
Fix package module ID / Cannot find module "vue"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
     "browser",
     "framework"
   ],
-  "main": "dist/vue.common.js",
+  "main": "dist/vue.js",
   "files": [
-    "dist/vue.common.js",
     "dist/vue.js",
     "dist/vue.min.js",
     "src"


### PR DESCRIPTION
Getting errors while trying to install via npm:
```
npm install vue
```

Was able to install the github version via:
```
npm install vuejs/vue#dev
```

However, I got the following error:
```
Error: Cannot find module 'vue'
```

Looks like the package.json main is pointing to a non-existing file:
`dist/vue.common.js`

I checked both `dev` and `master` branch, neither had the file.  This PR is removing
`dist/vue.common.js` from files and updating the package main to point to `dist.vue.js`
