### PR TITLE
Fix bug: directive sort is not stable on Chrome

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -105,7 +105,7 @@ function linkAndCapture (linker, vm) {
   var originalDirCount = vm._directives.length
   linker()
   var dirs = vm._directives.slice(originalDirCount)
-  dirs.sort(directiveComparator)
+  sortDirectives(dirs)
   for (var i = 0, l = dirs.length; i < l; i++) {
     dirs[i]._bind()
   }
@@ -113,16 +113,32 @@ function linkAndCapture (linker, vm) {
 }
 
 /**
- * Directive priority sort comparator
+ * sort directives by priority (stable sort)
  *
- * @param {Object} a
- * @param {Object} b
+ * @param {Array} dirs
  */
+function sortDirectives (dirs) {
+  if (dirs.length === 0) return
 
-function directiveComparator (a, b) {
-  a = a.descriptor.def.priority || DEFAULT_PRIORITY
-  b = b.descriptor.def.priority || DEFAULT_PRIORITY
-  return a > b ? -1 : a === b ? 0 : 1
+  var groupedMap = {}
+  for (var i = 0, j = dirs.length; i < j; i++) {
+    var dir = dirs[i]
+    var priority = dir.descriptor.def.priority || DEFAULT_PRIORITY
+    var array = groupedMap[priority]
+    if (!array) {
+      array = groupedMap[priority] = []
+    }
+    array.push(dir)
+  }
+
+  var index = 0
+  Object.keys(groupedMap).sort(function (a, b) {
+    return a > b ? -1 : a === b ? 0 : 1
+  }).forEach(function (priority) {
+    groupedMap[priority].forEach(function (item) {
+      dirs[index++] = item
+    })
+  })
 }
 
 /**


### PR DESCRIPTION
I'm building a tabs component. It is used like this:

```
<tabs>
  <tab title="1">Tab1</tab>
  <tab title="2">Tab2</tab>
  <tab title="3">Tab3</tab>
  <tab title="4">Tab4</tab>
  <tab title="5">Tab5</tab>
  <tab title="6">Tab6</tab>
  <tab title="7">Tab7</tab>
  <tab title="8">Tab8</tab>
  <tab title="9">Tab9</tab>
  <tab title="10">Tab10</tab>
</tabs>
```

[Live demo(Works fine)](https://jsfiddle.net/sgd2sLqf/4/)

It works fine when there are less than 10 ```<tab>s```. But tabs will disorder when I have more than 10 ```<tab>s```.

[Live demo(Bug)](https://jsfiddle.net/sgd2sLqf/5/)

The main reason is that the directive sorting by priority is not stable on Chrome.

I fixed this bug using a sort method(time: O(n), space: O(n)),  It also can be fixed using a stable sort method such as merge sort.