### PR TITLE
fix: glob in npm lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "webpack --watch --config build/webpack.dev.config.js & npm run serve-test",
     "serve-test": "webpack-dev-server --config build/webpack.test.config.js --host 0.0.0.0",
     "build-test": "webpack --config build/webpack.test.config.js",
-    "lint": "eslint src/** test/e2e/** test/unit/specs/** build/**.js",
+    "lint": "eslint src test/e2e test/unit/specs build",
     "e2e": "casperjs test --concise ./test/e2e",
     "unit": "karma start build/karma.unit.config.js",
     "cover": "karma start build/karma.cover.config.js",


### PR DESCRIPTION
Instead of using globs to be expanded in the shell, ESLint has support for recursively linting `.js` files inside a directory. Another reason for the change would be that `**` was expanding to all files, including files without `js` extension (like git's `.orig`).

If you still want to use a glob, the correct one would be `/**/*.js` but it's a fairly new feature in Bash so I wouldn't recommend that as an alternative.