### PR TITLE
Add halt event modifier.

### DIFF
--- a/src/directives/public/on.js
+++ b/src/directives/public/on.js
@@ -107,6 +107,9 @@ export default {
     if (this.modifiers.prevent) {
       handler = preventFilter(handler)
     }
+    if (this.modifiers.halt) {
+      handler = stopFilter(preventFilter(handler))
+    }
     if (this.modifiers.self) {
       handler = selfFilter(handler)
     }

--- a/test/unit/specs/directives/public/on_spec.js
+++ b/test/unit/specs/directives/public/on_spec.js
@@ -214,6 +214,27 @@ describe('v-on', function () {
     expect(window.location.hash).toBe(hash)
   })
 
+  it('halt modifier', function () {
+    var prevented
+    var outer = jasmine.createSpy('outer')
+    new Vue({
+      el: el,
+      template: '<div @click="outer"><div class="inner" @click.halt="inner"></div></div>',
+      methods: {
+        outer: outer,
+        inner: function (e) {
+          // store the prevented state now:
+          // IE will reset the `defaultPrevented` flag
+          // once the event handler call stack is done!
+          prevented = e.defaultPrevented
+        }
+      }
+    })
+    trigger(el.querySelector('.inner'), 'click')
+    expect(prevented).toBe(true)
+    expect(outer).not.toHaveBeenCalled()
+  })
+
   it('capture modifier', function () {
     document.body.appendChild(el)
     var outer = jasmine.createSpy('outer')


### PR DESCRIPTION
In my experience with JavaScript it is *very* common to call `stopPropagation` and `preventDefault` in tandem. This pull request adds a modifier which is a shortcut for both. Just a few notes:

1.) I am not attached to the name `halt`.
2.) If this looks good I can go ahead and add docs.

Possible alternative implementation:

```js
    if (this.modifiers.stop || this.modifiers.halt) {
      handler = stopFilter(handler)
    }
    if (this.modifiers.prevent || this.modifiers.halt) {
      handler = preventFilter(handler)
    }
```

Or, since `this.modifiers` is called a whole bunch:

```js
    var mods = this.modifiers
    if (mods.stop || mods.halt) {
      handler = stopFilter(handler)
    }
    if (mods.prevent || mods.halt) {
      handler = preventFilter(handler)
    }
```