### PR TITLE
CSS fixes for "Grid" example

### DIFF
--- a/examples/grid/style.css
+++ b/examples/grid/style.css
@@ -16,7 +16,8 @@ th {
   cursor: pointer;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 td {


### PR DESCRIPTION
Because `-user-select` on its own is not a valid CSS attribute, and because we don't discriminate browsers ;)