### PR TITLE
Add doc links to core features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 Vue.js is a library for building interactive web interfaces. It provides data-reactive components with a simple and flexible API. Core features include:
 
-- Dead simple, unobtrusive reactivity using plain JavaScript objects.
-- Component-oriented development style with tooling support
+- [Dead simple, unobtrusive reactivity using plain JavaScript objects.](http://vuejs.org/guide/overview.html#Reactive_Data_Binding)
+- [Component-oriented development style with tooling support](http://vuejs.org/guide/overview.html#Component_System)
 - Lean and extensible core
-- Flexible transition effect system
+- [Flexible transition effect system](http://vuejs.org/guide/transitions.html)
 - Fast without the need for complex optimization
 
 Note that Vue.js only supports [ES5-compliant browsers](http://kangax.github.io/compat-table/es5/) (IE8 and below are not supported). To check out live examples and docs, visit [vuejs.org](http://vuejs.org).


### PR DESCRIPTION
As proposed in #2303, I added documentation links to reactive data binding, component, and transition features. 