### PR TITLE
Support backspace with "delete" keycode alias

### DIFF
--- a/src/directives/public/on.js
+++ b/src/directives/public/on.js
@@ -7,7 +7,7 @@ const keyCodes = {
   tab: 9,
   enter: 13,
   space: 32,
-  'delete': 46,
+  'delete': [8, 46],
   up: 38,
   left: 37,
   right: 39,
@@ -28,6 +28,7 @@ function keyFilter (handler, keys) {
     }
     return keyCodes[key]
   })
+  codes = [].concat.apply([], codes)
   return function keyHandler (e) {
     if (codes.indexOf(e.keyCode) > -1) {
       return handler.call(this, e)

--- a/test/unit/specs/directives/public/on_spec.js
+++ b/test/unit/specs/directives/public/on_spec.js
@@ -88,6 +88,48 @@ describe('v-on', function () {
     })
   })
 
+  it('with delete modifier capturing DEL', function (done) {
+    new Vue({
+      el: el,
+      template: '<a v-on:keyup.delete="test">{{a}}</a>',
+      data: {a: 1},
+      methods: {
+        test: function () {
+          this.a++
+        }
+      }
+    })
+    var a = el.firstChild
+    trigger(a, 'keyup', function (e) {
+      e.keyCode = 46
+    })
+    _.nextTick(function () {
+      expect(a.textContent).toBe('2')
+      done()
+    })
+  })
+
+  it('with delete modifier capturing backspace', function (done) {
+    new Vue({
+      el: el,
+      template: '<a v-on:keyup.delete="test">{{a}}</a>',
+      data: {a: 1},
+      methods: {
+        test: function () {
+          this.a++
+        }
+      }
+    })
+    var a = el.firstChild
+    trigger(a, 'keyup', function (e) {
+      e.keyCode = 8
+    })
+    _.nextTick(function () {
+      expect(a.textContent).toBe('2')
+      done()
+    })
+  })
+
   it('with key modifier (keycode)', function (done) {
     new Vue({
       el: el,


### PR DESCRIPTION
Currently when using the `delete` alias in a on directive with keyup `delete" does not support using backspace. This seems quite counterintuitive. Additionally, on Mac keyboards the key normally identified as "backspace" on PC keyboards is called "delete." I was fairly surprised when using the delete modifier didn't detect the key.

I came upon this when developing a search / tag field that turned a search query into tokens when hitting enter or space. I wanted a way to delete tokens without using the mouse. The solution I came up with was detecting the delete key and removing the last token if the search field was empty. I spent 10 minutes debugging code until I realized that I had to press fn+delete (equivalent of DEL / forward delete on a Mac laptop-sized keyboard) for it to actually remove the token.

You can see a reduced test case / demo of this here: http://codepen.io/thecrypticace/pen/YwGKmJ

This PR makes a change to allow aliases to map to multiple key codes. And, using that, it adds support for delete to react to both backspace and DEL / forward delete.