### PR TITLE
Use more serious strings in tests

### DIFF
--- a/test/e2e/markdown.js
+++ b/test/e2e/markdown.js
@@ -13,9 +13,9 @@ casper.test.begin('markdown', 5, function (test) {
   .then(function () {
     this.sendKeys(
       'textarea',
-      '## yo\n\n' +
-      '- test\n' +
-      '- hi\n\n',
+      '## foo\n\n' +
+      '- bar\n' +
+      '- baz\n\n',
       { keepFocus: true }
     )
     // keyUp(13)
@@ -32,13 +32,13 @@ casper.test.begin('markdown', 5, function (test) {
   .then(function () {
     test.assertEval(function () {
       return document.querySelector('textarea').value ===
-        '## yo\n\n- test\n- hi\n\n# hello'
+        '## foo\n\n- bar\n- baz\n\n# hello'
     })
     test.assertEval(function () {
       return document.querySelector('#editor div')
         .innerHTML ===
-          '<h2 id="yo">yo</h2>\n' +
-          '<ul>\n<li>test</li>\n<li>hi</li>\n</ul>\n' +
+          '<h2 id="foo">foo</h2>\n' +
+          '<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n' +
           '<h1 id="hello">hello</h1>\n'
     })
   })

--- a/test/e2e/svg.js
+++ b/test/e2e/svg.js
@@ -34,7 +34,7 @@ casper.test.begin('svg', 18, function (test) {
   })
   .then(function () {
     this.fill('#add', {
-      newlabel: 'hi'
+      newlabel: 'foo'
     })
   })
   .thenClick('#add > button', function () {

--- a/test/unit/specs/api/data_spec.js
+++ b/test/unit/specs/api/data_spec.js
@@ -6,7 +6,7 @@ describe('Data API', function () {
   var vm
   beforeEach(function () {
     var el = document.createElement('div')
-    el.setAttribute('prop', 'hi')
+    el.setAttribute('prop', 'foo')
     vm = new Vue({
       el: el,
       props: ['prop'],
@@ -154,7 +154,7 @@ describe('Data API', function () {
         expect(val.a).toBe(1)
         expect(val.b.c).toBe(2)
         expect(val.d).toBe(2)
-        expect(val.prop).toBe('hi')
+        expect(val.prop).toBe('foo')
         spy()
       }
       vm.$log()

--- a/test/unit/specs/api/lifecycle_spec.js
+++ b/test/unit/specs/api/lifecycle_spec.js
@@ -14,13 +14,13 @@ describe('Lifecycle API', function () {
     it('normal', function () {
       var vm = new Vue({
         data: {
-          test: 'hi!'
+          test: 'foo'
         }
       })
       vm.$mount(el)
       expect(vm.$el).toBe(el)
       expect(el.__vue__).toBe(vm)
-      expect(el.textContent).toBe('hi!')
+      expect(el.textContent).toBe('foo')
     })
 
     it('auto-create', function () {
@@ -40,12 +40,12 @@ describe('Lifecycle API', function () {
       el.id = 'mount-test'
       document.body.appendChild(el)
       var vm = new Vue({
-        data: { test: 'hi!' }
+        data: { test: 'foo' }
       })
       vm.$mount('#mount-test')
       expect(vm.$el).toBe(el)
       expect(el.__vue__).toBe(vm)
-      expect(el.textContent).toBe('hi!')
+      expect(el.textContent).toBe('foo')
       document.body.removeChild(el)
     })
 
@@ -60,12 +60,12 @@ describe('Lifecycle API', function () {
       document.body.appendChild(el)
       var vm = new Vue({
         replace: true,
-        data: { test: 'hi!' },
+        data: { test: 'foo' },
         template: '<div>{{test}}</div>'
       })
       vm.$mount(el)
       expect(vm.$el).not.toBe(el)
-      expect(vm.$el.textContent).toBe('hi!')
+      expect(vm.$el.textContent).toBe('foo')
       expect(document.body.contains(el)).toBe(false)
       expect(document.body.lastChild).toBe(vm.$el)
       expect(vm.$el.className).toBe('replace-test')
@@ -77,13 +77,13 @@ describe('Lifecycle API', function () {
       var vm = new Vue({
         _linker: linker,
         data: {
-          test: 'hi!'
+          test: 'foo'
         }
       })
       vm.$mount(el)
       expect(vm.$el).toBe(el)
       expect(el.__vue__).toBe(vm)
-      expect(el.textContent).toBe('hi!')
+      expect(el.textContent).toBe('foo')
     })
 
     it('mount to fragment', function () {
@@ -99,13 +99,13 @@ describe('Lifecycle API', function () {
       document.body.appendChild(el)
       var vm = new Vue({
         replace: true,
-        data: { test: 'hi!' },
-        template: '<div>{{test}}</div><div>{{test + "!"}}</div>'
+        data: { test: 'foo' },
+        template: '<div>{{test}}</div><div>{{test + "bar"}}</div>'
       })
       vm.$mount(el)
       expect(vm.$el).not.toBe(el)
-      expect(vm.$el.nextSibling.textContent).toBe('hi!')
-      expect(vm.$el.nextSibling.nextSibling.textContent).toBe('hi!!')
+      expect(vm.$el.nextSibling.textContent).toBe('foo')
+      expect(vm.$el.nextSibling.nextSibling.textContent).toBe('foobar')
       expect(document.body.contains(el)).toBe(false)
       expect(document.body.lastChild).toBe(vm._fragmentEnd)
       vm.$remove()
@@ -115,7 +115,7 @@ describe('Lifecycle API', function () {
       var hooks = ['created', 'beforeCompile', 'compiled', 'attached', 'ready']
       var options = {
         data: {
-          test: 'hihi'
+          test: 'foo'
         }
       }
       hooks.forEach(function (hook) {
@@ -300,21 +300,21 @@ describe('Lifecycle API', function () {
         el: el,
         template: '{{a}}',
         data: {
-          a: 'hi'
+          a: 'foo'
         }
       })
       expect(vm._directives.length).toBe(1)
       var partial = document.createElement('span')
       partial.textContent = '{{a}}'
       var decompile = vm.$compile(partial)
-      expect(partial.textContent).toBe('hi')
+      expect(partial.textContent).toBe('foo')
       expect(vm._directives.length).toBe(2)
       decompile()
       expect(vm._directives.length).toBe(1)
-      vm.a = 'ha'
+      vm.a = 'bar'
       Vue.nextTick(function () {
-        expect(el.textContent).toBe('ha')
-        expect(partial.textContent).toBe('hi')
+        expect(el.textContent).toBe('bar')
+        expect(partial.textContent).toBe('foo')
         done()
       })
     })

--- a/test/unit/specs/async_component_spec.js
+++ b/test/unit/specs/async_component_spec.js
@@ -16,7 +16,7 @@ describe('Async components', function () {
     var go = jasmine.createSpy()
     new Vue({
       el: el,
-      template: '<test hi="ok" @ready="go"></test>',
+      template: '<test foo="bar" @ready="go"></test>',
       methods: {
         go: go
       },
@@ -24,8 +24,8 @@ describe('Async components', function () {
         test: function (resolve) {
           setTimeout(function () {
             resolve({
-              props: ['hi'],
-              template: '{{ hi }}',
+              props: ['foo'],
+              template: '{{ foo }}',
               ready: function () {
                 this.$emit('ready')
               }
@@ -36,7 +36,7 @@ describe('Async components', function () {
       }
     })
     function next () {
-      expect(el.textContent).toBe('ok')
+      expect(el.textContent).toBe('bar')
       expect(go).toHaveBeenCalled()
       done()
     }

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -51,7 +51,7 @@ describe('Compile', function () {
 
   it('normal directives', function () {
     el.setAttribute('v-a', 'b')
-    el.innerHTML = '<p v-a:hello.a.b="a" v-b="1">hello</p><div v-b.literal="hi"></div>'
+    el.innerHTML = '<p v-a:hello.a.b="a" v-b="1">hello</p><div v-b.literal="foo"></div>'
     var defA = { priority: 1 }
     var defB = { priority: 2 }
     var options = _.mergeOptions(Vue.options, {
@@ -95,7 +95,7 @@ describe('Compile', function () {
     // 4 (explicit literal)
     args = vm._bindDir.calls.argsFor(3)
     expect(args[0].name).toBe('b')
-    expect(args[0].expression).toBe('hi')
+    expect(args[0].expression).toBe('foo')
     expect(args[0].def).toBe(defB)
     expect(args[0].modifiers.literal).toBe(true)
     expect(args[1]).toBe(el.lastChild)
@@ -219,7 +219,7 @@ describe('Compile', function () {
   })
 
   it('inline html', function () {
-    data.html = '<div>yoyoyo</div>'
+    data.html = '<div>foo</div>'
     el.innerHTML = '{{{html}}} {{{*html}}}'
     var htmlDef = Vue.options.directives.html
     var linker = compile(el, Vue.options)
@@ -230,7 +230,7 @@ describe('Compile', function () {
     expect(htmlArgs[0].expression).toBe('html')
     expect(htmlArgs[0].def).toBe(htmlDef)
     // with placeholder comments & interpolated one-time html
-    expect(el.innerHTML).toBe('<!--v-html--> <div>yoyoyo</div>')
+    expect(el.innerHTML).toBe('<!--v-html--> <div>foo</div>')
   })
 
   it('terminal directives', function () {
@@ -334,7 +334,7 @@ describe('Compile', function () {
       ':test-two-way.sync="a" ' +
       ':two-way-warn.sync="a + 1" ' +
       ':test-one-time.once="a" ' +
-      ':literal-with-filter="\'HI\' | lowercase"' +
+      ':literal-with-filter="\'FOO\' | lowercase"' +
       '></div>'
     compiler.compileAndLinkProps(vm, el.firstChild, props)
     // check bindDir calls:
@@ -369,7 +369,7 @@ describe('Compile', function () {
     prop = args[0].prop
     expect(args[0].name).toBe('prop')
     expect(prop.path).toBe('literalWithFilter')
-    expect(prop.parentPath).toBe("'HI'")
+    expect(prop.parentPath).toBe("'FOO'")
     expect(prop.filters.length).toBe(1)
     expect(prop.mode).toBe(bindingModes.ONE_WAY)
   })
@@ -378,11 +378,11 @@ describe('Compile', function () {
     // temporarily remove vm.$parent
     var context = vm._context
     vm._context = null
-    el.setAttribute('v-bind:a', '"hi"')
+    el.setAttribute('v-bind:a', '"foo"')
     el.setAttribute(':b', '[1,2,3]')
     compiler.compileAndLinkProps(vm, el, { a: null, b: null })
     expect(vm._bindDir.calls.count()).toBe(0)
-    expect(vm.a).toBe('hi')
+    expect(vm.a).toBe('foo')
     expect(vm.b.join(',')).toBe('1,2,3')
     // restore parent mock
     vm._context = context
@@ -453,7 +453,7 @@ describe('Compile', function () {
       el: el,
       template: '<test :msg="msg"></test>',
       data: {
-        msg: 'hi'
+        msg: 'foo'
       },
       components: {
         test: {
@@ -482,7 +482,7 @@ describe('Compile', function () {
       },
       components: {
         test: {
-          template: 'hi'
+          template: 'foo'
         }
       }
     })
@@ -629,7 +629,7 @@ describe('Compile', function () {
       el: el,
       template: '<div class="{{a}}" :class="bcd"></div>',
       data: {
-        a: 'hi'
+        a: 'foo'
       }
     })
     expect('Do not mix mustache interpolation and v-bind').toHaveBeenWarned()
@@ -638,7 +638,7 @@ describe('Compile', function () {
   it('warn directives on fragment instances', function () {
     new Vue({
       el: el,
-      template: '<test id="hi" class="ok" :prop="123"></test>',
+      template: '<test id="foo" class="ok" :prop="123"></test>',
       components: {
         test: {
           replace: true,

--- a/test/unit/specs/directives/element/partial_spec.js
+++ b/test/unit/specs/directives/element/partial_spec.js
@@ -11,18 +11,18 @@ describe('Partial', function () {
   it('static', function (done) {
     var vm = new Vue({
       el: el,
-      template: '<partial name="yo"></partial>',
+      template: '<partial name="p"></partial>',
       data: {
-        msg: 'hello'
+        msg: 'foo'
       },
       partials: {
-        yo: '{{msg}}'
+        p: '{{msg}}'
       }
     })
-    expect(el.textContent).toBe('hello')
-    vm.msg = 'what'
+    expect(el.textContent).toBe('foo')
+    vm.msg = 'bar'
     _.nextTick(function () {
-      expect(el.textContent).toBe('what')
+      expect(el.textContent).toBe('bar')
       done()
     })
   })
@@ -52,14 +52,14 @@ describe('Partial', function () {
       el: el,
       template: '<div v-for="id in list"><partial v-bind:name="\'test-\' + id"></partial></div>',
       data: {
-        list: ['a', 'b']
+        list: ['foo', 'bar']
       },
       partials: {
-        'test-a': 'a {{id}}',
-        'test-b': 'b {{id}}'
+        'test-foo': 'foo {{id}}',
+        'test-bar': 'bar {{id}}'
       }
     })
-    expect(el.textContent).toBe('a ab b')
+    expect(el.textContent).toBe('foo foobar bar')
   })
 
   it('caching', function () {
@@ -75,16 +75,16 @@ describe('Partial', function () {
         '<partial name="cache-test"></partial> ' +
         '<partial name="cache-test"></partial>',
       partials: {
-        'cache-test': 'cache-test {{msg}}'
+        'cache-test': 'foo {{msg}}'
       }
     })
     new Comp({
       el: el,
       data: {
-        msg: 'hi'
+        msg: 'bar'
       }
     })
-    expect(el.textContent).toBe('cache-test hi cache-test hi')
+    expect(el.textContent).toBe('foo bar foo bar')
     // one call for instance, and one for partial
     expect(calls).toBe(2)
     // cleanup

--- a/test/unit/specs/directives/element/slot_spec.js
+++ b/test/unit/specs/directives/element/slot_spec.js
@@ -24,20 +24,20 @@ describe('Slot Distribution', function () {
   })
 
   it('default content', function () {
-    el.innerHTML = '<p>hi</p>'
+    el.innerHTML = '<p>foo</p>'
     options.template = '<div><slot></slot></div>'
     mount()
     expect(el.firstChild.tagName).toBe('DIV')
     expect(el.firstChild.firstChild.tagName).toBe('P')
-    expect(el.firstChild.firstChild.textContent).toBe('hi')
+    expect(el.firstChild.firstChild.textContent).toBe('foo')
   })
 
   it('no template auto content', function () {
-    el.innerHTML = '<p>hi</p>'
+    el.innerHTML = '<p>foo</p>'
     options._asComponent = true
     mount()
     expect(el.firstChild.tagName).toBe('P')
-    expect(el.firstChild.textContent).toBe('hi')
+    expect(el.firstChild.textContent).toBe('foo')
   })
 
   it('fallback content', function () {
@@ -77,17 +77,17 @@ describe('Slot Distribution', function () {
   })
 
   it('default content should only render parts not selected', function () {
-    el.innerHTML = '<div>hi</div><p slot="a">1</p><p slot="b">2</p>'
+    el.innerHTML = '<div>foo</div><p slot="a">1</p><p slot="b">2</p>'
     options.template =
       '<slot name="a"></slot>' +
       '<slot></slot>' +
       '<slot name="b"></slot>'
     mount()
-    expect(el.innerHTML).toBe('<p slot="a">1</p><div>hi</div><p slot="b">2</p>')
+    expect(el.innerHTML).toBe('<p slot="a">1</p><div>foo</div><p slot="b">2</p>')
   })
 
   it('content transclusion with replace', function () {
-    el.innerHTML = '<p>hi</p>'
+    el.innerHTML = '<p>foo</p>'
     options.template = '<div><div><slot></slot></div></div>'
     options.replace = true
     mount()
@@ -95,11 +95,11 @@ describe('Slot Distribution', function () {
     expect(res).not.toBe(el)
     expect(res.firstChild.tagName).toBe('DIV')
     expect(res.firstChild.firstChild.tagName).toBe('P')
-    expect(res.firstChild.firstChild.textContent).toBe('hi')
+    expect(res.firstChild.firstChild.textContent).toBe('foo')
   })
 
   it('block instance content transclusion', function () {
-    el.innerHTML = '<p slot="p">hi</p><span slot="span">ho</span>'
+    el.innerHTML = '<p slot="p">foo</p><span slot="span">ho</span>'
     options.template = '<div></div><slot name="p"></slot><slot name="span"></slot>'
     options.replace = true
     mount()
@@ -146,7 +146,7 @@ describe('Slot Distribution', function () {
     var vm = new Vue({
       el: el,
       data: {
-        msg: 'hello'
+        msg: 'foo'
       },
       template: '<test>{{msg}}</test>',
       components: {
@@ -155,10 +155,10 @@ describe('Slot Distribution', function () {
         }
       }
     })
-    expect(el.innerHTML).toBe('<test>hello</test>')
-    vm.msg = 'what'
+    expect(el.innerHTML).toBe('<test>foo</test>')
+    vm.msg = 'bar'
     nextTick(function () {
-      expect(el.innerHTML).toBe('<test>what</test>')
+      expect(el.innerHTML).toBe('<test>bar</test>')
       done()
     })
   })
@@ -217,7 +217,7 @@ describe('Slot Distribution', function () {
       template: '<test v-for="n in list" :class="cls" :a="n.a">{{msg}}</test>',
       data: {
         cls: 'parent',
-        msg: 'hi',
+        msg: 'foo',
         list: [{a: 1}, {a: 2}, {a: 3}]
       },
       components: {
@@ -229,12 +229,12 @@ describe('Slot Distribution', function () {
       }
     })
     var markup = vm.list.map(function (item) {
-      return '<div class="child parent">' + item.a + ' hi</div>'
+      return '<div class="child parent">' + item.a + ' foo</div>'
     }).join('')
     expect(el.innerHTML).toBe(markup)
-    vm.msg = 'ho'
+    vm.msg = 'bar'
     markup = vm.list.map(function (item) {
-      return '<div class="child parent">' + item.a + ' ho</div>'
+      return '<div class="child parent">' + item.a + ' bar</div>'
     }).join('')
     nextTick(function () {
       expect(el.innerHTML).toBe(markup)
@@ -384,16 +384,16 @@ describe('Slot Distribution', function () {
       template: '<div v-for="n in 3"><comp></comp></div>',
       components: {
         comp: {
-          template: '<div><slot>{{something}}</slot></div>',
+          template: '<div><slot>{{foo}}</slot></div>',
           data: function () {
             return {
-              something: 'hi'
+              foo: 'bar'
             }
           }
         }
       }
     })
-    expect(el.textContent).toBe('hihihi')
+    expect(el.textContent).toBe('barbarbar')
   })
 
   it('fallback for slot with v-if', function (done) {
@@ -425,7 +425,7 @@ describe('Slot Distribution', function () {
   it('slot inside template', function () {
     var vm = new Vue({
       el: el,
-      template: '<test>hi</test>',
+      template: '<test>foo</test>',
       components: {
         test: {
           data: function () {
@@ -442,7 +442,7 @@ describe('Slot Distribution', function () {
         }
       }
     })
-    expect(vm.$el.textContent).toBe('hi')
+    expect(vm.$el.textContent).toBe('foo')
   })
 
   it('warn dynamic slot attribute', function () {

--- a/test/unit/specs/directives/internal/class_spec.js
+++ b/test/unit/specs/directives/internal/class_spec.js
@@ -8,42 +8,42 @@ describe(':class', function () {
   })
 
   it('plain string', function () {
-    el.className = 'haha'
+    el.className = 'foo'
     var dir = _.extend({ el: el }, def)
-    dir.update('test')
-    expect(el.className).toBe('haha test')
-    dir.update('what now test')
-    expect(el.className).toBe('haha what now test')
-    dir.update('ok cool')
-    expect(el.className).toBe('haha ok cool')
+    dir.update('bar')
+    expect(el.className).toBe('foo bar')
+    dir.update('baz')
+    expect(el.className).toBe('foo baz')
+    dir.update('qux')
+    expect(el.className).toBe('foo qux')
     dir.update()
-    expect(el.className).toBe('haha')
+    expect(el.className).toBe('foo')
   })
 
   it('object value', function () {
-    el.className = 'hoho'
+    el.className = 'foo'
     var dir = _.extend({ el: el }, def)
     dir.update({
-      a: true,
-      b: false
+      bar: true,
+      baz: false
     })
-    expect(el.className).toBe('hoho a')
+    expect(el.className).toBe('foo bar')
     dir.update({
-      b: true
+      baz: true
     })
-    expect(el.className).toBe('hoho b')
+    expect(el.className).toBe('foo baz')
     dir.update(null)
-    expect(el.className).toBe('hoho')
+    expect(el.className).toBe('foo')
 
     dir.update({
-      'a b': true,
-      c: false
+      'bar baz': true,
+      qux: false
     })
-    expect(el.className).toBe('hoho a b')
+    expect(el.className).toBe('foo bar baz')
     dir.update({
-      c: true
+      qux: true
     })
-    expect(el.className).toBe('hoho c')
+    expect(el.className).toBe('foo qux')
   })
 
   it('array value', function () {

--- a/test/unit/specs/directives/internal/component_spec.js
+++ b/test/unit/specs/directives/internal/component_spec.js
@@ -107,14 +107,14 @@ describe('Component', function () {
       },
       components: {
         'view-a': {
-          template: '<div>AAA</div>',
+          template: '<div>foo</div>',
           replace: true,
           data: function () {
             return { view: 'a' }
           }
         },
         'view-b': {
-          template: '<div>BBB</div>',
+          template: '<div>bar</div>',
           replace: true,
           data: function () {
             return { view: 'b' }
@@ -122,10 +122,10 @@ describe('Component', function () {
         }
       }
     })
-    expect(el.innerHTML).toBe('<div view="view-a">AAA</div>')
+    expect(el.innerHTML).toBe('<div view="view-a">foo</div>')
     vm.view = 'view-b'
     _.nextTick(function () {
-      expect(el.innerHTML).toBe('<div view="view-b">BBB</div>')
+      expect(el.innerHTML).toBe('<div view="view-b">bar</div>')
       vm.view = ''
       _.nextTick(function () {
         expect(el.innerHTML).toBe('')
@@ -142,16 +142,16 @@ describe('Component', function () {
         '<component :is="$options.components.async"></component>',
       components: {
         test: {
-          template: 'hi'
+          template: 'foo'
         },
         async: function (resolve) {
           resolve({
-            template: 'ho'
+            template: 'bar'
           })
         }
       }
     })
-    expect(el.textContent).toBe('hiho')
+    expect(el.textContent).toBe('foobar')
   })
 
   it('keep-alive', function (done) {
@@ -166,32 +166,32 @@ describe('Component', function () {
       components: {
         'view-a': {
           created: spyA,
-          template: '<div>AAA</div>',
+          template: '<div>foo</div>',
           replace: true
         },
         'view-b': {
           created: spyB,
-          template: '<div>BBB</div>',
+          template: '<div>bar</div>',
           replace: true
         }
       }
     })
-    expect(el.innerHTML).toBe('<div>AAA</div>')
+    expect(el.innerHTML).toBe('<div>foo</div>')
     expect(spyA.calls.count()).toBe(1)
     expect(spyB.calls.count()).toBe(0)
     vm.view = 'view-b'
     _.nextTick(function () {
-      expect(el.innerHTML).toBe('<div>BBB</div>')
+      expect(el.innerHTML).toBe('<div>bar</div>')
       expect(spyA.calls.count()).toBe(1)
       expect(spyB.calls.count()).toBe(1)
       vm.view = 'view-a'
       _.nextTick(function () {
-        expect(el.innerHTML).toBe('<div>AAA</div>')
+        expect(el.innerHTML).toBe('<div>foo</div>')
         expect(spyA.calls.count()).toBe(1)
         expect(spyB.calls.count()).toBe(1)
         vm.view = 'view-b'
         _.nextTick(function () {
-          expect(el.innerHTML).toBe('<div>BBB</div>')
+          expect(el.innerHTML).toBe('<div>bar</div>')
           expect(spyA.calls.count()).toBe(1)
           expect(spyB.calls.count()).toBe(1)
           done()
@@ -286,12 +286,12 @@ describe('Component', function () {
       template: '<view-a></view-a>',
       components: {
         'view-a': {
-          template: 'AAA',
+          template: 'foo',
           activate: function (ready) {
             setTimeout(function () {
               expect(el.textContent).toBe('')
               ready()
-              expect(el.textContent).toBe('AAA')
+              expect(el.textContent).toBe('foo')
               done()
             }, 0)
           }
@@ -307,7 +307,7 @@ describe('Component', function () {
       template: '<view-a></view-a>',
       components: {
         'view-a': {
-          template: 'AAA',
+          template: 'foo',
           mixins: [{
             activate: function (done) {
               expect(el.textContent).toBe('')
@@ -320,7 +320,7 @@ describe('Component', function () {
               expect(mixinSpy).toHaveBeenCalled()
               expect(el.textContent).toBe('')
               ready()
-              expect(el.textContent).toBe('AAA')
+              expect(el.textContent).toBe('foo')
               done()
             }, 0)
           }
@@ -339,13 +339,13 @@ describe('Component', function () {
       template: '<component :is="view"></component>',
       components: {
         'view-a': {
-          template: 'AAA',
+          template: 'foo',
           activate: function (ready) {
             next = ready
           }
         },
         'view-b': {
-          template: 'BBB',
+          template: 'bar',
           activate: function (ready) {
             next = ready
           }
@@ -355,14 +355,14 @@ describe('Component', function () {
     expect(next).toBeTruthy()
     expect(el.textContent).toBe('')
     next()
-    expect(el.textContent).toBe('AAA')
+    expect(el.textContent).toBe('foo')
     vm.view = 'view-b'
     _.nextTick(function () {
-      expect(el.textContent).toBe('AAA')
+      expect(el.textContent).toBe('foo')
       // old vm is already removed, this is the new vm
       expect(vm.$children.length).toBe(1)
       next()
-      expect(el.textContent).toBe('BBB')
+      expect(el.textContent).toBe('bar')
       // ensure switching before ready event correctly
       // cleans up the component being waited on.
       // see #1152
@@ -373,7 +373,7 @@ describe('Component', function () {
         vm.view = 'view-b'
         _.nextTick(function () {
           expect(vm.$children.length).toBe(1)
-          expect(vm.$children[0].$el.textContent).toBe('BBB')
+          expect(vm.$children[0].$el.textContent).toBe('bar')
           // calling view-a's ready callback here should not throw
           // because it should've been cancelled (#1994)
           expect(callback).not.toThrow()
@@ -393,13 +393,13 @@ describe('Component', function () {
       template: '<component :is="view" keep-alive></component>',
       components: {
         'view-a': {
-          template: 'AAA',
+          template: 'foo',
           activate: function (ready) {
             next = ready
           }
         },
         'view-b': {
-          template: 'BBB',
+          template: 'bar',
           activate: function (ready) {
             next = ready
           }
@@ -407,17 +407,17 @@ describe('Component', function () {
       }
     })
     next()
-    expect(el.textContent).toBe('AAA')
+    expect(el.textContent).toBe('foo')
     vm.view = 'view-b'
     _.nextTick(function () {
       expect(vm.$children.length).toBe(2)
       next()
-      expect(el.textContent).toBe('BBB')
+      expect(el.textContent).toBe('bar')
       vm.view = 'view-a'
       _.nextTick(function () {
         // should switch without the need to emit
         // because of keep-alive
-        expect(el.textContent).toBe('AAA')
+        expect(el.textContent).toBe('foo')
         done()
       })
     })
@@ -434,8 +434,8 @@ describe('Component', function () {
       },
       template: '<component :is="view" transition="test" transition-mode="in-out"></component>',
       components: {
-        'view-a': { template: 'AAA' },
-        'view-b': { template: 'BBB' }
+        'view-a': { template: 'foo' },
+        'view-b': { template: 'bar' }
       },
       transitions: {
         test: {
@@ -450,17 +450,17 @@ describe('Component', function () {
         }
       }
     })
-    expect(el.textContent).toBe('AAA')
+    expect(el.textContent).toBe('foo')
     vm.view = 'view-b'
     _.nextTick(function () {
       expect(spy1).toHaveBeenCalled()
       expect(spy2).not.toHaveBeenCalled()
-      expect(el.textContent).toBe('AAABBB')
+      expect(el.textContent).toBe('foobar')
       next()
       _.nextTick(function () {
         expect(spy2).toHaveBeenCalled()
         _.nextTick(function () {
-          expect(el.textContent).toBe('BBB')
+          expect(el.textContent).toBe('bar')
           done()
         })
       })
@@ -478,8 +478,8 @@ describe('Component', function () {
       },
       template: '<component :is="view" transition="test" transition-mode="out-in"></component>',
       components: {
-        'view-a': { template: 'AAA' },
-        'view-b': { template: 'BBB' }
+        'view-a': { template: 'foo' },
+        'view-b': { template: 'bar' }
       },
       transitions: {
         test: {
@@ -494,15 +494,15 @@ describe('Component', function () {
         }
       }
     })
-    expect(el.textContent).toBe('AAA')
+    expect(el.textContent).toBe('foo')
     vm.view = 'view-b'
     _.nextTick(function () {
       expect(spy1).toHaveBeenCalled()
       expect(spy2).not.toHaveBeenCalled()
-      expect(el.textContent).toBe('AAA')
+      expect(el.textContent).toBe('foo')
       next()
       expect(spy2).toHaveBeenCalled()
-      expect(el.textContent).toBe('BBB')
+      expect(el.textContent).toBe('bar')
       done()
     })
   })

--- a/test/unit/specs/directives/internal/prop_spec.js
+++ b/test/unit/specs/directives/internal/prop_spec.js
@@ -10,7 +10,7 @@ describe('prop', function () {
     var vm = new Vue({
       el: el,
       data: {
-        b: 'B'
+        b: 'bar'
       },
       template: '<test v-bind:b="b" v-ref:child></test>',
       components: {
@@ -20,14 +20,14 @@ describe('prop', function () {
         }
       }
     })
-    expect(el.innerHTML).toBe('<test>B</test>')
-    vm.b = 'BB'
+    expect(el.innerHTML).toBe('<test>bar</test>')
+    vm.b = 'baz'
     Vue.nextTick(function () {
-      expect(el.innerHTML).toBe('<test>BB</test>')
-      vm.$refs.child.b = 'BBB'
-      expect(vm.b).toBe('BB')
+      expect(el.innerHTML).toBe('<test>baz</test>')
+      vm.$refs.child.b = 'qux'
+      expect(vm.b).toBe('baz')
       Vue.nextTick(function () {
-        expect(el.innerHTML).toBe('<test>BBB</test>')
+        expect(el.innerHTML).toBe('<test>qux</test>')
         done()
       })
     })
@@ -82,17 +82,17 @@ describe('prop', function () {
     vm.b = 'BB'
     Vue.nextTick(function () {
       expect(el.firstChild.textContent).toBe('AA BB AA')
-      vm.test = { a: 'AAA' }
+      vm.test = { a: 'foo' }
       Vue.nextTick(function () {
-        expect(el.firstChild.textContent).toBe('AAA BB AAA')
+        expect(el.firstChild.textContent).toBe('foo BB foo')
         vm.$data = {
-          b: 'BBB',
+          b: 'bar',
           test: {
-            a: 'AAAA'
+            a: 'fooA'
           }
         }
         Vue.nextTick(function () {
-          expect(el.firstChild.textContent).toBe('AAAA BBB AAAA')
+          expect(el.firstChild.textContent).toBe('fooA bar fooA')
           // test two-way
           vm.$refs.child.bb = 'B'
           vm.$refs.child.testt = { a: 'A' }
@@ -117,7 +117,7 @@ describe('prop', function () {
     var vm = new Vue({
       el: el,
       data: {
-        b: 'B'
+        b: 'foo'
       },
       template: '<test :b.once="b" v-ref:child></test>',
       components: {
@@ -127,10 +127,10 @@ describe('prop', function () {
         }
       }
     })
-    expect(el.innerHTML).toBe('<test>B</test>')
-    vm.b = 'BB'
+    expect(el.innerHTML).toBe('<test>foo</test>')
+    vm.b = 'bar'
     Vue.nextTick(function () {
-      expect(el.innerHTML).toBe('<test>B</test>')
+      expect(el.innerHTML).toBe('<test>foo</test>')
       done()
     })
   })
@@ -139,9 +139,9 @@ describe('prop', function () {
     var vm = new Vue({
       el: el,
       data: {
-        b: 'B'
+        b: 'foo'
       },
-      template: '<test :b.sync=" b + \'B\'" v-ref:child></test>',
+      template: '<test :b.sync=" b + \'bar\'" v-ref:child></test>',
       components: {
         test: {
           props: ['b'],
@@ -150,14 +150,14 @@ describe('prop', function () {
       }
     })
     expect('Cannot bind two-way prop with non-settable parent path').toHaveBeenWarned()
-    expect(el.innerHTML).toBe('<test>BB</test>')
-    vm.b = 'BB'
+    expect(el.innerHTML).toBe('<test>foobar</test>')
+    vm.b = 'baz'
     Vue.nextTick(function () {
-      expect(el.innerHTML).toBe('<test>BBB</test>')
-      vm.$refs.child.b = 'hahaha'
+      expect(el.innerHTML).toBe('<test>bazbar</test>')
+      vm.$refs.child.b = 'qux'
       Vue.nextTick(function () {
-        expect(vm.b).toBe('BB')
-        expect(el.innerHTML).toBe('<test>hahaha</test>')
+        expect(vm.b).toBe('baz')
+        expect(el.innerHTML).toBe('<test>qux</test>')
         done()
       })
     })
@@ -166,9 +166,9 @@ describe('prop', function () {
   it('warn expect two-way', function () {
     new Vue({
       el: el,
-      template: '<test :test="ok"></test>',
+      template: '<test :test="foo"></test>',
       data: {
-        ok: 'hi'
+        foo: 'bar'
       },
       components: {
         test: {
@@ -188,7 +188,7 @@ describe('prop', function () {
       el: el,
       template: '<test></test>',
       data: {
-        ok: 'hi'
+        foo: 'bar'
       },
       components: {
         test: {
@@ -262,10 +262,10 @@ describe('prop', function () {
       // unbind the two props
       child._directives[0].unbind()
       child._directives[1].unbind()
-      child.aa = 'AAA'
+      child.aa = 'foo'
       vm.b = 'BBB'
       Vue.nextTick(function () {
-        expect(el.firstChild.textContent).toBe('AAA BB')
+        expect(el.firstChild.textContent).toBe('foo BB')
         expect(vm.a).toBe('AA')
         done()
       })
@@ -277,8 +277,8 @@ describe('prop', function () {
       el: el,
       template: '<test :b="a" :c="d"></test>',
       data: {
-        a: 'AAA',
-        d: 'DDD'
+        a: 'foo',
+        d: 'bar'
       },
       components: {
         test: {
@@ -288,7 +288,7 @@ describe('prop', function () {
         }
       }
     })
-    expect(el.innerHTML).toBe('<p>AAA</p><p>DDD</p>')
+    expect(el.innerHTML).toBe('<p>foo</p><p>bar</p>')
   })
 
   describe('assertions', function () {
@@ -471,8 +471,8 @@ describe('prop', function () {
       el: el,
       template: '<test :b="a" :c="d"></test>',
       data: {
-        a: 'AAA',
-        d: 'DDD'
+        a: 'foo',
+        d: 'bar'
       },
       components: {
         test: {
@@ -491,7 +491,7 @@ describe('prop', function () {
     })
     expect('Missing required prop').toHaveBeenWarned()
     expect('Expected Number').toHaveBeenWarned()
-    expect(el.textContent).toBe('AAA')
+    expect(el.textContent).toBe('foo')
   })
 
   it('mixed syntax', function () {
@@ -499,8 +499,8 @@ describe('prop', function () {
       el: el,
       template: '<test :b="a" :c="d"></test>',
       data: {
-        a: 'AAA',
-        d: 'DDD'
+        a: 'foo',
+        d: 'bar'
       },
       components: {
         test: {
@@ -521,7 +521,7 @@ describe('prop', function () {
     })
     expect('Missing required prop').toHaveBeenWarned()
     expect('Expected Number').toHaveBeenWarned()
-    expect(el.textContent).toBe('AAA')
+    expect(el.textContent).toBe('foo')
   })
 
   it('should respect default value of a Boolean prop', function () {

--- a/test/unit/specs/directives/public/bind_spec.js
+++ b/test/unit/specs/directives/public/bind_spec.js
@@ -33,8 +33,8 @@ describe('v-bind', function () {
   it('should set property for input value', function () {
     dir.el = document.createElement('input')
     dir.arg = 'value'
-    dir.update('what')
-    expect(dir.el.value).toBe('what')
+    dir.update('foo')
+    expect(dir.el.value).toBe('foo')
     dir.el = document.createElement('input')
     dir.el.type = 'checkbox'
     dir.arg = 'checked'
@@ -56,11 +56,11 @@ describe('v-bind', function () {
   it('object format', function () {
     dir.el = document.createElement('input')
     dir.update({
-      'test': 'hi',
-      'value': 'what'
+      'test': 'foo',
+      'value': 'bar'
     })
-    expect(dir.el.getAttribute('test')).toBe('hi')
-    expect(dir.el.value).toBe('what')
+    expect(dir.el.getAttribute('test')).toBe('foo')
+    expect(dir.el.value).toBe('bar')
     dir.update({
       'xlink:special': 'ok'
     })

--- a/test/unit/specs/directives/public/for/for_spec.js
+++ b/test/unit/specs/directives/public/for/for_spec.js
@@ -278,17 +278,17 @@ describe('v-for', function () {
       },
       components: {
         'view-a': {
-          template: 'AAA'
+          template: 'foo'
         },
         'view-b': {
-          template: 'BBB'
+          template: 'bar'
         },
         'view-c': {
-          template: 'CCC'
+          template: 'baz'
         }
       }
     })
-    expect(el.innerHTML).toBe('<component>AAA</component><component>BBB</component><component>CCC</component>')
+    expect(el.innerHTML).toBe('<component>foo</component><component>bar</component><component>baz</component>')
     // primitive
     el = document.createElement('div')
     new Vue({
@@ -299,17 +299,17 @@ describe('v-for', function () {
       },
       components: {
         'view-a': {
-          template: 'AAA'
+          template: 'foo'
         },
         'view-b': {
-          template: 'BBB'
+          template: 'bar'
         },
         'view-c': {
-          template: 'CCC'
+          template: 'baz'
         }
       }
     })
-    expect(el.innerHTML).toBe('<component>AAA</component><component>BBB</component><component>CCC</component>')
+    expect(el.innerHTML).toBe('<component>foo</component><component>bar</component><component>baz</component>')
   })
 
   it('fragment loop', function (done) {
@@ -393,13 +393,13 @@ describe('v-for', function () {
       el: el,
       template: '<div v-for="item in list | filterBy filterKey | orderBy sortKey -1 | limitBy 2">{{item.id}}</div>',
       data: {
-        filterKey: 'hi!',
+        filterKey: 'foo',
         sortKey: 'id',
         list: [
-          { id: 1, id2: 4, msg: 'hi!' },
-          { id: 2, id2: 3, msg: 'na' },
-          { id: 3, id2: 2, msg: 'hi!' },
-          { id: 4, id2: 1, msg: 'na' }
+          { id: 1, id2: 4, msg: 'foo' },
+          { id: 2, id2: 3, msg: 'bar' },
+          { id: 3, id2: 2, msg: 'foo' },
+          { id: 4, id2: 1, msg: 'bar' }
         ]
       }
     })
@@ -407,7 +407,7 @@ describe('v-for', function () {
 
     go(
       function () {
-        vm.filterKey = 'na'
+        vm.filterKey = 'bar'
       }, assertMarkup
     )
     .then(
@@ -422,14 +422,14 @@ describe('v-for', function () {
     )
     .then(
       function () {
-        vm.list.push({ id: 0, id2: 4, msg: 'na' })
+        vm.list.push({ id: 0, id2: 4, msg: 'bar' })
       }, assertMarkup
     )
     .then(
       function () {
         vm.list = [
-          { id: 33, id2: 4, msg: 'hi!' },
-          { id: 44, id2: 3, msg: 'na' }
+          { id: 33, id2: 4, msg: 'foo' },
+          { id: 44, id2: 3, msg: 'bar' }
         ]
       }, assertMarkup
     )
@@ -490,9 +490,9 @@ describe('v-for', function () {
       template: '<test v-for="item in list" :item="item" track-by="id"></test>',
       data: {
         list: [
-          { id: 1, msg: 'hi' },
-          { id: 2, msg: 'ha' },
-          { id: 3, msg: 'ho' }
+          { id: 1, msg: 'foo' },
+          { id: 2, msg: 'bar' },
+          { id: 3, msg: 'baz' }
         ]
       },
       components: {
@@ -507,8 +507,8 @@ describe('v-for', function () {
     // swap the data with different objects, but with
     // the same ID!
     vm.list = [
-      { id: 1, msg: 'wa' },
-      { id: 2, msg: 'wo' }
+      { id: 1, msg: 'qux' },
+      { id: 2, msg: 'quux' }
     ]
     _.nextTick(function () {
       assertMarkup()
@@ -764,8 +764,8 @@ describe('v-for', function () {
           { id: 1, msg: 'hi', list: [
             { id: 1, msg: 'hi foo' }
           ] },
-          { id: 2, msg: 'ha', list: [] },
-          { id: 3, msg: 'ho', list: [] }
+          { id: 2, msg: 'bar', list: [] },
+          { id: 3, msg: 'baz', list: [] }
         ]
       }
     })
@@ -775,11 +775,11 @@ describe('v-for', function () {
     var oldInnerNodes = el.children[0].children
 
     vm.list = [
-      { id: 1, msg: 'wa', list: [
+      { id: 1, msg: 'baz', list: [
         { id: 1, msg: 'hi foo' },
         { id: 2, msg: 'hi bar' }
       ] },
-      { id: 2, msg: 'wo', list: [] }
+      { id: 2, msg: 'qux', list: [] }
     ]
 
     _.nextTick(function () {
@@ -806,8 +806,8 @@ describe('v-for', function () {
 
   it('switch between object-converted & array mode', function (done) {
     var obj = {
-      a: { msg: 'AA' },
-      b: { msg: 'BB' }
+      a: { msg: 'foo' },
+      b: { msg: 'bar' }
     }
     var arr = [obj.b, obj.a]
     var vm = new Vue({
@@ -822,7 +822,7 @@ describe('v-for', function () {
     }).join(''))
     vm.obj = arr
     _.nextTick(function () {
-      expect(el.innerHTML).toBe('<div>BB</div><div>AA</div>')
+      expect(el.innerHTML).toBe('<div>bar</div><div>foo</div>')
       // make sure it cleared the cache
       expect(vm._directives[0].cache.a).toBeNull()
       expect(vm._directives[0].cache.b).toBeNull()

--- a/test/unit/specs/directives/public/if_spec.js
+++ b/test/unit/specs/directives/public/if_spec.js
@@ -112,10 +112,10 @@ describe('v-if', function () {
       template: '<component :is="view" v-if="ok"></component>',
       components: {
         'view-a': {
-          template: 'AAA'
+          template: 'foo'
         },
         'view-b': {
-          template: 'BBB'
+          template: 'bar'
         }
       }
     })
@@ -124,12 +124,12 @@ describe('v-if', function () {
     // toggle if with lazy instantiation
     vm.ok = true
     nextTick(function () {
-      expect(el.innerHTML).toBe('<component>AAA</component>')
+      expect(el.innerHTML).toBe('<component>foo</component>')
       expect(vm.$children.length).toBe(1)
       // switch view when if=true
       vm.view = 'view-b'
       nextTick(function () {
-        expect(el.innerHTML).toBe('<component>BBB</component>')
+        expect(el.innerHTML).toBe('<component>bar</component>')
         expect(vm.$children.length).toBe(1)
         // toggle if when already instantiated
         vm.ok = false
@@ -140,7 +140,7 @@ describe('v-if', function () {
           vm.view = 'view-a'
           vm.ok = true
           nextTick(function () {
-            expect(el.innerHTML).toBe('<component>AAA</component>')
+            expect(el.innerHTML).toBe('<component>foo</component>')
             expect(vm.$children.length).toBe(1)
             done()
           })
@@ -328,7 +328,7 @@ describe('v-if', function () {
       template: '<template v-if="show"><test></test></template>',
       components: {
         test: {
-          template: 'hi',
+          template: 'foo',
           replace: true,
           attached: attachSpy,
           detached: detachSpy
@@ -356,7 +356,7 @@ describe('v-if', function () {
     })
 
     function assertMarkup () {
-      expect(el.innerHTML).toBe(vm.show ? 'hi' : '')
+      expect(el.innerHTML).toBe(vm.show ? 'foo' : '')
     }
 
     function assertCalls (attach, detach) {

--- a/test/unit/specs/directives/public/model_spec.js
+++ b/test/unit/specs/directives/public/model_spec.js
@@ -559,15 +559,15 @@ describe('v-model', function () {
     var vm = new Vue({
       el: el,
       data: {
-        test: 'aaa'
+        test: 'foo'
       },
       template: '<input v-model="test">'
     })
     var input = el.firstChild
-    input.value = 'aa'
+    input.value = 'bar'
     trigger(input, 'cut')
     _.nextTick(function () {
-      expect(vm.test).toBe('aa')
+      expect(vm.test).toBe('bar')
       input.value = 'a'
       trigger(input, 'keyup', function (e) {
         e.keyCode = 8
@@ -575,7 +575,7 @@ describe('v-model', function () {
       expect(vm.test).toBe('a')
       // teardown
       vm._directives[0]._teardown()
-      input.value = 'bbb'
+      input.value = 'bar'
       trigger(input, 'keyup', function (e) {
         e.keyCode = 8
       })
@@ -590,8 +590,8 @@ describe('v-model', function () {
       var vm = new Vue({
         el: el,
         data: {
-          test: 'aaa',
-          test2: 'bbb'
+          test: 'foo',
+          test2: 'bar'
         },
         template: '<input v-model="test"><input v-model="test2 | uppercase">'
       })
@@ -599,19 +599,19 @@ describe('v-model', function () {
       var input2 = el.childNodes[1]
       trigger(input, 'compositionstart')
       trigger(input2, 'compositionstart')
-      input.value = input2.value = 'ccc'
+      input.value = input2.value = 'baz'
       // input before composition unlock should not call set
       trigger(input, 'input')
       trigger(input2, 'input')
-      expect(vm.test).toBe('aaa')
-      expect(vm.test2).toBe('bbb')
+      expect(vm.test).toBe('foo')
+      expect(vm.test2).toBe('bar')
       // after composition unlock it should work
       trigger(input, 'compositionend')
       trigger(input2, 'compositionend')
       trigger(input, 'input')
       trigger(input2, 'input')
-      expect(vm.test).toBe('ccc')
-      expect(vm.test2).toBe('ccc')
+      expect(vm.test).toBe('baz')
+      expect(vm.test2).toBe('baz')
       // IE complains about "unspecified error" when calling
       // setSelectionRange() on an input element that's been
       // removed from the DOM, so we wait until the
@@ -624,13 +624,13 @@ describe('v-model', function () {
     var vm = new Vue({
       el: el,
       data: {
-        test: 'b',
-        b: 'BB'
+        test: 'foo',
+        b: 'bar'
       },
-      template: '<textarea v-model="test">a {{b}} c</textarea>'
+      template: '<textarea v-model="test">foo {{b}} baz</textarea>'
     })
-    expect(vm.test).toBe('a BB c')
-    expect(el.firstChild.value).toBe('a BB c')
+    expect(vm.test).toBe('foo bar baz')
+    expect(el.firstChild.value).toBe('foo bar baz')
   })
 
   it('warn invalid tag', function () {
@@ -765,7 +765,7 @@ describe('v-model', function () {
         '</form>',
       data: {
         ok: true,
-        msg: 'hi'
+        msg: 'foo'
       },
       methods: {
         save: function () {

--- a/test/unit/specs/directives/public/ref_spec.js
+++ b/test/unit/specs/directives/public/ref_spec.js
@@ -121,16 +121,16 @@ describe('ref', function () {
         comp: {
           template: '<slot></slot>',
           data: function () {
-            return { msg: 'hi' }
+            return { msg: 'foo' }
           }
         }
       }
     })
     expect(getWarnCount()).toBe(0)
-    expect(vm.$el.textContent).toBe('hi')
-    vm.$children[0].msg = 'ho'
+    expect(vm.$el.textContent).toBe('foo')
+    vm.$children[0].msg = 'bar'
     _.nextTick(function () {
-      expect(vm.$el.textContent).toBe('ho')
+      expect(vm.$el.textContent).toBe('bar')
       done()
     })
   })

--- a/test/unit/specs/directives/public/text_spec.js
+++ b/test/unit/specs/directives/public/text_spec.js
@@ -8,8 +8,8 @@ describe('v-text', function () {
     }
     _.extend(dir, def)
     dir.bind()
-    dir.update('hi')
-    expect(dir.el.textContent).toBe('hi')
+    dir.update('foo')
+    expect(dir.el.textContent).toBe('foo')
     dir.update(123)
     expect(dir.el.textContent).toBe('123')
   })
@@ -20,8 +20,8 @@ describe('v-text', function () {
     }
     _.extend(dir, def)
     dir.bind()
-    dir.update('hi')
-    expect(dir.el.nodeValue).toBe('hi')
+    dir.update('foo')
+    expect(dir.el.nodeValue).toBe('foo')
     dir.update(123)
     expect(dir.el.nodeValue).toBe('123')
   })

--- a/test/unit/specs/instance/misc_spec.js
+++ b/test/unit/specs/instance/misc_spec.js
@@ -4,7 +4,7 @@ describe('misc', function () {
   describe('_applyFilters', function () {
     var vm = new Vue({
       data: {
-        msg: 'BBB'
+        msg: 'bar'
       },
       filters: {
         read: function (v, arg) {
@@ -41,11 +41,11 @@ describe('misc', function () {
 
     it('read', function () {
       var filters = [
-        { name: 'read', args: [{dynamic: false, value: 'AAA'}] },
+        { name: 'read', args: [{dynamic: false, value: 'foo'}] },
         { name: 'read2', args: [{dynamic: true, value: 'msg'}] }
       ]
       var val = vm._applyFilters('test', null, filters, false)
-      expect(val).toBe('test read:AAA read2:BBB')
+      expect(val).toBe('test read:foo read2:bar')
     })
 
     it('write', function () {
@@ -68,7 +68,7 @@ describe('misc', function () {
     })
 
     it('warn not found', function () {
-      vm._applyFilters('what', null, [{name: 'wtf'}])
+      vm._applyFilters('waldo', null, [{name: 'nemo'}])
       expect('Failed to resolve filter').toHaveBeenWarned()
     })
   })

--- a/test/unit/specs/misc_spec.js
+++ b/test/unit/specs/misc_spec.js
@@ -8,18 +8,18 @@ describe('Misc', function () {
       el: document.createElement('div'),
       template: '<div v-test>{{test}}</div>',
       data: {
-        test: 'hi'
+        test: 'foo'
       },
       directives: {
         test: {
           bind: function () {
-            this.el.insertBefore(document.createTextNode('yo '),
+            this.el.insertBefore(document.createTextNode('bar '),
               this.el.firstChild)
           }
         }
       }
     })
-    expect(vm.$el.textContent).toBe('yo hi')
+    expect(vm.$el.textContent).toBe('bar foo')
   })
 
   it('attached/detached hooks for transcluded components', function () {
@@ -36,7 +36,7 @@ describe('Misc', function () {
           template: '<slot></slot>'
         },
         inner: {
-          template: 'hi',
+          template: 'foo',
           attached: spy1,
           detached: spy2
         }
@@ -194,13 +194,13 @@ describe('Misc', function () {
       el: document.createElement('div'),
       template: '{{msg}}',
       data: Object.freeze({
-        msg: 'hi!'
+        msg: 'foo'
       })
     })
-    expect(vm.$el.textContent).toBe('hi!')
-    try { vm.msg = 'ho!' } catch (e) {}
+    expect(vm.$el.textContent).toBe('foo')
+    try { vm.msg = 'bar' } catch (e) {}
     Vue.nextTick(function () {
-      expect(vm.$el.textContent).toBe('hi!')
+      expect(vm.$el.textContent).toBe('foo')
       done()
     })
   })
@@ -210,14 +210,14 @@ describe('Misc', function () {
       el: document.createElement('div'),
       template: '{{msg}} {{frozen.msg}}',
       data: {
-        msg: 'hi',
+        msg: 'foo',
         frozen: Object.freeze({
           msg: 'frozen'
         })
       }
     })
-    expect(vm.$el.textContent).toBe('hi frozen')
-    vm.msg = 'ho'
+    expect(vm.$el.textContent).toBe('foo frozen')
+    vm.msg = 'bar'
     try {
       vm.frozen.msg = 'changed'
     } catch (error) {
@@ -226,7 +226,7 @@ describe('Misc', function () {
       }
     }
     Vue.nextTick(function () {
-      expect(vm.$el.textContent).toBe('ho frozen')
+      expect(vm.$el.textContent).toBe('bar frozen')
       done()
     })
   })
@@ -424,10 +424,10 @@ describe('Misc', function () {
       el: document.createElement('div'),
       template: '<div class="{{test}}" transition="test"></div>',
       data: {
-        test: 'hi'
+        test: 'foo'
       }
     })
-    expect(vm.$el.firstChild.className).toBe('hi test-transition')
+    expect(vm.$el.firstChild.className).toBe('foo test-transition')
   })
 
   it('transclude class merging should skip interpolated class', function () {
@@ -435,7 +435,7 @@ describe('Misc', function () {
       el: document.createElement('div'),
       template: '<test class="outer-{{test}}"></test>',
       data: {
-        test: 'hi'
+        test: 'foo'
       },
       components: {
         test: {
@@ -444,7 +444,7 @@ describe('Misc', function () {
         }
       }
     })
-    expect(vm.$el.firstChild.className).toBe('outer-hi')
+    expect(vm.$el.firstChild.className).toBe('outer-foo')
   })
 
   // #2163
@@ -511,7 +511,7 @@ describe('Misc', function () {
           },
           components: {
             child: {
-              template: 'yo',
+              template: 'foo',
               attached: spyChild
             }
           }

--- a/test/unit/specs/parsers/expression_spec.js
+++ b/test/unit/specs/parsers/expression_spec.js
@@ -108,15 +108,15 @@ var testCases = [
   },
   {
     // expressions with inline object literals
-    exp: "sortRows({ column: 'name', test: haha, durrr: 123 })",
+    exp: "sortRows({ column: 'name', test: foo, durrr: 123 })",
     scope: {
       sortRows: function (params) {
         return params.column + params.test + params.durrr
       },
-      haha: 'hoho'
+      foo: 'bar'
     },
-    expected: 'namehoho123',
-    paths: ['sortRows', 'haha']
+    expected: 'namebar123',
+    paths: ['sortRows', 'bar']
   },
   {
     // space between path segments

--- a/test/unit/specs/parsers/template_spec.js
+++ b/test/unit/specs/parsers/template_spec.js
@@ -34,10 +34,10 @@ describe('Template Parser', function () {
   })
 
   it('should handle string that contains html entities', function () {
-    var res = parse('hi&lt;hi')
+    var res = parse('foo&lt;bar')
     expect(res.nodeType).toBe(11)
     expect(res.childNodes.length).toBe(1)
-    expect(res.firstChild.nodeValue).toBe('hi<hi')
+    expect(res.firstChild.nodeValue).toBe('foo<bar')
     // #1330
     res = parse('hello &#x2F; hello')
     expect(res.nodeType).toBe(11)

--- a/test/unit/specs/parsers/text_spec.js
+++ b/test/unit/specs/parsers/text_spec.js
@@ -5,7 +5,7 @@ var config = require('src/config')
 var testCases = [
   {
     // no tags
-    text: 'haha',
+    text: 'foo',
     expected: null
   },
   {

--- a/test/unit/specs/util/component_spec.js
+++ b/test/unit/specs/util/component_spec.js
@@ -9,15 +9,15 @@ describe('Util - component', function () {
     expect(res).toBeUndefined()
 
     // static <component is="...">
-    el.setAttribute('is', 'what')
+    el.setAttribute('is', 'foo')
     res = _.checkComponentAttr(el)
-    expect(res.id).toBe('what')
+    expect(res.id).toBe('foo')
     expect(res.dynamic).toBeFalsy()
 
     // <component :is="...">
-    el.setAttribute(':is', 'what')
+    el.setAttribute(':is', 'foo')
     res = _.checkComponentAttr(el)
-    expect(res.id).toBe('what')
+    expect(res.id).toBe('foo')
     expect(res.dynamic).toBe(true)
 
     // custom element, not defined
@@ -35,10 +35,10 @@ describe('Util - component', function () {
 
     // is on undefined custom element
     el = document.createElement('test2')
-    el.setAttribute('is', 'what')
+    el.setAttribute('is', 'foo')
     res = _.checkComponentAttr(el, {
       components: {}
     })
-    expect(res.id).toBe('what')
+    expect(res.id).toBe('foo')
   })
 })

--- a/test/unit/specs/util/debug_spec.js
+++ b/test/unit/specs/util/debug_spec.js
@@ -19,10 +19,10 @@ if (typeof console !== 'undefined') {
     it('format component name', function () {
       config.silent = false
       _.warn.and.callThrough()
-      _.warn('oops', new Vue({ name: 'hi' }))
-      expect(console.error).toHaveBeenCalledWith(warnPrefix + 'oops (found in component: <hi>)')
-      _.warn('oops', { name: 'ho' })
-      expect(console.error).toHaveBeenCalledWith(warnPrefix + 'oops (found in component: <ho>)')
+      _.warn('oops', new Vue({ name: 'foo' }))
+      expect(console.error).toHaveBeenCalledWith(warnPrefix + 'oops (found in component: <foo>)')
+      _.warn('oops', { name: 'bar' })
+      expect(console.error).toHaveBeenCalledWith(warnPrefix + 'oops (found in component: <bar>)')
     })
 
     it('not warn when silent is ture', function () {

--- a/test/unit/specs/util/lang_spec.js
+++ b/test/unit/specs/util/lang_spec.js
@@ -14,14 +14,14 @@ describe('Util - Language Enhancement', function () {
     expect(_.isLiteral('12.3')).toBe(true)
     expect(_.isLiteral('true')).toBe(true)
     expect(_.isLiteral(' false ')).toBe(true)
-    expect(_.isLiteral('"hi"')).toBe(true)
-    expect(_.isLiteral(" 'whatt' ")).toBe(true)
+    expect(_.isLiteral('"foo"')).toBe(true)
+    expect(_.isLiteral(" 'foo' ")).toBe(true)
     expect(_.isLiteral('a.b.c')).toBe(false)
     expect(_.isLiteral('1 + 1')).toBe(false)
   })
 
   it('toString', function () {
-    expect(_._toString('hi')).toBe('hi')
+    expect(_._toString('foo')).toBe('foo')
     expect(_._toString(1.234)).toBe('1.234')
     expect(_._toString(null)).toBe('')
     expect(_._toString(undefined)).toBe('')
@@ -48,16 +48,16 @@ describe('Util - Language Enhancement', function () {
   })
 
   it('hyphenate', function () {
-    expect(_.hyphenate('whatsUp')).toBe('whats-up')
+    expect(_.hyphenate('fooBar')).toBe('foo-bar')
     expect(_.hyphenate('a1BfC')).toBe('a1-bf-c')
     expect(_.hyphenate('already-With-Hyphen')).toBe('already-with-hyphen')
   })
 
   it('classify', function () {
     expect(_.classify('abc')).toBe('Abc')
-    expect(_.classify('some-long-name')).toBe('SomeLongName')
-    expect(_.classify('what_about_this')).toBe('WhatAboutThis')
-    expect(_.classify('how/about/that')).toBe('HowAboutThat')
+    expect(_.classify('foo-bar')).toBe('FooBar')
+    expect(_.classify('foo_bar')).toBe('FooBar')
+    expect(_.classify('foo/bar')).toBe('FooBar')
   })
 
   it('bind', function () {
@@ -101,7 +101,7 @@ describe('Util - Language Enhancement', function () {
     expect(_.isObject(null)).toBeFalsy()
     expect(_.isObject(123)).toBeFalsy()
     expect(_.isObject(true)).toBeFalsy()
-    expect(_.isObject('hi')).toBeFalsy()
+    expect(_.isObject('foo')).toBeFalsy()
     expect(_.isObject(undefined)).toBeFalsy()
     expect(_.isObject(function () {})).toBeFalsy()
   })
@@ -113,7 +113,7 @@ describe('Util - Language Enhancement', function () {
     expect(_.isPlainObject(null)).toBeFalsy()
     expect(_.isPlainObject(123)).toBeFalsy()
     expect(_.isPlainObject(true)).toBeFalsy()
-    expect(_.isPlainObject('hi')).toBeFalsy()
+    expect(_.isPlainObject('foo')).toBeFalsy()
     expect(_.isPlainObject(undefined)).toBeFalsy()
     expect(_.isPlainObject(function () {})).toBe(false)
     expect(_.isPlainObject(window)).toBe(false)

--- a/test/unit/specs/util/options_spec.js
+++ b/test/unit/specs/util/options_spec.js
@@ -140,7 +140,7 @@ describe('Util - Option merging', function () {
       components: null
     }, {
       components: {
-        test: { template: 'hi' }
+        test: { template: 'foo' }
       }
     })
     expect(typeof res.components.test).toBe('function')
@@ -152,7 +152,7 @@ describe('Util - Option merging', function () {
       components: null
     }, {
       components: {
-        a: { template: 'hi' }
+        a: { template: 'foo' }
       }
     })
     expect('Do not use built-in or reserved HTML elements as component id: a').toHaveBeenWarned()
@@ -160,7 +160,7 @@ describe('Util - Option merging', function () {
       components: null
     }, {
       components: {
-        slot: { template: 'hi' }
+        slot: { template: 'foo' }
       }
     })
     expect('Do not use built-in or reserved HTML elements as component id: slot').toHaveBeenWarned()
@@ -355,13 +355,13 @@ describe('Util - Option resolveAsset', function () {
       data: {},
       components: {
         'hyphenated-component': {
-          template: 'hi'
+          template: 'foo'
         },
         camelCasedComponent: {
-          template: 'yo'
+          template: 'bar'
         },
         PascalCasedComponent: {
-          template: 'ho'
+          template: 'baz'
         }
       }
     })


### PR DESCRIPTION
As discussed, this commit aims to make some tests a bit more serious by replacing `'hi hi ho ho'` with `'foo bar'` :)