### PR TITLE
[2.0] [vuejs:next] add "aside" as reservedTag

### DIFF
--- a/src/platforms/web/util/element.js
+++ b/src/platforms/web/util/element.js
@@ -10,7 +10,7 @@ export const namespaceMap = {
 
 export const isReservedTag = makeMap(
   'html,body,base,head,link,meta,style,title,' +
-  'address,article,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
+  'address,article,aside,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
   'div,dd,dl,dt,figcaption,figure,hr,img,li,main,ol,p,pre,ul,' +
   'a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,rtc,ruby,' +
   's,samp,small,span,strong,sub,sup,time,u,var,wbr,area,audio,map,track,video,' +

--- a/src/platforms/web/util/element.js
+++ b/src/platforms/web/util/element.js
@@ -9,7 +9,7 @@ export const namespaceMap = {
 }
 
 export const isReservedTag = makeMap(
-  'html,base,head,link,meta,style,title,' +
+  'html,body,base,head,link,meta,style,title,' +
   'address,article,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
   'div,dd,dl,dt,figcaption,figure,hr,img,li,main,ol,p,pre,ul,' +
   'a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,rtc,ruby,' +


### PR DESCRIPTION
fix "[Vue warn]: Unknown custom element: `<aside>` - did you register the component correctly? ..."

`<aside>` is acturally a html element
Reference:https://developer.mozilla.org/en/docs/Web/HTML/Element/aside