### PR TITLE
Fix data functions being called twice. (fix #2687)

### DIFF
--- a/src/instance/internal/init.js
+++ b/src/instance/internal/init.js
@@ -94,11 +94,6 @@ export default function (Vue) {
     // it will be filled up in _initScope().
     this._data = {}
 
-    // save raw constructor data before merge
-    // so that we know which properties are provided at
-    // instantiation.
-    this._runtimeData = options.data
-
     // call init hook
     this._callHook('init')
 

--- a/src/instance/internal/state.js
+++ b/src/instance/internal/state.js
@@ -87,11 +87,6 @@ export default function (Vue) {
       )
     }
     var props = this._props
-    var runtimeData = this._runtimeData
-      ? typeof this._runtimeData === 'function'
-        ? this._runtimeData()
-        : this._runtimeData
-      : null
     // proxy data on instance
     var keys = Object.keys(data)
     var i, key
@@ -104,7 +99,7 @@ export default function (Vue) {
       //    template prop present
       if (
         !props || !hasOwn(props, key) ||
-        (runtimeData && hasOwn(runtimeData, key) && props[key].raw === null)
+        (data && hasOwn(data, key) && props[key].raw === null)
       ) {
         this._proxy(key)
       } else if (process.env.NODE_ENV !== 'production') {

--- a/test/unit/specs/instance/state_spec.js
+++ b/test/unit/specs/instance/state_spec.js
@@ -9,6 +9,27 @@ describe('Instance state initialization', function () {
     expect('should return an object').toHaveBeenWarned()
   })
 
+  it('should initialize data once per strat', function () {
+    var spyOncePerStrat = jasmine.createSpy('called once per strat')
+    const VM = Vue.extend({
+      data: function () {
+        spyOncePerStrat()
+        return {
+          result: 'false'
+        }
+      }
+    })
+    new VM({
+      data: function () {
+        spyOncePerStrat()
+        return {
+          result: 'true'
+        }
+      }
+    })
+    expect(spyOncePerStrat.calls.count()).toBe(2)
+  })
+
   describe('data proxy', function () {
     var data = {
       a: 0,


### PR DESCRIPTION
- Added test for checking prop to data clash
- Added test to ensure data function is only called once per strut
- Removed this._runtimeData uses 'data' for prop to data clash check

Fixes: [ISSUE-2687](https://github.com/vuejs/vue/issues/2687)