### PR TITLE
Add support for v-bind:content shorthand (fixes #2843)

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -14,7 +14,8 @@ import {
   checkComponentAttr,
   findRef,
   defineReactive,
-  getAttr
+  getAttr,
+  camelize
 } from '../util/index'
 
 // special binding prefixes
@@ -716,6 +717,11 @@ function compileDirectives (attrs, options) {
         pushDir(dirName, internalDirectives[dirName])
       } else {
         arg = dirName
+        // support for shorthand expression (#2843)
+        // <div v-bind:content> => <div v-bind:content="content">
+        if (!value) {
+          value = camelize(dirName)
+        }
         pushDir('bind', publicDirectives.bind)
       }
     } else

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -112,6 +112,8 @@ describe('Compile', function () {
     el.setAttribute(':class', 'a')
     el.setAttribute(':style', 'b')
     el.setAttribute(':title', 'c')
+    el.setAttribute(':content', '')
+    el.setAttribute(':data-content', '')
 
     // The order of setAttribute is not guaranteed to be the same with
     // the order of attribute enumberation, therefore we need to save
@@ -135,6 +137,20 @@ describe('Compile', function () {
         expression: 'c',
         arg: 'title',
         def: publicDirectives.bind
+      },
+      ':content': {
+        name: 'bind',
+        attr: ':content',
+        expression: 'content',
+        arg: 'content',
+        def: publicDirectives.bind
+      },
+      ':data-content': {
+        name: 'bind',
+        attr: ':data-content',
+        expression: 'dataContent',
+        arg: 'data-content',
+        def: publicDirectives.bind
       }
     }
     var expects = [].map.call(el.attributes, function (attr) {
@@ -143,7 +159,7 @@ describe('Compile', function () {
 
     var linker = compile(el, Vue.options)
     linker(vm, el)
-    expect(vm._bindDir.calls.count()).toBe(3)
+    expect(vm._bindDir.calls.count()).toBe(5)
 
     expects.forEach(function (e, i) {
       var args = vm._bindDir.calls.argsFor(i)


### PR DESCRIPTION
I personally quite like the feature request #2843, so I went ahead and try to support it. 

With this commit, `v-bind` with an empty expression will imply the expression to be the directive name, i.e. `v-bind :content` will have the same effect as `v-bind:content="content"`, `:href` will have the same effect as `:href="href"` and so on so forth. Note that only attribute bindings are affected by this change. Event, transition, class/style bindings etc. remain untouched. 

Not sure if I'm missing anything here – all unit tests passed fine, though. Let me know if there's anything to fix or improve, or just close this PR if you don't intend to support the feature.