### PR TITLE
Fix x-template typo in select2 example

### DIFF
--- a/examples/select2/index.html
+++ b/examples/select2/index.html
@@ -18,7 +18,7 @@
     <div id="el">
     </div>
 
-    <script type="text/x-tempalte" id="demo-template">
+    <script type="text/x-template" id="demo-template">
       <div>
         <p>Selected: {{ selected }}</p>
         <select2 :options="options" v-model="selected">


### PR DESCRIPTION
This typo has no effect on the demo.