### PR TITLE
Proof of concept: Detect writing to non-reactive properties

### DIFF
--- a/examples/changewatch/index.html
+++ b/examples/changewatch/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Vue.js tree-view demo</title>
+  <script src="../../dist/vue.js"></script>
+</head>
+<body>
+  <div id="demo">
+    <div>
+      <button @click="doIt">Do It</button>
+    </div>
+  </div>
+  <script type="text/javascript">
+    new Vue({
+      el: '#demo',
+      data: {
+        rootValue: 0,
+        item1: {
+          valid1: 0,
+          nestedObj1: {
+            nestedValid1: 0
+          },
+          nestedArray1: [
+            {
+              x: 0
+            }
+          ]
+        }
+      },
+      methods: {
+        doIt: function () {
+          // should not throw error
+          this.rootValue = 1;
+
+          // should show a warning
+          this.invalidValue = 1;
+
+          // no error
+          this.item1.valid1 = 1;
+
+          // error
+          this.item1.invalid1 = 1;
+
+          // no error
+          this.item1.nestedObj1.nestedValid1 = 1;
+
+          // error
+          this.item1.nestedObj1.nestedInValid1 = 1;
+
+          // no error
+          this.item1.nestedArray1[0].x = 1;
+
+          // error
+          this.item1.nestedArray1[0].y = 1;
+
+          // error
+          this.item1.nestedArray1[1] = {x:5}
+        }
+      }
+    })
+  </script>
+</body>
+</html>

--- a/src/instance/internal/state.js
+++ b/src/instance/internal/state.js
@@ -11,7 +11,8 @@ import {
   query,
   hasOwn,
   isReserved,
-  bind
+  bind,
+  bindWithDebug
 } from '../../util/index'
 
 export default function (Vue) {
@@ -252,7 +253,7 @@ export default function (Vue) {
     var methods = this.$options.methods
     if (methods) {
       for (var key in methods) {
-        this[key] = bind(methods[key], this)
+        this[key] = bindWithDebug(methods[key], this)
       }
     }
   }

--- a/src/util/lang.js
+++ b/src/util/lang.js
@@ -228,6 +228,20 @@ export function bind (fn, ctx) {
   }
 }
 
+export function bindWithDebug (fn, ctx) {
+  ctx = new Proxy (ctx, {
+    set: function (target, propKey, value, receiver) {
+      if(target._data && target._data.__ob__ && !target._data.__ob__.watchedKeys.hasOwnProperty (propKey)) {
+        console.warn (propKey, "is not reactive on root object");
+      }
+
+      return Reflect.set(target, propKey, value, receiver);
+    }
+  });
+
+  return bind (fn, ctx);
+}
+
 /**
  * Convert an Array-like object to a real Array.
  *


### PR DESCRIPTION
This is very very early proof of concept right now. If a property in a data object is written to while it's not reactive, a warning is shown. This will later be used only in debug mode, but I haven't added a debug mode check yet. The code will be re-written cleanly once it's confirmed working.

Note: this uses no dirty checking and instead uses ES6 proxies, which is supported only on latest chrome and firefox. 

Need help with this:

* Pull my branch `reactive-warn` into your repo.
* edit `changewatch/index.html` with updates 
* find false positives, etc. Things when it should show warnings but doesn't. Or other edge cases.

Example: 
![screen shot 2016-03-24 at 9 49 58 am](https://cloud.githubusercontent.com/assets/80173/14008350/e1fa4514-f1a5-11e5-9e4c-0ec3ad1fdac5.png)