### PR TITLE
Allow rendering forbidden tags on the server

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -85,7 +85,7 @@ export function parse (
         element.ns = ns
       }
 
-      if (isForbiddenTag(element)) {
+      if (process.env.VUE_ENV !== 'server' && isForbiddenTag(element)) {
         element.forbidden = true
         process.env.NODE_ENV !== 'production' && warn(
           'Templates should only be responsbile for mapping the state to the ' +


### PR DESCRIPTION
Currently if you try to render `<script>` tag on the server side you'll get an error, which is not right, because server is not restricted by the rules of the browser. It is useful if server-side component is rendering the `<html>` tag with `<head>` `<body>` and everything else