### PR TITLE
[fix] Don't remove newlines during parseText

### DIFF
--- a/src/parsers/text.js
+++ b/src/parsers/text.js
@@ -22,8 +22,8 @@ export function compileRegex () {
   var unsafeOpen = escapeRegex(config.unsafeDelimiters[0])
   var unsafeClose = escapeRegex(config.unsafeDelimiters[1])
   tagRE = new RegExp(
-    unsafeOpen + '(.+?)' + unsafeClose + '|' +
-    open + '(.+?)' + close,
+    unsafeOpen + '([^]+?)' + unsafeClose + '|' +
+    open + '([^]+?)' + close,
     'g'
   )
   htmlRE = new RegExp(
@@ -52,7 +52,6 @@ export function parseText (text) {
   if (hit) {
     return hit
   }
-  text = text.replace(/\n/g, '')
   if (!tagRE.test(text)) {
     return null
   }

--- a/test/unit/specs/parsers/text_spec.js
+++ b/test/unit/specs/parsers/text_spec.js
@@ -49,6 +49,15 @@ var testCases = [
     expected: [
       { tag: true, value: 'value', html: false, oneTime: false }
     ]
+  },
+  // new lines preserved outside of tags
+  {
+    text: 'hello\n{{value}}\nworld',
+    expected: [
+        { value: 'hello\n' },
+        { tag: true, value: 'value', html: false, oneTime: false },
+        { value: '\nworld' }
+    ]
   }
 ]
 


### PR DESCRIPTION
Since `text` is being used as the key in `cache.get(text)` and the
cache is checked *before* newlines were removed, the cache would always
miss if the input `text` had *any* newlines.

I updated `tagRe` to match tags which contain newlines, and added an
extra test case to ensure newlines outside of tags are preserved