### PR TITLE
Handle back-ticks in expression

### DIFF
--- a/src/parsers/expression.js
+++ b/src/parsers/expression.js
@@ -23,7 +23,7 @@ const improperKeywordsRE =
 
 const wsRE = /\s/g
 const newlineRE = /\n/g
-const saveRE = /[\{,]\s*[\w\$_]+\s*:|('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*\$\{|\}(?:[^`\\]|\\.)*`|`(?:[^`\\]|\\.)*`)|new |typeof |void /g
+const saveRE = /[\{,]\s*[\w\$_]+\s*:|('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*\$\{|\}(?:[^`\\"']|\\.)*`|`(?:[^`\\]|\\.)*`)|new |typeof |void /g
 const restoreRE = /"(\d+)"/g
 const pathTestRE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\['.*?'\]|\[".*?"\]|\[\d+\]|\[[A-Za-z_$][\w$]*\])*$/
 const identRE = /[^\w$\.](?:[A-Za-z_$][\w$]*)/g

--- a/test/unit/specs/parsers/expression_spec.js
+++ b/test/unit/specs/parsers/expression_spec.js
@@ -68,6 +68,18 @@ var testCases = [
     expected: { a: '35', b: 32 }
   },
   {
+    // Object with string values with back-quotes
+    exp: '[{"a":"he`llo"},{"b":"world"},{"c":55}]',
+    scope: {},
+    expected: [{ 'a': 'he`llo'}, { 'b': 'world'}, { 'c': 55}]
+  },
+  {
+    // Object with string values and back quotes (single quoted string)
+    exp: '[{\'a\':\'he`llo\'},{\'b\':\'world\'},{\'c\':55}]',
+    scope: {},
+    expected: [{ 'a': 'he`llo'}, { 'b': 'world'}, { 'c': 55}]
+  },
+  {
     // dollar signs and underscore
     exp: "_a + ' ' + $b",
     scope: {


### PR DESCRIPTION
This fixes #3273 but might introduce other bugs. I'm not sure of it.