### PR TITLE
fix key modifiers detecting

### DIFF
--- a/src/directives/public/on.js
+++ b/src/directives/public/on.js
@@ -112,7 +112,7 @@ export default {
     // key filter
     var keys = Object.keys(this.modifiers)
       .filter(function (key) {
-        return key !== 'stop' && key !== 'prevent'
+        return key !== 'stop' && key !== 'prevent' && key !== 'self'
       })
     if (keys.length) {
       handler = keyFilter(handler, keys)


### PR DESCRIPTION
I found this when investigating the possibility of **extending modifiers for `v-on`**.

This is feature is useful in some situation, eg: `real-blur`

```js
Vue.modifier('real', function (handler) {
  return function (evt) {
    if (evt.type !== 'blur' || document.activeElement !== evt.target) {
      return handler.call(this, evt)
    }
  }
})
```

@yyx990803  :trollface: 