### PR TITLE
Using absolute exclude path in `build/webpack.test.config.js` 

### DIFF
--- a/build/webpack.test.config.js
+++ b/build/webpack.test.config.js
@@ -17,7 +17,12 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel',
-        exclude: /test\/unit|node_modules/
+        // NOTE: use absolute path to make sure
+        // running tests is OK even if it is in node_modules of other project
+        exclude: [
+          path.resolve(__dirname, '../test/unit'),
+          path.resolve(__dirname, '../node_modules')
+        ]
       }
     ]
   },


### PR DESCRIPTION
Changing the relative `exclude` path to absolute to make sure tests can be running OK even if Vue is in `node_modules` of other project.