### PR TITLE
Fix test about assigning to frozen object in chrome.

### DIFF
--- a/test/unit/specs/misc_spec.js
+++ b/test/unit/specs/misc_spec.js
@@ -223,7 +223,13 @@ describe('Misc', function () {
     })
     expect(vm.$el.textContent).toBe('hi frozen')
     vm.msg = 'ho'
-    vm.frozen.msg = 'changed'
+    try {
+      vm.frozen.msg = 'changed'
+    } catch (error) {
+      if (!(error instanceof TypeError)) {
+        throw error
+      }
+    }
     Vue.nextTick(function () {
       expect(vm.$el.textContent).toBe('ho frozen')
       done()


### PR DESCRIPTION
When assigning property to a frozen object, an error is occurred in my chrome 47.0.2526.106