### PR TITLE
Fixed #2988

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -5,6 +5,7 @@ import { parseText, tokensToExp } from '../parsers/text'
 import { parseDirective } from '../parsers/directive'
 import { parseTemplate } from '../parsers/template'
 import {
+  _toString,
   resolveAsset,
   toArray,
   warn,
@@ -446,7 +447,7 @@ function makeTextNodeLinkFn (tokens, frag) {
           if (token.html) {
             replace(node, parseTemplate(value, true))
           } else {
-            node.data = value === undefined ? '' : value
+            node.data = _toString(value)
           }
         } else {
           vm._bindDir(token.descriptor, node, host, scope)

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -446,7 +446,7 @@ function makeTextNodeLinkFn (tokens, frag) {
           if (token.html) {
             replace(node, parseTemplate(value, true))
           } else {
-            node.data = value
+           node.data = value === undefined ? '' : value
           }
         } else {
           vm._bindDir(token.descriptor, node, host, scope)

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -446,7 +446,7 @@ function makeTextNodeLinkFn (tokens, frag) {
           if (token.html) {
             replace(node, parseTemplate(value, true))
           } else {
-           node.data = value === undefined ? '' : value
+            node.data = value === undefined ? '' : value
           }
         } else {
           vm._bindDir(token.descriptor, node, host, scope)


### PR DESCRIPTION
Make rendering of undefined and null in one-time binding mode as same as reactive binding.