### PR TITLE
Feature: warn when mounting to body.

### DIFF
--- a/src/instance/api/lifecycle.js
+++ b/src/instance/api/lifecycle.js
@@ -24,6 +24,14 @@ export default function (Vue) {
     if (!el) {
       el = document.createElement('div')
     }
+    if (process.env.NODE_ENV !== 'production') {
+      if (el.tagName && el.tagName.toUpperCase() === 'BODY') {
+        warn(
+          'Mounting view model directly into document.body ' +
+          'is discouraged.'
+        )
+      }
+    }
     this._compile(el)
     this._initDOMHooks()
     if (inDoc(this.$el)) {

--- a/test/unit/specs/api/lifecycle_spec.js
+++ b/test/unit/specs/api/lifecycle_spec.js
@@ -146,6 +146,16 @@ describe('Lifecycle API', function () {
       expect(hasWarned('$mount() should be called only once')).toBe(true)
     })
 
+    it('warn when mounting to body', function () {
+      new Vue({
+        el: document.createElement('body')
+      })
+
+      expect(hasWarned(
+        'Mounting view model directly into document.body is discouraged.'
+      )).toBe(true)
+    })
+
   })
 
   describe('$destroy', function () {


### PR DESCRIPTION
[BrowserSync](http://browsersync.io/) sometimes failed when mounting vue instance to `document.body`. Although I have not recognized where the specific cause is, it recovered when mounting to a child element. Whatever, I think warning about this issue is a good idea. Moreover, React [warned about it](https://github.com/facebook/react/blob/3b96650e39ddda5ba49245713ef16dbc52d25e9e/src/renderers/dom/client/ReactMount.js#L398-L406) as well (Discussion: facebook/react#3207)