### PR TITLE
Fix watcher target not resetting properly

### DIFF
--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -204,10 +204,12 @@ export default class Watcher {
   evaluate () {
     // avoid overwriting another watcher that is being
     // collected.
-    const current = Dep.target
+    const currentPrevTarget = prevTarget
+    prevTarget = Dep.target
     this.value = this.get()
     this.dirty = false
-    Dep.target = current
+    Dep.target = prevTarget
+    prevTarget = currentPrevTarget
   }
 
   /**


### PR DESCRIPTION
Possible fix for https://github.com/vuejs/vue/issues/3133.

The problem appears to be rooted in [`prevTarget`](https://github.com/vuejs/vue/blob/v2.0.0-alpha.5/src/core/observer/watcher.js#L15) getting funky [during instance mounting](https://github.com/vuejs/vue/blob/v2.0.0-alpha.5/src/core/instance/lifecycle.js#L53). This causes `Dep.target` to never be reset to `null`.

This is most likely not the best solution. Maybe a better place for solution would be around [here](https://github.com/vuejs/vue/blob/v2.0.0-alpha.5/src/core/instance/lifecycle.js#L54) or [here](https://github.com/vuejs/vue/blob/v2.0.0-alpha.5/src/core/observer/watcher.js#L77).

Also I can't come up with a better unit test than the original repro:
- Create two instances, first with a computed property (easiest way to reproduce), make sure computed field is used in the template,
- Change the data of the second instance,
- Make sure that first instance didn't update.

Should I include it anyway?

/cc @yyx990803 