### PR TITLE
[2.0] allow to initialize value attribute to 0

### DIFF
--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -22,8 +22,9 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
       // non-string values will be stringified
       elm._value = cur
       // avoid resetting cursor position when value is the same
-      if (elm.value != cur) { // eslint-disable-line
-        elm.value = cur
+      const strCur = cur == null ? '' : String(cur)
+      if (elm.value !== strCur) {
+        elm.value = strCur
       }
     } else {
       elm[key] = cur

--- a/test/unit/modules/vdom/modules/props.spec.js
+++ b/test/unit/modules/vdom/modules/props.spec.js
@@ -23,4 +23,10 @@ describe('vdom domProps module', () => {
     const elm = patch(vnode1, vnode2)
     expect(elm.src).toBeUndefined()
   })
+
+  it('should initialize the elements value to zero', () => {
+    const vnode = new VNode('input', { domProps: { value: 0 }})
+    const elm = patch(null, vnode)
+    expect(elm.value).toBe('0')
+  })
 })


### PR DESCRIPTION
I realized `<input :value="value">` is not working on initialization when `value` is `0`.
And also `undefined` is appeared on input field, they are not happened on v1.0

Reproduction: 
[2.0.0-beta.5] https://jsfiddle.net/srbg2em6/1/
[1.0.26] https://jsfiddle.net/srbg2em6/