### PR TITLE
Suppress a warning 'Unknown custom element' with SSR <img> tag

### DIFF
--- a/src/platforms/web/util/element.js
+++ b/src/platforms/web/util/element.js
@@ -9,7 +9,7 @@ export const namespaceMap = {
 export const isReservedTag = makeMap(
   'html,base,head,link,meta,style,title,' +
   'address,article,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
-  'div,dd,dl,dt,figcaption,figure,hr,li,main,ol,p,pre,ul,' +
+  'div,dd,dl,dt,figcaption,figure,hr,img,li,main,ol,p,pre,ul,' +
   'a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,rtc,ruby,' +
   's,samp,small,span,strong,sub,sup,time,u,var,wbr,area,audio,map,track,video,' +
   'embed,object,param,source,canvas,script,noscript,del,ins,' +

--- a/test/ssr/ssr.sync.spec.js
+++ b/test/ssr/ssr.sync.spec.js
@@ -99,11 +99,13 @@ describe('SSR: renderToString', () => {
           <span>{{ test }}</span>
           <input :value="test">
           <test></test>
+          <img :src="imageUrl">
         </div>
       `,
       data: {
         test: 'hi',
-        isRed: true
+        isRed: true,
+        imageUrl: 'https://vuejs.org/images/logo.png'
       },
       components: {
         test: {
@@ -119,6 +121,7 @@ describe('SSR: renderToString', () => {
         '<span>hi</span>' +
         '<input value="hi">' +
         '<div class="a">hahahaha</div>' +
+        '<img src="https://vuejs.org/images/logo.png">' +
       '</div>'
     )
   })


### PR DESCRIPTION
Hi, I just tried a simple example of v2.0 SSR with \<img\> tag like below.

```js
renderToString(new Vue(compileTemplate({
  data () {
    return {
      imageUrl: 'https://vuejs.org/images/logo.png'
    }
  },
  template: `<div><img :src="imageUrl"></div>`
}
```

Then I see the following warning as an error.

```
[Vue warn]: Unknown custom element: <img> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
```

It looks \<img\> tag is just missing in reserved tags. I added it to the list and the warning disappeared.
Also, I added an \<img\> tag into an existing test just in case.