### PR TITLE
Support for mutiple class names as key (close #2571)

### DIFF
--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -206,6 +206,19 @@ export function setClass (el, cls) {
  */
 
 export function addClass (el, cls) {
+  // Space " " is not a valid character for a DOM token.
+  // As such, if cls includes multiple class names (e.g.
+  // "a b c"), we split it into mutiple child-tokens and
+  // process them. This also satisfies the feature request
+  // #2571.
+  if (cls.indexOf(' ') !== -1) {
+    cls.split(/\s+/).forEach(function (cl) {
+      addClass(el, cl)
+    })
+
+    return
+  }
+
   if (el.classList) {
     el.classList.add(cls)
   } else {

--- a/test/unit/specs/util/dom_spec.js
+++ b/test/unit/specs/util/dom_spec.js
@@ -101,6 +101,8 @@ describe('Util - DOM', function () {
     expect(el.className).toBe('cc bb')
     _.addClass(el, 'bb')
     expect(el.className).toBe('cc bb')
+    _.addClass(el, 'aa dd')
+    expect(el.className).toBe('cc bb aa dd')
   })
 
   it('addClass/removeClass for SVG/IE9', function () {


### PR DESCRIPTION
This commit adds support for using multiple class names as key when specifying a `:class` object, for example `<div :class="{ 'a b c': flag }">`. Previously, doing so will trigger an uncaught InvalidCharacterError, as spaces are not allowed in DOM tokens. Feature request #2571 should also be satisfied by this commit.