### PR TITLE
Preserve cursor position when changing input from Vuex.

### DIFF
--- a/src/directives/public/bind.js
+++ b/src/directives/public/bind.js
@@ -110,11 +110,15 @@ export default {
       attrWithPropsRE.test(attr) &&
       attr in el
     ) {
-      el[attr] = attr === 'value'
+      var attrValue = attr === 'value'
         ? value == null // IE9 will set input.value to "null" for null...
           ? ''
           : value
         : value
+
+      if (el[attr] !== attrValue) {
+        el[attr] = attrValue
+      }
     }
     // set model props
     var modelProp = modelProps[attr]


### PR DESCRIPTION
Fixes https://github.com/vuejs/vuex/issues/162

textarea works different and we need to set it as before.

Same issue is also present on v2.0. @yyx990803 should I open PR for 2.0 too?