### PR TITLE
Add an option to extend a component

### DIFF
--- a/src/util/options.js
+++ b/src/util/options.js
@@ -332,6 +332,9 @@ export function mergeOptions (parent, child, vm) {
   }
   var options = {}
   var key
+  if (child.extends) {
+    parent = mergeOptions(parent, child.extends, vm)
+  }
   if (child.mixins) {
     for (var i = 0, l = child.mixins.length; i < l; i++) {
       parent = mergeOptions(parent, child.mixins[i], vm)

--- a/test/unit/specs/util/options_spec.js
+++ b/test/unit/specs/util/options_spec.js
@@ -278,6 +278,20 @@ describe('Util - Option merging', function () {
     expect(Object.getOwnPropertyDescriptor(data, 'b').get).toBeTruthy()
   })
 
+  it('extends', function () {
+    var f1 = function () {}
+    var f2 = function () {}
+    var f3 = function () {}
+    var componentA = { template: 'foo', methods: { f1: f1, f2: function () {} } }
+    var componentB = { extends: componentA, methods: { f2: f2 } }
+    var componentC = { extends: componentB, template: 'bar', methods: { f3: f3 } }
+    var res = merge({}, componentC)
+    expect(res.template).toBe('bar')
+    expect(res.methods.f1).toBe(f1)
+    expect(res.methods.f2).toBe(f2)
+    expect(res.methods.f3).toBe(f3)
+  })
+
   it('mixins', function () {
     var a = {}
     var b = {}


### PR DESCRIPTION
#### Related to: vuejs/vue-loader#207

This works as expected for the `<template>` and the `<script>`, but not for the `<style>`.
I noticed that all the `styles` are loaded, but with the wrong priority.

Maybe some changes are needed to the `vue-loader` to figure out that, right?