### PR TITLE
[fix] Convert string to number

### DIFF
--- a/src/observer/array.js
+++ b/src/observer/array.js
@@ -62,7 +62,7 @@ def(
   '$set',
   function $set (index, val) {
     if (index >= this.length) {
-      this.length = index + 1
+      this.length = Number(index) + 1
     }
     return this.splice(index, 1, val)[0]
   }


### PR DESCRIPTION
I found this issue by a [question](http://stackoverflow.com/questions/34388349/vue-js-binding-radio-elements-of-same-name-to-array) on StackOverflow.

If the `index` is string, the `this.length` assigned with the concatenated value of `index` and `1`.