### PR TITLE
remove :is attribute even when component is cached (fixes #2666)

### DIFF
--- a/src/directives/internal/component.js
+++ b/src/directives/internal/component.js
@@ -56,6 +56,7 @@ export default {
       // cached, when the component is used elsewhere this attribute
       // will remain at link time.
       this.el.removeAttribute('is')
+      this.el.removeAttribute(':is')
       // remove ref, same as above
       if (this.descriptor.ref) {
         this.el.removeAttribute('v-ref:' + hyphenate(this.descriptor.ref))


### PR DESCRIPTION
Hello,

__This bug fixes #2666, a html file reproducing the bug within it's context can be found [here](https://github.com/GuillaumeLeclerc/vue-seo/blob/master/examples/hreflang.html)__ 

Since it's only one line I don't think a test is required but I'll explain why the bug occurs and why the PR fixes this.

As stated [here](https://github.com/vuejs/vue/blob/be7339b38ad5083fd0d0baaa2eb9f508b5f9ce23/src/directives/internal/component.js#L55), the compilation is cached so for all components except the first one the attributes are not removed. Users might want to use the ':is' version. In this case it's not removed from the DOM and visible.

This PR fixes the bug in my codebase.

Thank you !