### PR TITLE
在$watch方法中初始化Wather的时候，user选项是不是漏写了？

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -215,7 +215,8 @@ Directive.prototype._setupParamWatcher = function (key, expression) {
       called = true
     }
   }, {
-    immediate: true
+    immediate: true,
+    user: false
   })
   ;(this._paramUnwatchFns || (this._paramUnwatchFns = [])).push(unwatch)
 }

--- a/src/instance/api/data.js
+++ b/src/instance/api/data.js
@@ -84,7 +84,7 @@ export default function (Vue) {
       deep: options && options.deep,
       sync: options && options.sync,
       filters: parsed && parsed.filters,
-      user: true
+      user: !options || options.user !== false
     })
     if (options && options.immediate) {
       cb.call(vm, watcher.value)

--- a/src/instance/api/data.js
+++ b/src/instance/api/data.js
@@ -83,7 +83,8 @@ export default function (Vue) {
     var watcher = new Watcher(vm, expOrFn, cb, {
       deep: options && options.deep,
       sync: options && options.sync,
-      filters: parsed && parsed.filters
+      filters: parsed && parsed.filters,
+      user: true
     })
     if (options && options.immediate) {
       cb.call(vm, watcher.value)


### PR DESCRIPTION
您好，非常抱歉再来骚扰您。

这个是我上次提的[Issuess](https://github.com/vuejs/vue/issues/2036)，非常感谢您的回答。

晚上发现在1.0x版本中$watch存在一个问题，您的batcher中存在两个队列，一个是用户注册的Wather的队列，一个是内部代码注册的Watcher。在将watcher推入队列的时候，用watcher.user判断应该推入哪个队列。

我想起在0.11版本中vm的$watch方法中，实例化Watcher的时候是设置了user为true的。

而在新的1.0x版本中，为什么$watch代码里初始化Watcher的时候却没有设置user。

下面是两个版本的对比:

``` Javascript
  // 摘至1.0x版本的$watch方法：
  var watcher = new Watcher(vm, expOrFn, cb, {
    deep: options && options.deep,
    sync: options && options.sync,
    filters: parsed && parsed.filters
  })

```

```Javascript
  //摘至0.11版本的$watch方法：
  watcher = vm._userWatchers[key] =
    new Watcher(vm, exp, wrappedCb, {
      deep: deep,
      user: true
  })

```