### PR TITLE
allow empty expression in terminal directives

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -587,11 +587,10 @@ function checkTerminalDirectives (el, options) {
   var value, dirName
   for (var i = 0, l = terminalDirectives.length; i < l; i++) {
     dirName = terminalDirectives[i]
-    /* eslint-disable no-cond-assign */
-    if (value = el.getAttribute('v-' + dirName)) {
+    value = el.getAttribute('v-' + dirName)
+    if (value != null) {
       return makeTerminalNodeLinkFn(el, dirName, value, options)
     }
-    /* eslint-enable no-cond-assign */
   }
 }
 


### PR DESCRIPTION
Eg: `<div v-if>`, i think this is a bug, expression validation should be in directive itself.

ps. Do i need to add test for this?