### PR TITLE
Fix missing removal of v-transition class

### DIFF
--- a/src/directives/internal/transition.js
+++ b/src/directives/internal/transition.js
@@ -11,6 +11,7 @@ export default {
     // resolve on owner vm
     var hooks = resolveAsset(this.vm.$options, 'transitions', id)
     id = id || 'v'
+    oldId = oldId || 'v'
     el.__v_trans = new Transition(el, id, hooks, this.vm)
     if (oldId) {
       removeClass(el, oldId + '-transition')

--- a/test/unit/specs/directives/internal/transition_spec.js
+++ b/test/unit/specs/directives/internal/transition_spec.js
@@ -14,7 +14,7 @@ describe('transition', function () {
     })
     var dir = new Directive({
       name: 'transition',
-      raw: 'test',
+      raw: '',
       def: def,
       modifiers: {
         literal: true
@@ -22,17 +22,22 @@ describe('transition', function () {
     }, vm, el)
     dir._bind()
     var transition = dir.el.__v_trans
+    expect(transition.enterClass).toBe('v-enter')
+    expect(transition.leaveClass).toBe('v-leave')
+    expect(dir.el.className).toBe('v-transition')
+    dir.update('test', '')
+    transition = dir.el.__v_trans
     expect(transition.el).toBe(dir.el)
     expect(transition.hooks).toBe(fns)
     expect(transition.enterClass).toBe('test-enter')
     expect(transition.leaveClass).toBe('test-leave')
-    expect(dir.el.className === 'test-transition')
+    expect(dir.el.className).toBe('test-transition')
     dir.update('lol', 'test')
     transition = dir.el.__v_trans
     expect(transition.enterClass).toBe('lol-enter')
     expect(transition.leaveClass).toBe('lol-leave')
     expect(transition.fns).toBeUndefined()
-    expect(dir.el.className === 'lol-transition')
+    expect(dir.el.className).toBe('lol-transition')
   })
 
   it('dynamic transitions', function (done) {


### PR DESCRIPTION
Fix #2972

At first I added this test too since manually updating the directive may differ from real updates but then I realised it must be already tested on binding tests so I removed it.

```javascript
  it('removes v-transition on dynamic transition', function (done) {
    var el = document.createElement('div')
    document.body.appendChild(el)
    var vm = new Vue({
      el: el,
      template: '<div :transition="trans"></div>',
      data: {
        trans: null
      },
      replace: true
    })

    _.nextTick(function () {
      expect(vm.$el.className).toBe('v-transition')
      vm.trans = 'a'
      _.nextTick(function () {
        expect(vm.$el.className).toBe('a-transition')
        done()
      })
    })
  })
```