### PR TITLE
Fix custom terminal directive with global mixin

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -627,7 +627,8 @@ function makeTerminalNodeLinkFn (el, dirName, value, options, def) {
     filters: parsed.filters,
     raw: value,
     // either an element directive, or if/for
-    def: def || publicDirectives[dirName]
+    // #2366 or custom terminal directive
+    def: def || resolveAsset(options, 'directives', dirName)
   }
   // check ref for v-for and router-view
   if (dirName === 'for' || dirName === 'router-view') {

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -634,4 +634,17 @@ describe('Compile', function () {
     expect(el.textContent).toBe('worked!')
     expect(getWarnCount()).toBe(0)
   })
+
+  it('allow custom terminal directive', function () {
+    Vue.mixin({})
+    Vue.compiler.terminalDirectives.push('foo')
+    Vue.directive('foo', {})
+
+    new Vue({
+      el: el,
+      template: '<div v-foo></div>'
+    })
+
+    expect(getWarnCount()).toBe(0)
+  })
 })

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -636,7 +636,7 @@ describe('Compile', function () {
   })
 
   it('allow custom terminal directive', function () {
-    Vue.mixin({})
+    Vue.mixin({}) // #2366 conflict with custom terminal directive
     Vue.compiler.terminalDirectives.push('foo')
     Vue.directive('foo', {})
 


### PR DESCRIPTION
Repo: https://jsfiddle.net/rhyzx/qdyq4z7z/2/

This is because Vue will [replace](https://github.com/vuejs/vue/blob/dev/src/instance/api/global.js#L157) old options with new one instead of extending exist options when `mixin()`, so compiler will get an outdated reference of [directives definition object](https://github.com/vuejs/vue/blob/dev/src/compiler/compile.js#L630).
