### PR TITLE
Fix/order by primitives

### DIFF
--- a/src/filters/array-filters.js
+++ b/src/filters/array-filters.js
@@ -84,7 +84,9 @@ export function orderBy (arr, sortKeys, order) {
 
   if (typeof sortKeys === 'string') {
     sortKeys = [sortKeys]
-  } else if (!sortKeys || !sortKeys.length) {
+  } else if (!sortKeys || (sortKeys !== true && !sortKeys.length)) {
+    // we check if sortKeys === true because you can sort primitive values with
+    // array | orderBy true: http://vuejs.org/api/#orderBy
     return arr
   }
 
@@ -101,7 +103,9 @@ export function orderBy (arr, sortKeys, order) {
 
   function recursiveCompare (a, b, i) {
     i = i || 0
-    if (i === sortKeys.length - 1) return compare(a, b, i)
+    if (sortKeys === true || i === sortKeys.length - 1) {
+      return compare(a, b, i)
+    }
     return compare(a, b, i) || recursiveCompare(a, b, i + 1)
   }
 

--- a/src/filters/array-filters.js
+++ b/src/filters/array-filters.js
@@ -75,12 +75,12 @@ export function filterBy (arr, search, delimiter) {
  * Filter filter for arrays
  *
  * @param {String|Array<String>} sortKeys
- * @param {String} reverse
+ * @param {Boolean} [order]
  */
 
-export function orderBy (arr, sortKeys, reverse) {
+export function orderBy (arr, sortKeys, order) {
   arr = convertArray(arr)
-  let order = (reverse && reverse < 0) ? -1 : 1
+  order = (order && order < 0) ? -1 : 1
 
   if (typeof sortKeys === 'string') {
     sortKeys = [sortKeys]

--- a/test/unit/specs/filters/filters_spec.js
+++ b/test/unit/specs/filters/filters_spec.js
@@ -230,6 +230,13 @@ describe('Filters', function () {
     assertArray(res, [arr[1], arr[2], arr[0]])
   })
 
+  it('orderBy primitive values', function () {
+    var filter = filters.orderBy
+    var arr = [9, 11, 1, 2]
+    var res = filter(arr, true)
+    assertArray(res, [arr[2], arr[3], arr[0], arr[1]])
+  })
+
   it('orderBy multiple fields', function () {
     var filter = filters.orderBy
     var arr = [


### PR DESCRIPTION
Bug introduced in 04a213b3215067de0e05ea65603273a7d92baf7a
Usage shown in the doc: http://vuejs.org/api/#orderBy
`arr | orderBy true`