### PR TITLE
fix(util/env): wrong parameter type in document.createTextNode.

### DIFF
--- a/src/util/env.js
+++ b/src/util/env.js
@@ -74,7 +74,7 @@ export const nextTick = (function () {
   if (typeof MutationObserver !== 'undefined') {
     var counter = 1
     var observer = new MutationObserver(nextTickHandler)
-    var textNode = document.createTextNode(counter)
+    var textNode = document.createTextNode(counter.toString())
     observer.observe(textNode, {
       characterData: true
     })


### PR DESCRIPTION
It wouldn't cause any issues, but not substandard.

https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode