### PR TITLE
Some improvements for "Modal" example

### DIFF
--- a/examples/modal/index.html
+++ b/examples/modal/index.html
@@ -38,13 +38,6 @@
       </div>
     </script>
 
-    <script>
-      // register modal component
-      Vue.component('modal', {
-        template: '#modal-template'
-      })
-    </script>
-
     <!-- app -->
     <div id="app">
       <button id="show-modal" @click="showModal = true">Show Modal</button>
@@ -59,6 +52,11 @@
     </div>
 
     <script>
+      // register modal component
+      Vue.component('modal', {
+        template: '#modal-template'
+      })
+
       // start app
       new Vue({
         el: '#app',

--- a/examples/modal/index.html
+++ b/examples/modal/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Vue.js Modal Example</title>
     <script src="../../dist/vue.js"></script>
-    <link rel="stylesheet" href="modal.css">
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <!-- template for the modal component -->

--- a/examples/modal/style.css
+++ b/examples/modal/style.css
@@ -40,7 +40,7 @@
 }
 
 /*
- * the following styles are auto-applied to elements with
+ * The following styles are auto-applied to elements with
  * transition="modal" when their visibility is toggled
  * by Vue.js.
  *


### PR DESCRIPTION
I've taken the liberty to:

* Rename `modal.css` into `style.css` following other examples' convention
* Merge the two `<script>` tags into one for leaner code.