### PR TITLE
use absolute exclude path in `build/webpack.test.config.js` and fix error when recursively traverse an object

### DIFF
--- a/build/webpack.test.config.js
+++ b/build/webpack.test.config.js
@@ -17,7 +17,12 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel',
-        exclude: /test\/unit|node_modules/
+        // NOTE: use absolute path to make sure
+        // running tests is OK even if it is in node_modules of other project
+        exclude: [
+          path.resolve(__dirname, '../test/unit'),
+          path.resolve(__dirname, '../node_modules')
+        ]
       }
     ]
   },

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -334,7 +334,7 @@ Watcher.prototype.teardown = function () {
 function traverse (val, walkedObjs) {
   var i, keys
 
-  !walkedObjs && (walkedObjs = {})
+  walkedObjs = walkedObjs || {}
   if (isArray(val)) {
     i = val.length
     while (i--) traverse(val[i], walkedObjs)

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -331,14 +331,25 @@ Watcher.prototype.teardown = function () {
  * @param {*} val
  */
 
-function traverse (val) {
+function traverse (val, walkedObjs) {
   var i, keys
+
+  !walkedObjs && (walkedObjs = {})
   if (isArray(val)) {
     i = val.length
-    while (i--) traverse(val[i])
+    while (i--) traverse(val[i], walkedObjs)
   } else if (isObject(val)) {
+    if (val.__ob__) {
+      var depId = val.__ob__.dep.id;
+      if (walkedObjs[depId]) {
+        return
+      } else {
+        walkedObjs[depId] = true
+      }
+    }
+
     keys = Object.keys(val)
     i = keys.length
-    while (i--) traverse(val[keys[i]])
+    while (i--) traverse(val[keys[i]], walkedObjs)
   }
 }

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -340,7 +340,7 @@ function traverse (val, walkedObjs) {
     while (i--) traverse(val[i], walkedObjs)
   } else if (isObject(val)) {
     if (val.__ob__) {
-      var depId = val.__ob__.dep.id;
+      var depId = val.__ob__.dep.id
       if (walkedObjs[depId]) {
         return
       } else {

--- a/test/unit/specs/watcher_spec.js
+++ b/test/unit/specs/watcher_spec.js
@@ -286,6 +286,23 @@ describe('Watcher', function () {
     })
   })
 
+  it('deep watch with circular references', function (done) {
+    new Watcher(vm, 'b', spy, {
+      deep: true
+    })
+    Vue.set(vm.b, '_', vm.b)
+    nextTick(function () {
+      expect(spy).toHaveBeenCalledWith(vm.b, vm.b)
+      expect(spy.calls.count()).toBe(1)
+      vm.b._.c = 1
+      nextTick(function () {
+        expect(spy).toHaveBeenCalledWith(vm.b, vm.b)
+        expect(spy.calls.count()).toBe(2)
+        done()
+      })
+    })
+  })
+
   it('fire change for prop addition/deletion in non-deep mode', function (done) {
     new Watcher(vm, 'b', spy)
     Vue.set(vm.b, 'e', 123)


### PR DESCRIPTION
* use absolute path to make sure running tests is OK even if it is in node_modules of other project
* fix 'Maximum call stack size exceeded' when recursively traverse an object