### PR TITLE
SSR no data observations

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -10,6 +10,7 @@ import {
   hasOwn,
   isReserved
 } from '../util/index'
+import Vue from '../instance/index'
 
 const arrayKeys = Object.getOwnPropertyNames(arrayMethods)
 
@@ -145,6 +146,7 @@ export function observe (value, vm) {
     ob = value.__ob__
   } else if (
     observerState.shouldConvert &&
+    !Vue.prototype.$isServerRenderer &&
     (isArray(value) || isPlainObject(value)) &&
     Object.isExtensible(value) &&
     !value._isVue

--- a/src/entries/web-server-renderer.js
+++ b/src/entries/web-server-renderer.js
@@ -1,15 +1,20 @@
-import { createRenderer } from 'server/create-renderer'
+import { createRenderer as _createRenderer } from 'server/create-renderer'
 import { isUnaryTag } from 'web/util/index'
 import modules from 'web/server/modules/index'
 import baseDirectives from 'web/server/directives/index'
+import _Vue from './web-runtime'
 
-export default function publicCreateRenderer (options = {}) {
+export function createRenderer (options = {}) {
   // user can provide server-side implementations for custom directives
   // when creating the renderer.
   const directives = Object.assign(baseDirectives, options.directives)
-  return createRenderer({
+  return _createRenderer({
     isUnaryTag,
     modules,
     directives
   })
 }
+
+export const Vue = _Vue
+
+_Vue.prototype.$isServerRenderer = true

--- a/test/ssr/jasmine.json
+++ b/test/ssr/jasmine.json
@@ -1,6 +1,7 @@
 {
   "spec_dir": "test/ssr",
   "spec_files": [
+    "ssr.vue.spec.js",
     "ssr.string.spec.js",
     "ssr.stream.spec.js"
   ],

--- a/test/ssr/ssr.stream.spec.js
+++ b/test/ssr/ssr.stream.spec.js
@@ -1,6 +1,5 @@
-import Vue from '../../dist/vue.common.js'
 import { compileToFunctions } from '../../dist/compiler.js'
-import createRenderer from '../../dist/server-renderer.js'
+import { createRenderer, Vue } from '../../dist/server-renderer.js'
 const { renderToStream } = createRenderer()
 
 describe('SSR: renderToStream', () => {

--- a/test/ssr/ssr.string.spec.js
+++ b/test/ssr/ssr.string.spec.js
@@ -1,6 +1,5 @@
-import Vue from '../../dist/vue.common.js'
 import { compileToFunctions } from '../../dist/compiler.js'
-import createRenderer from '../../dist/server-renderer.js'
+import { createRenderer, Vue } from '../../dist/server-renderer.js'
 const { renderToString } = createRenderer()
 
 // TODO: test custom server-side directives

--- a/test/ssr/ssr.vue.spec.js
+++ b/test/ssr/ssr.vue.spec.js
@@ -1,0 +1,36 @@
+import { Vue } from '../../dist/server-renderer.js'
+
+// TODO: test custom server-side directives
+
+describe('SSR: Vue', () => {
+  it('$isServerRenderer on Vue prototype', () => {
+    const vm = new Vue({
+      data: {
+        foo: 'server',
+        bar: 'rendering'
+      }
+    })
+    expect(Vue.prototype.$isServerRenderer).toBe(true)
+    expect(vm.$isServerRenderer).toBe(true)
+  })
+
+  it('no data observations', () => {
+    const vm = new Vue({
+      data: {
+        foo: 'server',
+        bar: 'rendering'
+      },
+      computed: {
+        combined () {
+          return this.foo + this.bar
+        }
+      }
+    })
+
+    vm.foo = ''
+
+    expect(vm.foo).toBe('')
+    expect(vm.combined).toBe('rendering')
+    expect(vm.__ob__).toBe(undefined)
+  })
+})


### PR DESCRIPTION
- `$isServerRenderer` added to Vue prototype
- Turn off data observations with `$isServerRenderer`
- `server-renderer` exports Vue runtime without compiler for convenience
- Updated SSR test imports
- Added test coverage for data observation