### PR TITLE
extract style/class/transition as web platform compiler modules

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -12,7 +12,7 @@ declare type CompilerOptions = {
 }
 
 declare type ModuleOptions = {
-  staticKeys: Array<string>,
+  staticKeys?: Array<string>,
   parse: Function,
   genData: Function
 }

--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -2,12 +2,19 @@ declare type CompilerOptions = {
   warn?: Function,
   expectHTML?: boolean,
   preserveWhitespace?: boolean,
+  modules?: Array<ModuleOptions>,
   directives?: { [key: string]: Function },
   isUnaryTag?: (tag: string) => ?boolean,
   isReservedTag?: (tag: string) => ?boolean,
   mustUseProp?: (attr: string) => ?boolean,
   getTagNamespace?: (tag: string) => ?string,
   delimiters?: [string, string]
+}
+
+declare type ModuleOptions = {
+  staticKeys: Array<string>,
+  parse: Function,
+  genData: Function
 }
 
 declare type ASTElementHandler = {

--- a/src/compiler/codegen.js
+++ b/src/compiler/codegen.js
@@ -121,7 +121,7 @@ function genData (el: ASTElement): string {
   }
   // platform modules
   platformModules.forEach(module => {
-    data = module.genData(el, data)
+    data += module.genData(el) || ''
   })
   // v-show, used to avoid transition being applied
   // since v-show takes it over

--- a/src/compiler/codegen.js
+++ b/src/compiler/codegen.js
@@ -12,6 +12,7 @@ const baseDirectives = {
 
 // configurable state
 let warn
+let platformModules
 let platformDirectives
 let isPlatformReservedTag
 let staticRenderFns
@@ -29,6 +30,7 @@ export function generate (
   const currentStaticRenderFns: Array<string> = staticRenderFns = []
   currentOptions = options
   warn = options.warn || baseWarn
+  platformModules = options.modules || []
   platformDirectives = options.directives || {}
   isPlatformReservedTag = options.isReservedTag || (() => false)
   const code = ast ? genElement(ast) : '__r__(__s__("div"))'
@@ -117,21 +119,10 @@ function genData (el: ASTElement): string {
   if (el.slotTarget) {
     data += `slot:${el.slotTarget},`
   }
-  // class
-  if (el.staticClass) {
-    data += `staticClass:${el.staticClass},`
-  }
-  if (el.classBinding) {
-    data += `class:${el.classBinding},`
-  }
-  // style
-  if (el.styleBinding) {
-    data += `style:${el.styleBinding},`
-  }
-  // transition
-  if (el.transition) {
-    data += `transition:{definition:(${el.transition}),appear:${el.transitionOnAppear}},`
-  }
+  // platform modules
+  platformModules.forEach(module => {
+    module.genData(el, data)
+  })
   // v-show, used to avoid transition being applied
   // since v-show takes it over
   if (el.attrsMap['v-show']) {

--- a/src/compiler/codegen.js
+++ b/src/compiler/codegen.js
@@ -121,7 +121,7 @@ function genData (el: ASTElement): string {
   }
   // platform modules
   platformModules.forEach(module => {
-    module.genData(el, data)
+    data = module.genData(el, data)
   })
   // v-show, used to avoid transition being applied
   // since v-show takes it over

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -30,6 +30,7 @@ const decodeHTMLCached = cached(decodeHTML)
 let warn
 let platformGetTagNamespace
 let platformMustUseProp
+let platformModules
 let delimiters
 
 /**
@@ -42,6 +43,7 @@ export function parse (
   warn = options.warn || baseWarn
   platformGetTagNamespace = options.getTagNamespace || (_ => null)
   platformMustUseProp = options.mustUseProp || (_ => false)
+  platformModules = options.modules || []
   delimiters = options.delimiters
   const stack = []
   let root
@@ -106,9 +108,9 @@ export function parse (
         processRender(element)
         processSlot(element)
         processComponent(element)
-        processClassBinding(element)
-        processStyleBinding(element)
-        processTransition(element)
+        platformModules.forEach(module => {
+          module.parse(element, options)
+        })
         processAttrs(element)
       }
 
@@ -288,43 +290,6 @@ function processComponent (el) {
   }
   if (getAndRemoveAttr(el, 'inline-template') != null) {
     el.inlineTemplate = true
-  }
-}
-
-function processClassBinding (el) {
-  const staticClass = getAndRemoveAttr(el, 'class')
-  if (process.env.NODE_ENV !== 'production' && staticClass) {
-    const expression = parseText(staticClass, delimiters)
-    if (expression) {
-      warn(
-        `class="${staticClass}": ` +
-        'Interpolation inside attributes has been deprecated. ' +
-        'Use v-bind or the colon shorthand instead.'
-      )
-    }
-  }
-  el.staticClass = JSON.stringify(staticClass)
-  const classBinding = getBindingAttr(el, 'class', false /* getStatic */)
-  if (classBinding) {
-    el.classBinding = classBinding
-  }
-}
-
-function processStyleBinding (el) {
-  const styleBinding = getBindingAttr(el, 'style', false /* getStatic */)
-  if (styleBinding) {
-    el.styleBinding = styleBinding
-  }
-}
-
-function processTransition (el) {
-  let transition = getBindingAttr(el, 'transition')
-  if (transition === '""') {
-    transition = true
-  }
-  if (transition) {
-    el.transition = transition
-    el.transitionOnAppear = getBindingAttr(el, 'transition-on-appear') != null
   }
 }
 

--- a/src/entries/web-compiler.js
+++ b/src/entries/web-compiler.js
@@ -2,6 +2,7 @@
 
 import { extend } from 'shared/util'
 import { compile as baseCompile } from 'compiler/index'
+import modules from 'web/compiler/modules/index'
 import directives from 'web/compiler/directives/index'
 import { isReservedTag, isUnaryTag, mustUseProp, getTagNamespace } from 'web/util/index'
 
@@ -16,6 +17,7 @@ const cache2: { [key: string]: CompiledFunctions } = Object.create(null)
 const baseOptions: CompilerOptions = {
   expectHTML: true,
   preserveWhitespace: true,
+  modules,
   directives,
   isReservedTag,
   isUnaryTag,

--- a/src/entries/web-compiler.js
+++ b/src/entries/web-compiler.js
@@ -18,6 +18,7 @@ const baseOptions: CompilerOptions = {
   expectHTML: true,
   preserveWhitespace: true,
   modules,
+  staticKeys: genStaticKeys(modules),
   directives,
   isReservedTag,
   isUnaryTag,
@@ -52,4 +53,17 @@ export function compileToFunctions (
     res.staticRenderFns[i] = new Function(compiled.staticRenderFns[i])
   }
   return (cache[template] = res)
+}
+
+function genStaticKeys (modules: Array<ModuleOptions>): string {
+  let keys = []
+  if (modules) {
+    modules.forEach(module => {
+      const staticKeys = module.staticKeys
+      if (staticKeys && staticKeys.length) {
+        keys = keys.concat(staticKeys)
+      }
+    })
+  }
+  return keys.join(',')
 }

--- a/src/platforms/web/compiler/modules/class.js
+++ b/src/platforms/web/compiler/modules/class.js
@@ -1,0 +1,42 @@
+import { parseText } from 'compiler/parser/text-parser'
+import {
+  getAndRemoveAttr,
+  getBindingAttr,
+  baseWarn
+} from 'compiler/helpers'
+
+function parse (el, options) {
+  const warn = options.warn || baseWarn
+  const staticClass = getAndRemoveAttr(el, 'class')
+  if (process.env.NODE_ENV !== 'production' && staticClass) {
+    const expression = parseText(staticClass, options.delimiters)
+    if (expression) {
+      warn(
+        `class="${staticClass}": ` +
+        'Interpolation inside attributes has been deprecated. ' +
+        'Use v-bind or the colon shorthand instead.'
+      )
+    }
+  }
+  el.staticClass = JSON.stringify(staticClass)
+  const classBinding = getBindingAttr(el, 'class', false /* getStatic */)
+  if (classBinding) {
+    el.classBinding = classBinding
+  }
+}
+
+function genData (el, data) {
+  if (el.staticClass) {
+    data += `staticClass:${el.staticClass},`
+  }
+  if (el.classBinding) {
+    data += `class:${el.classBinding},`
+  }
+  return data
+}
+
+export default {
+  staticKeys: ['staticClass'],
+  parse,
+  genData
+}

--- a/src/platforms/web/compiler/modules/class.js
+++ b/src/platforms/web/compiler/modules/class.js
@@ -25,7 +25,8 @@ function parse (el, options) {
   }
 }
 
-function genData (el, data) {
+function genData (el) {
+  let data = ''
   if (el.staticClass) {
     data += `staticClass:${el.staticClass},`
   }

--- a/src/platforms/web/compiler/modules/index.js
+++ b/src/platforms/web/compiler/modules/index.js
@@ -1,0 +1,9 @@
+import klass from './class'
+import style from './style'
+import transition from './transition'
+
+export default [
+  klass,
+  style,
+  transition
+]

--- a/src/platforms/web/compiler/modules/style.js
+++ b/src/platforms/web/compiler/modules/style.js
@@ -1,0 +1,23 @@
+import {
+  getBindingAttr
+} from 'compiler/helpers'
+
+function parse (el, options) {
+  const styleBinding = getBindingAttr(el, 'style', false /* getStatic */)
+  if (styleBinding) {
+    el.styleBinding = styleBinding
+  }
+}
+
+function genData (el, data) {
+  if (el.styleBinding) {
+    data += `style:${el.styleBinding},`
+  }
+  return data
+}
+
+export default {
+  staticKeys: [],
+  parse,
+  genData
+}

--- a/src/platforms/web/compiler/modules/style.js
+++ b/src/platforms/web/compiler/modules/style.js
@@ -9,11 +9,11 @@ function parse (el, options) {
   }
 }
 
-function genData (el, data) {
+function genData (el) {
   if (el.styleBinding) {
-    data += `style:${el.styleBinding},`
+    return `style:${el.styleBinding},`
   }
-  return data
+  return ''
 }
 
 export default {

--- a/src/platforms/web/compiler/modules/transition.js
+++ b/src/platforms/web/compiler/modules/transition.js
@@ -1,0 +1,27 @@
+import {
+  getBindingAttr
+} from 'compiler/helpers'
+
+function parse (el, options) {
+  let transition = getBindingAttr(el, 'transition')
+  if (transition === '""') {
+    transition = true
+  }
+  if (transition) {
+    el.transition = transition
+    el.transitionOnAppear = getBindingAttr(el, 'transition-on-appear') != null
+  }
+}
+
+function genData (el, data) {
+  if (el.transition) {
+    data += `transition:{definition:(${el.transition}),appear:${el.transitionOnAppear}},`
+  }
+  return data
+}
+
+export default {
+  staticKeys: [],
+  parse,
+  genData
+}

--- a/src/platforms/web/compiler/modules/transition.js
+++ b/src/platforms/web/compiler/modules/transition.js
@@ -13,11 +13,11 @@ function parse (el, options) {
   }
 }
 
-function genData (el, data) {
+function genData (el) {
   if (el.transition) {
-    data += `transition:{definition:(${el.transition}),appear:${el.transitionOnAppear}},`
+    return `transition:{definition:(${el.transition}),appear:${el.transitionOnAppear}},`
   }
-  return data
+  return ''
 }
 
 export default {

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -1,4 +1,5 @@
 import { parse } from 'compiler/parser/index'
+import modules from 'web/compiler/modules/index'
 import directives from 'web/compiler/directives/index'
 import { extend } from 'shared/util'
 import { isReservedTag, isUnaryTag, mustUseProp, getTagNamespace } from 'web/util/index'
@@ -7,6 +8,7 @@ describe('parser', () => {
   const baseOptions = {
     expectHTML: true,
     preserveWhitespace: true,
+    modules,
     directives,
     isReservedTag,
     isUnaryTag,


### PR DESCRIPTION
Currently they are written and treated as special attributes. This pr made them possible decoupled from web platform implementations.

And each platform will custom more attributes as platform compiler modules in the future.

Updates:

* added `modules?: Array<ModuleOptions>` in `CompilerOptions` type
* added `src/platforms/web/compiler/modules/*`

Changes:

* `parser`
  * `processClassBinding(element)`
  * `processStyleBinding(element)`
  * `processTransition(element)`
* `optimizer`
  * `isStaticKey`
* `codegen`
  * `genData(el)`