### PR TITLE
[next][advice]new render mechanism

### DIFF
--- a/src/compiler/codegen.js
+++ b/src/compiler/codegen.js
@@ -23,7 +23,7 @@ export function generate (ast, options) {
   warn = options.warn || baseWarn
   platformDirectives = options.directives || {}
   isPlatformReservedTag = options.isReservedTag || (() => false)
-  const code = ast ? genElement(ast) : '__h__("div")'
+  const code = ast ? genElement(ast) : '__r__(__s__("div"))'
   staticRenderFns = prevStaticRenderFns
   return {
     render: `with (this) { return ${code}}`,
@@ -51,11 +51,11 @@ function genElement (el) {
       ? 'undefined'
       : genChildren(el, !isPlatformReservedTag(el.tag) /* asThunk */)
     const namespace = el.ns ? `,'${el.ns}'` : ''
-    const code = `__h__('${el.tag}', ${genData(el)}, ${children}${namespace})`
+    const code = `__r__(__s__('${el.tag}', ${genData(el)}${namespace}), ${children})`
     if (el.staticRoot) {
       // hoist static sub-trees out
       staticRenderFns.push(`with(this){return ${code}}`)
-      return `_staticTrees[${staticRenderFns.length - 1}]`
+      return `__m__(${staticRenderFns.length - 1})`
     } else {
       return code
     }
@@ -118,6 +118,9 @@ function genData (el) {
     data += `class:${el.classBinding},`
   }
   // style
+  if (el.staticStyle) {
+    data += `staticStyle:${el.staticStyle},`
+  }
   if (el.styleBinding) {
     data += `style:${el.styleBinding},`
   }
@@ -218,7 +221,7 @@ function genNode (node) {
 function genText (text) {
   return text.expression
     ? `(${text.expression})`
-    : JSON.stringify(text.text)
+    : '__t__(' + JSON.stringify(text.text) + ')'
 }
 
 function genRender (el) {
@@ -231,7 +234,7 @@ function genSlot (el) {
 }
 
 function genComponent (el) {
-  return `__h__(${el.component}, ${genData(el)}, ${genChildren(el, true)})`
+  return `__r__(__s__(${el.component}, ${genData(el)}), ${genChildren(el, true)})`
 }
 
 function genProps (props) {

--- a/src/compiler/codegen.js
+++ b/src/compiler/codegen.js
@@ -1,10 +1,12 @@
 import { genHandlers } from './events'
 import { ref } from './directives/ref'
+import { atom } from './directives/atom'
 import { baseWarn } from './helpers'
 import { noop } from 'shared/util'
 
 const baseDirectives = {
   ref,
+  atom,
   cloak: noop
 }
 
@@ -97,6 +99,10 @@ function genData (el) {
   if (el.directives) {
     const dirs = genDirectives(el)
     if (dirs) data += dirs + ','
+  }
+  // atom
+  if (el.atom) {
+    data += 'atom:true,'
   }
   // pre
   if (el.pre) {

--- a/src/compiler/directives/atom.js
+++ b/src/compiler/directives/atom.js
@@ -1,0 +1,3 @@
+export function atom (el) {
+  el.atom = true
+}

--- a/src/compiler/optimizer.js
+++ b/src/compiler/optimizer.js
@@ -48,7 +48,7 @@ function markStaticRoots (node) {
 
 const isStaticKey = makeMap(
   'tag,attrsList,attrsMap,plain,parent,children,' +
-  'staticAttrs,staticClass'
+  'staticAttrs,staticStyle,staticClass'
 )
 
 function isStatic (node) {

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -43,6 +43,7 @@ export function lifecycleMixin (Vue) {
     callHook(this, 'beforeMount')
     this._isStream = this.$options.stream
     this._currentVNode = this._currentVNode || { elm: this.$el.parentNode }
+    this._currentVNodeHistory = []
     this._watcher = new Watcher(this, this._render, this._update)
     if (this._isStream) {
       this._updateFirst(this._watcher.value)

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -41,11 +41,17 @@ export function lifecycleMixin (Vue) {
       }
     }
     callHook(this, 'beforeMount')
-    this._firstRendering = true
-    this._lastParent = { elm: this.$el.parentNode }
+    const isStream = this.$options.stream
+    this._firstRendering = isStream
+    this._currentVNode = this._currentVNode || { elm: this.$el.parentNode }
     this._watcher = new Watcher(this, this._render, this._update)
-    this._updateFirst(this._watcher.value)
+    if (isStream) {
+      this._updateFirst(this._watcher.value)
+    } else {
+      this._update(this._watcher.value)
+    }
     this._firstRendering = false
+    this.$options.stream = false
     this._mounted = true
     // root instance, call mounted on self
     if (this.$root === this) {

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -42,7 +42,10 @@ export function lifecycleMixin (Vue) {
     }
     callHook(this, 'beforeMount')
     this._isStream = this.$options.stream
-    this._currentVNode = this._currentVNode || { elm: this.$el.parentNode }
+    this._currentVNode = this._currentVNode
+    if (!this._currentVNode && this.$el && this.$el.parentNode) {
+      this._currentVNode = { elm: this.$el.parentNode }
+    }
     this._currentVNodeHistory = []
     this._watcher = new Watcher(this, this._render, this._update)
     if (this._isStream) {

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -41,17 +41,15 @@ export function lifecycleMixin (Vue) {
       }
     }
     callHook(this, 'beforeMount')
-    const isStream = this.$options.stream
-    this._firstRendering = isStream
+    this._isStream = this.$options.stream
     this._currentVNode = this._currentVNode || { elm: this.$el.parentNode }
     this._watcher = new Watcher(this, this._render, this._update)
-    if (isStream) {
+    if (this._isStream) {
       this._updateFirst(this._watcher.value)
     } else {
       this._update(this._watcher.value)
     }
-    this._firstRendering = false
-    this.$options.stream = false
+    this._isStream = false
     this._mounted = true
     // root instance, call mounted on self
     if (this.$root === this) {

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -41,14 +41,33 @@ export function lifecycleMixin (Vue) {
       }
     }
     callHook(this, 'beforeMount')
+    this._firstRendering = true
+    this._lastParent = { elm: this.$el.parentNode }
     this._watcher = new Watcher(this, this._render, this._update)
-    this._update(this._watcher.value)
+    this._updateFirst(this._watcher.value)
+    this._firstRendering = false
     this._mounted = true
     // root instance, call mounted on self
     if (this.$root === this) {
       callHook(this, 'mounted')
     }
     return this
+  }
+
+  Vue.prototype._updateFirst = function (vnode) {
+    if (this._mounted) {
+      callHook(this, 'beforeUpdate')
+    }
+    const parentNode = this.$options._parentVnode
+    vnode.parent = parentNode
+    this._vnode = vnode
+    // set parent vnode element after patch
+    if (parentNode) {
+      parentNode.elm = this.$el
+    }
+    if (this._mounted) {
+      callHook(this, 'updated')
+    }
   }
 
   Vue.prototype._update = function (vnode) {

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -1,5 +1,5 @@
 import config from '../config'
-import { createElement, renderElement, renderSelf } from '../vdom/create-element'
+import { createElement, renderElement, renderSelf, renderText, renderStatic } from '../vdom/create-element'
 import { emptyVNode } from '../vdom/vnode'
 import { flatten } from '../vdom/helpers'
 import { bind, isArray, isObject, renderString } from 'shared/util'
@@ -58,6 +58,8 @@ export function renderMixin (Vue) {
   Vue.prototype.__h__ = createElement
   Vue.prototype.__r__ = renderElement
   Vue.prototype.__s__ = renderSelf
+  Vue.prototype.__t__ = renderText
+  Vue.prototype.__m__ = renderStatic
 
   // toString for mustaches
   Vue.prototype.__toString__ = renderString

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -1,5 +1,5 @@
 import config from '../config'
-import createElement from '../vdom/create-element'
+import { createElement, renderElement, renderSelf } from '../vdom/create-element'
 import { emptyVNode } from '../vdom/vnode'
 import { flatten } from '../vdom/helpers'
 import { bind, isArray, isObject, renderString } from 'shared/util'
@@ -56,6 +56,8 @@ export function renderMixin (Vue) {
 
   // shorthands used in render functions
   Vue.prototype.__h__ = createElement
+  Vue.prototype.__r__ = renderElement
+  Vue.prototype.__s__ = renderSelf
 
   // toString for mustaches
   Vue.prototype.__toString__ = renderString

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -89,8 +89,9 @@ export function createComponentInstanceForVnode (vnode) {
 }
 
 function init (vnode) {
+  const parent = vnode.componentOptions.parent
   const child = vnode.child = createComponentInstanceForVnode(vnode)
-  child._currentVNode = parent._currentVNode
+  child._currentVNode = parent && parent._currentVNode
   child._append = vnode.data && vnode.data.append
   child.$mount(vnode.elm)
 }

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -92,7 +92,7 @@ function init (vnode) {
   const parent = vnode.componentOptions.parent
   const child = vnode.child = createComponentInstanceForVnode(vnode)
   child._currentVNode = parent && parent._currentVNode
-  child._append = vnode.data && vnode.data.append
+  child._atom = vnode.data && vnode.data.atom
   child.$mount(vnode.elm)
 }
 

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -91,6 +91,7 @@ export function createComponentInstanceForVnode (vnode) {
 function init (vnode) {
   const child = vnode.child = createComponentInstanceForVnode(vnode)
   child._currentVNode = parent._currentVNode
+  child._append = vnode.data && vnode.data.append
   child.$mount(vnode.elm)
 }
 

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -90,7 +90,8 @@ export function createComponentInstanceForVnode (vnode) {
 
 function init (vnode) {
   const child = vnode.child = createComponentInstanceForVnode(vnode)
-  child.$mount()
+  child._currentVNode = parent._currentVNode
+  child.$mount(vnode.elm)
 }
 
 function prepatch (oldVnode, vnode) {

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -47,7 +47,7 @@ export function createElement (tag, data, children, namespace) {
 
 export function renderElement (vnode, children) {
   if (vnode.component) {
-    const component = createComponent(vnode.Ctor, vnode.data, vnode.parent, vnode.children, vnode.context)
+    const component = createComponent(vnode.Ctor, vnode.data, vnode.parent, children, vnode.context)
     if (this._isStream) {
       this.__stream_patch__(component)
     }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -59,7 +59,7 @@ export function renderElement (vnode, children) {
   vnode.setChildren(flatten(children))
   revertCurrentVNode(this)
   if (this._isStream) {
-    if (vnode.data && vnode.data.append) {
+    if (vnode.data && vnode.data.atom) {
       this.__tree_patch__(vnode)
     }
   }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -55,6 +55,11 @@ export function renderElement (vnode, children) {
   }
   vnode.setChildren(flatten(children))
   revertCurrentVNode(this)
+  if (this._isStream) {
+    if (vnode.data && vnode.data.append) {
+      this.__tree_patch__(vnode)
+    }
+  }
   return vnode
 }
 
@@ -104,14 +109,14 @@ function createSelfVNode (tag, data, text, namespace, context) {
 function setCurrentVNode (vnode, context) {
   if (context._isStream) {
     context.__stream_patch__(vnode)
-    context._lastVNode = context._currentVNode
+    context._currentVNodeHistory.push(context._currentVNode)
     context._currentVNode = vnode
   }
 }
 
 function revertCurrentVNode(context) {
   if (context._isStream) {
-    context._currentVNode = context._lastVNode
-    context._lastVNode = undefined
+    const temp = context._currentVNode
+    context._currentVNode = context._currentVNodeHistory.pop()
   }
 }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -114,9 +114,8 @@ function setCurrentVNode (vnode, context) {
   }
 }
 
-function revertCurrentVNode(context) {
+function revertCurrentVNode (context) {
   if (context._isStream) {
-    const temp = context._currentVNode
     context._currentVNode = context._currentVNodeHistory.pop()
   }
 }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -53,6 +53,9 @@ export function renderElement (vnode, children) {
     }
     return component
   }
+  if (typeof children === 'function') {
+    children = children() // why children is a function for unknown element?
+  }
   vnode.setChildren(flatten(children))
   revertCurrentVNode(this)
   if (this._isStream) {

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -54,10 +54,7 @@ export function renderElement (vnode, children) {
     return component
   }
   vnode.setChildren(flatten(children))
-  if (this._isStream) {
-    this._currentVNode = this._lastVNode
-    this._lastVNode = undefined
-  }
+  revertCurrentVNode(this)
   return vnode
 }
 
@@ -88,6 +85,7 @@ export function renderSelf (tag, data, namespace) {
 
 export function renderText (str) {
   createSelfVNode(undefined, undefined, str, undefined, this)
+  revertCurrentVNode(this)
   return str
 }
 
@@ -108,5 +106,12 @@ function setCurrentVNode (vnode, context) {
     context.__stream_patch__(vnode)
     context._lastVNode = context._currentVNode
     context._currentVNode = vnode
+  }
+}
+
+function revertCurrentVNode(context) {
+  if (context._isStream) {
+    context._currentVNode = context._lastVNode
+    context._lastVNode = undefined
   }
 }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -5,7 +5,7 @@ import { flatten } from './helpers'
 import { renderState } from '../instance/render'
 import { warn, resolveAsset } from '../util/index'
 
-export default function createElement (tag, data, children, namespace) {
+export function createElement (tag, data, children, namespace) {
   const context = this
   const parent = renderState.activeInstance
   if (!tag) {
@@ -15,10 +15,12 @@ export default function createElement (tag, data, children, namespace) {
   if (typeof tag === 'string') {
     let Ctor
     if (config.isReservedTag(tag)) {
-      return VNode(
-        tag, data, flatten(children),
+      const vnode = VNode(
+        tag, data, null,
         undefined, undefined, namespace, context
       )
+      vnode.setChildren(flatten(children))
+      return vnode
     } else if ((Ctor = resolveAsset(context.$options, 'components', tag))) {
       return createComponent(Ctor, data, parent, children, context)
     } else {
@@ -31,12 +33,67 @@ export default function createElement (tag, data, children, namespace) {
           )
         }
       }
-      return VNode(
-        tag, data, flatten(children && children()),
+      const vnode = VNode(
+        tag, data, null,
         undefined, undefined, namespace, context
       )
+      vnode.setChildren(flatten(children && children()))
+      return vnode
     }
   } else {
     return createComponent(tag, data, parent, children, context)
+  }
+}
+
+export function renderElement (vnode, children) {
+  if (vnode.component) {
+    return createComponent(vnode.Ctor, vnode.data, vnode.parent, vnode.children, vnode.context)
+  }
+  vnode.setChildren(flatten(children))
+  if (this._firstRendering) {
+    this._lastParent = vnode
+  }
+  return vnode
+}
+
+export function renderSelf (tag, data, namespace) {
+  const context = this
+  const parent = renderState.activeInstance
+  if (typeof tag === 'string') {
+    let Ctor
+    if (config.isReservedTag(tag)) {
+      const vnode = VNode(
+        tag, data, null,
+        undefined, undefined, namespace, context
+      )
+      if (this._firstRendering) {
+        this.__first_patch__(vnode)
+        this._lastParent = vnode
+      }
+      return vnode
+    } else if ((Ctor = resolveAsset(context.$options, 'components', tag))) {
+      return { Ctor, data, parent, context, component: true }
+    } else {
+      if (process.env.NODE_ENV !== 'production') {
+        if (!namespace && config.isUnknownElement(tag)) {
+          warn(
+            'Unknown custom element: <' + tag + '> - did you ' +
+            'register the component correctly? For recursive components, ' +
+            'make sure to provide the "name" option.'
+          )
+        }
+      }
+      const vnode = VNode(
+        tag, data, null,
+        undefined, undefined, namespace, context
+      )
+      if (this._firstRendering) {
+        this.__first_patch__(vnode)
+        this._lastParent = vnode
+      }
+      return vnode
+    }
+  } else {
+    return { tag, data, parent, context, component: true }
   }
 }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -47,11 +47,16 @@ export function createElement (tag, data, children, namespace) {
 
 export function renderElement (vnode, children) {
   if (vnode.component) {
-    return createComponent(vnode.Ctor, vnode.data, vnode.parent, vnode.children, vnode.context)
+    const component = createComponent(vnode.Ctor, vnode.data, vnode.parent, vnode.children, vnode.context)
+    if (this._firstRendering) {
+      this.__first_patch__(component)
+    }
+    return component
   }
   vnode.setChildren(flatten(children))
   if (this._firstRendering) {
-    this._lastParent = vnode
+    this._currentVNode = this._lastVNode
+    this._lastVNode = undefined
   }
   return vnode
 }
@@ -68,7 +73,8 @@ export function renderSelf (tag, data, namespace) {
       )
       if (this._firstRendering) {
         this.__first_patch__(vnode)
-        this._lastParent = vnode
+        this._lastVNode = this._currentVNode
+        this._currentVNode = vnode
       }
       return vnode
     } else if ((Ctor = resolveAsset(context.$options, 'components', tag))) {
@@ -89,11 +95,35 @@ export function renderSelf (tag, data, namespace) {
       )
       if (this._firstRendering) {
         this.__first_patch__(vnode)
-        this._lastParent = vnode
+        this._currentVNode = vnode
       }
       return vnode
     }
   } else {
     return { tag, data, parent, context, component: true }
   }
+}
+
+export function renderText (str) {
+  const context = this
+  const vnode = VNode(
+    undefined, undefined, undefined,
+    str, undefined, undefined, context
+  )
+  if (context._firstRendering) {
+    context.__first_patch__(vnode)
+    this._lastVNode = this._currentVNode
+    this._currentVNode = vnode
+  }
+  return str
+}
+
+export function renderStatic (index) {
+  const vnode = this._staticTrees[index]
+  if (this._firstRendering) {
+    this.__first_patch__(vnode)
+    this._lastVNode = this._currentVNode
+    this._currentVNode = vnode
+  }
+  return vnode
 }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -65,6 +65,10 @@ export function renderElement (vnode, children) {
 
 export function renderSelf (tag, data, namespace) {
   const parent = renderState.activeInstance
+  if (!tag) {
+    // in case of component :is set to falsy value
+    return emptyVNode
+  }
   if (typeof tag === 'string') {
     let Ctor
     if (config.isReservedTag(tag)) {
@@ -84,7 +88,7 @@ export function renderSelf (tag, data, namespace) {
       return createSelfVNode(tag, data, undefined, namespace, this)
     }
   } else {
-    return { tag, data, parent, context: this, component: true }
+    return { Ctor: tag, data, parent, context: this, component: true }
   }
 }
 

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -385,7 +385,7 @@ export function createPatchFunction (backend) {
     return vnode.elm
   }
 
-  function firstPatch (vnode) {
+  function streamPatch (vnode) {
     var insertedVnodeQueue = []
     var currentVNode = this._currentVNode
     createElm(vnode, insertedVnodeQueue)
@@ -396,5 +396,5 @@ export function createPatchFunction (backend) {
     return vnode.elm
   }
 
-  return { patch, firstPatch }
+  return { patch, streamPatch }
 }

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -397,6 +397,9 @@ export function createPatchFunction (backend) {
     if (!vnode.data || !vnode.data.append && vnode.elm) {
       nodeOps.appendChild(currentVNode.elm, vnode.elm)
     }
+    if (!this.$el) {
+      this.$el = vnode.elm
+    }
     return vnode.elm
   }
 

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -390,11 +390,11 @@ export function createPatchFunction (backend) {
     var currentVNode = this._currentVNode
     createElm(vnode, insertedVnodeQueue)
     invokeInsertHook(insertedVnodeQueue)
-    if (!this._currentVNodeHistory.length && this._append) {
+    if (!this._currentVNodeHistory.length && this._atom) {
       vnode.data = vnode.data || {}
-      vnode.data.append = true
+      vnode.data.atom = true
     }
-    if (!vnode.data || !vnode.data.append && vnode.elm) {
+    if (!vnode.data || !vnode.data.atom && vnode.elm) {
       nodeOps.appendChild(currentVNode.elm, vnode.elm)
     }
     if (!this.$el) {

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -390,11 +390,23 @@ export function createPatchFunction (backend) {
     var currentVNode = this._currentVNode
     createElm(vnode, insertedVnodeQueue)
     invokeInsertHook(insertedVnodeQueue)
+    if (!this._currentVNodeHistory.length && this._append) {
+      vnode.data = vnode.data || {}
+      vnode.data.append = true
+    }
+    if (!vnode.data || !vnode.data.append && vnode.elm) {
+      nodeOps.appendChild(currentVNode.elm, vnode.elm)
+    }
+    return vnode.elm
+  }
+
+  function treePatch (vnode) {
+    var currentVNode = this._currentVNode
     if (vnode.elm) {
       nodeOps.appendChild(currentVNode.elm, vnode.elm)
     }
     return vnode.elm
   }
 
-  return { patch, streamPatch }
+  return { patch, streamPatch, treePatch }
 }

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -337,7 +337,7 @@ export function createPatchFunction (backend) {
     }
   }
 
-  return function patch (oldVnode, vnode) {
+  function patch (oldVnode, vnode) {
     let elm, parent
     const insertedVnodeQueue = []
 
@@ -384,4 +384,15 @@ export function createPatchFunction (backend) {
     invokeInsertHook(insertedVnodeQueue)
     return vnode.elm
   }
+
+  function firstPatch (vnode) {
+    var insertedVnodeQueue = []
+    var lastParent = this._lastParent
+    createElm(vnode, insertedVnodeQueue)
+    invokeInsertHook(insertedVnodeQueue)
+    nodeOps.appendChild(lastParent.elm, vnode.elm)
+    return vnode.elm
+  }
+
+  return { patch, firstPatch }
 }

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -387,10 +387,12 @@ export function createPatchFunction (backend) {
 
   function firstPatch (vnode) {
     var insertedVnodeQueue = []
-    var lastParent = this._lastParent
+    var currentVNode = this._currentVNode
     createElm(vnode, insertedVnodeQueue)
     invokeInsertHook(insertedVnodeQueue)
-    nodeOps.appendChild(lastParent.elm, vnode.elm)
+    if (vnode.elm) {
+      nodeOps.appendChild(currentVNode.elm, vnode.elm)
+    }
     return vnode.elm
   }
 

--- a/src/core/vdom/vnode.js
+++ b/src/core/vdom/vnode.js
@@ -7,8 +7,13 @@ export default function VNode (tag, data, children, text, elm, ns, context) {
     elm,
     ns,
     context,
-    key: data && data.key
+    key: data && data.key,
+    setChildren
   }
 }
 
 export const emptyVNode = VNode(undefined, undefined, undefined, '')
+
+function setChildren (children) {
+  this.children = children
+}

--- a/src/entries/web-runtime.js
+++ b/src/entries/web-runtime.js
@@ -17,9 +17,10 @@ Vue.options.directives = platformDirectives
 
 // install platform patch function
 const modules = baseModules.concat(platformModules)
-Vue.prototype.__patch__ = config._isServer
-  ? noop
-  : createPatchFunction({ nodeOps, modules })
+const patch = createPatchFunction({ nodeOps, modules })
+Vue.prototype.__patch__ = config._isServer ? noop : patch.patch
+Vue.prototype.__stream_patch__ = config._isServer ? noop : patch.streamPatch
+Vue.prototype.__tree_patch__ = config._isServer ? noop : patch.treePatch
 
 // wrap mount
 Vue.prototype.$mount = function (el) {

--- a/src/platforms/web/runtime/modules/class.js
+++ b/src/platforms/web/runtime/modules/class.js
@@ -1,5 +1,5 @@
 import { setClass } from '../class-util'
-import { genClassForVnode, concat, stringifyClass } from 'web/util/index'
+import { genClassForVnode, concat } from 'web/util/index'
 
 function updateClass (oldVnode, vnode) {
   const el = vnode.elm
@@ -13,7 +13,7 @@ function updateClass (oldVnode, vnode) {
   // handle transition classes
   const transitionClass = el._transitionClasses
   if (transitionClass) {
-    cls = concat(cls, stringifyClass(transitionClass))
+    cls = concat(cls, transitionClass)
   }
 
   // set the class

--- a/src/platforms/web/runtime/modules/style.js
+++ b/src/platforms/web/runtime/modules/style.js
@@ -18,6 +18,18 @@ const normalize = cached(function (prop) {
   }
 })
 
+function createStyle (oldVnode, vnode) {
+  if (!vnode.data.style) {
+    return
+  }
+  const elm = vnode.elm
+  const staticStyle = vnode.data.staticStyle
+  for (const name in staticStyle) {
+    elm.style[normalize(name)] = staticStyle[name]
+  }
+  updateStyle(oldVnode, vnode)
+}
+
 function updateStyle (oldVnode, vnode) {
   if (!oldVnode.data.style && !vnode.data.style) {
     return
@@ -56,6 +68,6 @@ function toObject (arr) {
 }
 
 export default {
-  create: updateStyle,
+  create: createStyle,
   update: updateStyle
 }

--- a/src/platforms/web/util/class.js
+++ b/src/platforms/web/util/class.js
@@ -41,14 +41,14 @@ export function resolveClass (value) {
     return value.split(' ')
   }
   if (isArray(value)) {
-    let res = []
+    const res = []
     for (let i = 0, l = value.length; i < l; i++) {
       if (value[i]) res.concat(resolveClass(value[i]))
     }
     return res
   }
   if (isObject(value)) {
-    let res = []
+    const res = []
     for (const key in value) {
       if (value[key]) res.push(key)
     }

--- a/src/platforms/web/util/class.js
+++ b/src/platforms/web/util/class.js
@@ -25,33 +25,33 @@ function genClassFromData (data) {
   const dynamicClass = data.class
   const staticClass = data.staticClass
   if (staticClass || dynamicClass) {
-    return concat(staticClass, stringifyClass(dynamicClass))
+    return concat(staticClass, resolveClass(dynamicClass))
   }
 }
 
 export function concat (a, b) {
-  return a ? b ? (a + ' ' + b) : a : (b || '')
+  return a ? b ? a.concat(b) : a : (b || [])
 }
 
-export function stringifyClass (value) {
+export function resolveClass (value) {
   if (!value) {
-    return ''
+    return []
   }
   if (typeof value === 'string') {
-    return value
+    return value.split(' ')
   }
   if (isArray(value)) {
-    let res = ''
+    let res = []
     for (let i = 0, l = value.length; i < l; i++) {
-      if (value[i]) res += stringifyClass(value[i]) + ' '
+      if (value[i]) res.concat(resolveClass(value[i]))
     }
-    return res.slice(0, -1)
+    return res
   }
   if (isObject(value)) {
-    let res = ''
+    let res = []
     for (const key in value) {
-      if (value[key]) res += key + ' '
+      if (value[key]) res.push(key)
     }
-    return res.slice(0, -1)
+    return res
   }
 }


### PR DESCRIPTION
In web the best practise of first time rendering is just append the whole dom tree once into the body. But in some other virtual dom situation like mobile web or native app, the first time rendering is not as fast as users' expectation. So I tried to make "a little" change to implement "stream rendering" to optimize the first-screen perf. And let it be able to append the whole dom tree either once or node-by-node:

1. changed `__h__(tag, data, children)` into `__r__(__s__(tag, data), children)` so the parent node could be calculate->generate->append first and the children later.
2. supported `stream: true` option and added a new `__stream_patch__` method besides `__patch__` to optimize the first-time rendering logic. If no `stream: true` option set, just render as normal before.
3. supported `atom: true` in `vnode.data` to describe whether this node will be appended with its children together as a atom or child-by-child in "stream rendering" mode.

Additionally, I changed the `class`/`staticClass` from string to array and added an object `staticStyle` for better virtual dom control.