### PR TITLE
Vue treats `null` expression as `undefined`?

### DIFF
--- a/test/unit/specs/parsers/expression_spec.js
+++ b/test/unit/specs/parsers/expression_spec.js
@@ -219,6 +219,12 @@ var testCases = [
     paths: []
   },
   {
+    exp: 'null',
+    scope: {},
+    expected: null,
+    paths: []
+  },
+  {
     // Date global
     exp: 'Date.now() > new Date("2000-01-01")',
     scope: {},


### PR DESCRIPTION
Not sure if it's just me misunderstanding how things work, but Vue is apparently treating `null` expression as `undefined`. Here is a failed test case to demonstrate the issue. 

If this is confirmed to be a bug, I can try to work on a fix.