### PR TITLE
Fix Problem : TypeError: this.op is not a function

### DIFF
--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -246,7 +246,7 @@ p.leaveNextTick = function () {
 p.leaveDone = function () {
   this.left = true
   this.cancel = this.pendingJsCb = null
-  this.op()
+  if(this.op) this.op()
   removeClass(this.el, this.leaveClass)
   this.callHook('afterLeave')
   if (this.cb) this.cb()

--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -246,7 +246,7 @@ p.leaveNextTick = function () {
 p.leaveDone = function () {
   this.left = true
   this.cancel = this.pendingJsCb = null
-  if(this.op) this.op()
+  if (this.op) this.op()
   removeClass(this.el, this.leaveClass)
   this.callHook('afterLeave')
   if (this.cb) this.cb()


### PR DESCRIPTION
Here is the problem  https://github.com/vuejs/vue/issues/1698

I come accross this problem today 
I found *leaveDone* function execute twice, while this.op is null at the end of first execution lead that problem;

```
p$1.leaveDone = function () {
  this.left = true;
  this.cancel = this.pendingJsCb = null;
  this.op();
  removeClass(this.el, this.leaveClass);
  this.callHook('afterLeave');
  if (this.cb) this.cb();
  this.op = null;
};
```