### PR TITLE
Allow extended Vue constructors as the mixins option

### DIFF
--- a/src/util/options.js
+++ b/src/util/options.js
@@ -339,7 +339,11 @@ export function mergeOptions (parent, child, vm) {
   }
   if (child.mixins) {
     for (var i = 0, l = child.mixins.length; i < l; i++) {
-      parent = mergeOptions(parent, child.mixins[i], vm)
+      var mixin = child.mixins[i]
+      var mixinOptions = mixin.prototype instanceof Vue
+        ? mixin.options
+        : mixin
+      parent = mergeOptions(parent, mixinOptions, vm)
     }
   }
   for (key in parent) {

--- a/test/unit/specs/util/options_spec.js
+++ b/test/unit/specs/util/options_spec.js
@@ -303,12 +303,14 @@ describe('Util - Option merging', function () {
     var f4 = function () {}
     var mixinA = { a: 1, directives: { a: a }, created: f2 }
     var mixinB = { b: 1, directives: { b: b }, created: f3 }
+    var mixinC = Vue.extend({ c: 1 })
     var res = merge(
       { a: 2, directives: { c: c }, created: [f1] },
-      { directives: { d: d }, mixins: [mixinA, mixinB], created: f4 }
+      { directives: { d: d }, mixins: [mixinA, mixinB, mixinC], created: f4 }
     )
     expect(res.a).toBe(1)
     expect(res.b).toBe(1)
+    expect(res.c).toBe(1)
     expect(res.directives.a).toBe(a)
     expect(res.directives.b).toBe(b)
     expect(res.directives.c).toBe(c)


### PR DESCRIPTION
Fix #2956 