### PR TITLE
do not call shift if the key already exists

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -33,12 +33,12 @@ var p = Cache.prototype
 
 p.put = function (key, value) {
   var removed
-  if (this.size === this.limit) {
-    removed = this.shift()
-  }
 
   var entry = this.get(key, true)
   if (!entry) {
+    if (this.size === this.limit) {
+      removed = this.shift()
+    }
     entry = {
       key: key
     }


### PR DESCRIPTION
if the cache size is equal to cache limit and now we put a new entry with an existed key (not the head key), the result is we removed the head entry and updated an existed entry. the cache size will be limit-1. so we need to move the if-statement inside