### PR TITLE
[2.0] [vuejs:next] add "body" as reservedTag

### DIFF
--- a/src/platforms/web/util/element.js
+++ b/src/platforms/web/util/element.js
@@ -9,7 +9,7 @@ export const namespaceMap = {
 }
 
 export const isReservedTag = makeMap(
-  'html,base,head,link,meta,style,title,' +
+  'html,body,base,head,link,meta,style,title,' +
   'address,article,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
   'div,dd,dl,dt,figcaption,figure,hr,img,li,main,ol,p,pre,ul,' +
   'a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,rtc,ruby,' +


### PR DESCRIPTION
fix "[Vue warn]: Unknown custom element: `<body>` - did you register the component correctly? ..."