### PR TITLE
指令解析优化

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -22,7 +22,7 @@ import {
 // special binding prefixes
 const bindRE = /^v-bind:|^:/
 const onRE = /^v-on:|^@/
-const argRE = /:(.*)$/
+const dirAttrRE = /^v-([^:]+)(?:$|:(.*)$)/
 const modifierRE = /\.[^\.]+/g
 const transitionRE = /^(v-bind:|:)?transition$/
 
@@ -643,7 +643,7 @@ function makeTerminalNodeLinkFn (el, dirName, value, options, def) {
 function compileDirectives (attrs, options) {
   var i = attrs.length
   var dirs = []
-  var attr, name, value, rawName, rawValue, dirName, arg, modifiers, dirDef, tokens
+  var attr, name, value, rawName, rawValue, dirName, arg, modifiers, dirDef, tokens, matched
   while (i--) {
     attr = attrs[i]
     name = rawName = attr.name
@@ -701,14 +701,9 @@ function compileDirectives (attrs, options) {
     } else
 
     // normal directives
-    if (name.indexOf('v-') === 0) {
-      // check arg
-      arg = (arg = name.match(argRE)) && arg[1]
-      if (arg) {
-        name = name.replace(argRE, '')
-      }
-      // extract directive name
-      dirName = name.slice(2)
+    if ((matched = name.match(dirAttrRE))) {
+      dirName = matched[1]
+      arg = matched[2]
 
       // skip v-else (when used with v-show)
       if (dirName === 'else') {


### PR DESCRIPTION
您好。

您的代码非常精彩，分而治之的道理无处不在，以至于在第二遍阅读的时候任然感觉荡气回肠。


另外有个小问题：

在解析v-这种一般指令的时候为什么不用正则将指令名称和参数分离呢。