### PR TITLE
Allow currency filter to specify places

### DIFF
--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -63,20 +63,23 @@ export default {
   /**
    * 12345 => $12,345.00
    *
-   * @param {String} sign
+   * @param {String} currency
+   * @param {Number} places
    */
 
-  currency (value, currency) {
+  currency (value, currency, places) {
     value = parseFloat(value)
     if (!isFinite(value) || (!value && value !== 0)) return ''
     currency = currency != null ? currency : '$'
-    var stringified = Math.abs(value).toFixed(2)
-    var _int = stringified.slice(0, -3)
-    var i = _int.length % 3
+    places = places != null ? places : 2
+    var stringified = Math.abs(value).toFixed(places)
+    var dotplace = Math.abs(places + 1)
+    var _int = stringified.slice(0, -dotplace)
+    var i = _int.length % dotplace
     var head = i > 0
-      ? (_int.slice(0, i) + (_int.length > 3 ? ',' : ''))
+      ? (_int.slice(0, i) + (_int.length > dotplace ? ',' : ''))
       : ''
-    var _float = stringified.slice(-3)
+    var _float = stringified.slice(-dotplace)
     var sign = value < 0 ? '-' : ''
     return sign + currency + head +
       _int.slice(i).replace(digitsRE, '$1,') +

--- a/test/unit/specs/filters/filters_spec.js
+++ b/test/unit/specs/filters/filters_spec.js
@@ -77,6 +77,11 @@ describe('Filters', function () {
     expect(filter(-50)).toBe('-$50.00')
     expect(filter(-150.43)).toBe('-$150.43')
     expect(filter(-1500.4343434)).toBe('-$1,500.43')
+    // places
+    expect(filter(123, '$', 2)).toBe('$123.00')
+    expect(filter(123.45, '$', 0)).toBe('$123')
+    expect(filter(123.456, '$', 2)).toBe('$123.46')
+    expect(filter(123.456, '$', 3)).toBe('$123.456')
   })
 
   it('debounce', function (done) {


### PR DESCRIPTION
This adds another parameter to the `currency` filter which allows specifying of the places to display. This is useful if you only want to display a currency as £100.