### PR TITLE
Closed input problem

### DIFF
--- a/test/unit/modules/compiler/sfc-parser.spec.js
+++ b/test/unit/modules/compiler/sfc-parser.spec.js
@@ -30,6 +30,16 @@ describe('Single File Component parser', () => {
     expect(res.script.content.trim()).toBe('export default {}')
   })
 
+  fit('should parse template with closed input', () => {
+    const res = parseComponent(`
+      <template>
+        <input type="text"/>
+      </template>
+    `)
+
+    expect(res.template.content.trim()).toBe('<input type="text">')
+  })
+
   it('should handle nested template', () => {
     const res = parseComponent(`
       <template>


### PR DESCRIPTION
Versions: `2.0.0-alpha.4` and vue-`loader@9.0.1` or `vueify@9.0.1`

My whole `App.vue`:

### Won't render (no error or warning displayed) - inline closed input
```
<template>
  <input type="text" name="name" value="TDD" />
</template>
```

vs

### Renders
```
<template>
  <input type="text" name="name" value="TDD">
</template>
```

It works as expected if you use whole Vue package (template compilation not done up front).
http://codepen.io/zigomir/pen/yJaLVN?editors=1010

Adding failing test.