### PR TITLE
Pass a context to factory functions

### DIFF
--- a/src/instance/internal/misc.js
+++ b/src/instance/internal/misc.js
@@ -76,7 +76,7 @@ export default function (Vue) {
       } else {
         factory.requested = true
         var cbs = factory.pendingCallbacks = [cb]
-        factory(function resolve (res) {
+        factory.call(this, function resolve (res) {
           if (isPlainObject(res)) {
             res = Vue.extend(res)
           }


### PR DESCRIPTION
Allow this use case:

```javascript
const component = Vue.extend({
  template: '<div><dynamic></dynamic></div>',
  data() {
    return {
      path: 'some/path';
    }
  },
  components: {
    dynamic: function(resolve) {
      // "this" would be undefined otherwise, preventing us from using the instance's data
      require([`${this.path}/dynamic_module`], resolve);
      // System.import(`${this.path}/dynamic_module`).then(resolve)
    }
  }
});
```