### PR TITLE
Prevent setting unchanged value of input on blur

### DIFF
--- a/src/directives/public/model/text.js
+++ b/src/directives/public/model/text.js
@@ -129,7 +129,10 @@ export default {
   },
 
   update (value) {
-    this.el.value = _toString(value)
+    // #3029 only update when the value changes. This prevent
+    // browsers from overwriting values like selectionStart
+    value = _toString(value)
+    if (value !== this.el.value) this.el.value = value
   },
 
   unbind () {


### PR DESCRIPTION
Fix #3029
Force setting the value actually resets selectionStart and selectionEnd
No test is added because you cannot simulate the bug by using
input.blur()