### PR TITLE
Fix inline statement propagation

### DIFF
--- a/src/instance/api/data.js
+++ b/src/instance/api/data.js
@@ -24,8 +24,9 @@ export default function (Vue) {
         var self = this
         return function statementHandler () {
           self.$arguments = toArray(arguments)
-          res.get.call(self, self)
+          var result = res.get.call(self, self)
           self.$arguments = null
+          return result
         }
       } else {
         try {

--- a/test/unit/specs/api/events_spec.js
+++ b/test/unit/specs/api/events_spec.js
@@ -154,6 +154,56 @@ describe('Events API', function () {
     expect(spy.calls.count()).toBe(2)
   })
 
+  it('handle $dispatch by v-on inline-statement', function () {
+    var parent = new Vue({
+      el: document.createElement('div'),
+      template: '<child1 @test="onTest()" v-ref:child></child1>',
+      methods: {
+        onTest: function () {
+          spy()
+        }
+      },
+      components: {
+        child1: {
+          template: '<child2 @test="onTest()" v-ref:child></child2>',
+          methods: {
+            onTest: function () {
+              spy()
+            }
+          },
+          components: {
+            child2: {
+              template: '<child3 @test="onTest()" v-ref:child></child3>',
+              methods: {
+                onTest: function () {
+                  spy()
+                  return true
+                }
+              },
+              components: {
+                child3: {
+                  template: '<child4 v-ref:child></child4>',
+                  // `v-on` on component will be treat as its inner handler
+                  // so propagation cancelling is ignored on `<child4 @test="handler">`
+                  components: {
+                    child4: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+    parent
+      .$refs.child // child1
+      .$refs.child // child2
+      .$refs.child // child3
+      .$refs.child // child4
+      .$dispatch('test')
+    expect(spy.calls.count()).toBe(2)
+  })
+
   it('$dispatch cancel', function () {
     var child = new Vue({ parent: vm })
     var child2 = new Vue({ parent: child })


### PR DESCRIPTION
When handle events by inline statement, propagation continuing is not working.

By the way: https://github.com/rhyzx/vue/blob/fix-inline-statement-propagation/test/unit/specs/api/events_spec.js#L186-L187 ,  binding handler using `v-on` directive to component will be treat as its inner handler, this is **non-intuitive** in my opinion, eg:

```js
// parent.vue
<foo @test="stopPropagation"></foo>
```

`test` event dispatched by `foo` will still propagate even if `stopPropagation` returned `false`, what do you think about this? @yyx990803 