### PR TITLE
Improve terminalable directive

### DIFF
--- a/src/directives/public/for.js
+++ b/src/directives/public/for.js
@@ -22,6 +22,7 @@ let uid = 0
 const vFor = {
 
   priority: FOR,
+  terminal: true,
 
   params: [
     'track-by',

--- a/src/directives/public/if.js
+++ b/src/directives/public/if.js
@@ -11,6 +11,7 @@ import {
 export default {
 
   priority: IF,
+  terminal: true,
 
   bind () {
     var el = this.el

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -249,6 +249,48 @@ describe('Compile', function () {
     expect(args[1]).toBe(el.firstChild)
   })
 
+  it('custom terminal directives', function () {
+    var defTerminal = {
+      terminal: true,
+      priority: Vue.options.directives.if.priority + 1
+    }
+    var options = _.mergeOptions(Vue.options, {
+      directives: { term: defTerminal }
+    })
+    el.innerHTML = '<div v-term:arg1.modifier1.modifier2="foo"></div>'
+    var linker = compile(el, options)
+    linker(vm, el)
+    expect(vm._bindDir.calls.count()).toBe(1)
+    var args = vm._bindDir.calls.argsFor(0)
+    expect(args[0].name).toBe('term')
+    expect(args[0].expression).toBe('foo')
+    expect(args[0].rawName).toBe('v-term:arg1.modifier1.modifier2')
+    expect(args[0].arg).toBe('arg1')
+    expect(args[0].modifiers.modifier1).toBe(true)
+    expect(args[0].modifiers.modifier2).toBe(true)
+    expect(args[0].def).toBe(defTerminal)
+  })
+
+  it('custom terminal directives priority', function () {
+    var defTerminal = {
+      terminal: true,
+      priority: Vue.options.directives.if.priority + 1
+    }
+    var options = _.mergeOptions(Vue.options, {
+      directives: { term: defTerminal }
+    })
+    el.innerHTML = '<div v-term:arg1 v-if="ok"></div>'
+    var linker = compile(el, options)
+    linker(vm, el)
+    expect(vm._bindDir.calls.count()).toBe(1)
+    var args = vm._bindDir.calls.argsFor(0)
+    expect(args[0].name).toBe('term')
+    expect(args[0].expression).toBe('')
+    expect(args[0].rawName).toBe('v-term:arg1')
+    expect(args[0].arg).toBe('arg1')
+    expect(args[0].def).toBe(defTerminal)
+  })
+
   it('custom element components', function () {
     var options = _.mergeOptions(Vue.options, {
       components: {
@@ -625,19 +667,6 @@ describe('Compile', function () {
       components: { comp: { template: '<div></div>' }}
     })
     expect(el.textContent).toBe('worked!')
-    expect(getWarnCount()).toBe(0)
-  })
-
-  it('allow custom terminal directive', function () {
-    Vue.mixin({}) // #2366 conflict with custom terminal directive
-    Vue.compiler.terminalDirectives.push('foo')
-    Vue.directive('foo', {})
-
-    new Vue({
-      el: el,
-      template: '<div v-foo></div>'
-    })
-
     expect(getWarnCount()).toBe(0)
   })
 })


### PR DESCRIPTION
There are times when we want to use the `arg` and `modifires` in custom terminal directive, and control the priority.

e.g.
```html
<input type="text" v-validate:feild1.input-off="['required']">
```

Recently, in the following related issues or PR, we became able to define the terminal directive.

- allow empty expression in terminal directives
https://github.com/vuejs/vue/pull/2137

- transfer DOM
https://github.com/vuejs/vue/issues/2130

However, we can not yet.

I fixed this issues.
I hope that this PR are merged with you.

Please check the codes.