### PR TITLE
Fixed: the "pluralize" filter with multi arguments, when selected arg…

### DIFF
--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -104,9 +104,13 @@ export default {
 
   pluralize (value) {
     var args = toArray(arguments, 1)
-    return args.length > 1
-      ? (args[value % 10 - 1] || args[args.length - 1])
-      : (args[0] + (value === 1 ? '' : 's'))
+    var length = args.length
+    if (length > 1) {
+      var index = value % 10 - 1
+      return index in args ? args[index] : args[length - 1]
+    } else {
+      return args[0] + (value === 1 ? '' : 's')
+    }
   },
 
   /**

--- a/test/unit/specs/filters/filters_spec.js
+++ b/test/unit/specs/filters/filters_spec.js
@@ -53,6 +53,8 @@ describe('Filters', function () {
     expect(filter(2, 'st', 'nd', 'rd', 'th')).toBe('nd')
     expect(filter(3, 'st', 'nd', 'rd', 'th')).toBe('rd')
     expect(filter(4, 'st', 'nd', 'rd', 'th')).toBe('th')
+    // multi args where selected argument is empty string
+    expect(filter(1, '', 'nd', 'rd', 'th')).toBe('')
   })
 
   it('currency', function () {


### PR DESCRIPTION
In Vue.js `1.0.25` the "pluralize" filter returns "three"
```js
Vue.filter('pluralize')(1, "", "two", "three") // three
```
instead of the empty string. After this fix, the "pluralize" filter returns the empty string:
```js
Vue.filter('pluralize')(1, "", "two", "three") // ""
```