### PR TITLE
stringToFragment not using cache when templateString != templateStrin…

### DIFF
--- a/src/parsers/template.js
+++ b/src/parsers/template.js
@@ -108,10 +108,8 @@ function stringToFragment (templateString, raw) {
     var suffix = wrap[2]
     var node = document.createElement('div')
 
-    if (!raw) {
-      templateString = templateString.trim()
-    }
-    node.innerHTML = prefix + templateString + suffix
+    var templateStringToUse = raw ? templateString : templateString.trim()
+    node.innerHTML = prefix + templateStringToUse + suffix
     while (depth--) {
       node = node.lastChild
     }

--- a/test/unit/specs/parsers/template_spec.js
+++ b/test/unit/specs/parsers/template_spec.js
@@ -170,4 +170,13 @@ describe('Template Parser', function () {
     expect(res.childNodes.length).toBe(1)
     expect(res.firstChild.tagName).toBe('P')
   })
+
+  it('should reuse fragment from cache for the same string template', function () {
+    var stringTemplate = '    <p>test</p>    '
+    // When parsing a template, adds the created fragment to a cache
+    var res = parse(stringTemplate)
+
+    var newRes = parse(stringTemplate)
+    expect(newRes).toBe(res)
+  })
 })


### PR DESCRIPTION
…g.trim()

The issue was that initially we check the cache by an un-trimmed key, while later on, before putting a value in the cache, we trim the key. This would lead to the fragment of a templateString that has spaces at the beginning or the end, not to be retrieved from the cache.