### PR TITLE
Fix html interpolation

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -882,7 +882,7 @@ function flatifyNodeList (nodeList) {
 function containsOpeningDelimiter (node) {
   var openingRe = new RegExp(config.delimiters[0] + '|' + config.unsafeDelimiters[0], 'g')
   var endingRe = new RegExp(config.delimiters[1] + '|' + config.unsafeDelimiters[1], 'g')
-  if( node && node.nodeType === 3 ){
+  if (node && node.nodeType === 3) {
     var openingMatches = node.textContent.match(openingRe)
     var endingMatches = node.textContent.match(endingRe)
     if (!openingMatches) openingMatches = []
@@ -892,8 +892,6 @@ function containsOpeningDelimiter (node) {
   return false
 }
 
-
-
 /**
  * Check if a node contains an ending delimiter
  *
@@ -901,10 +899,10 @@ function containsOpeningDelimiter (node) {
  * @return {Boolean}
  */
 
-function containsClosingDelimiter (node) {
+function containsClosingDelimiter (node) {
   var openingRe = new RegExp(config.delimiters[0] + '|' + config.unsafeDelimiters[0], 'g')
   var endingRe = new RegExp(config.delimiters[1] + '|' + config.unsafeDelimiters[1], 'g')
-  if( node && node.nodeType === 3 ){
+  if (node && node.nodeType === 3) {
     var openingMatches = node.textContent.match(openingRe)
     var endingMatches = node.textContent.match(endingRe)
     if (!openingMatches) openingMatches = []

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -857,12 +857,10 @@ function flatifyNodeList (nodeList) {
   var openingDelimiterNode = false
   for (var i = 0, l = nodeList.length; i < l; i++) {
     var node = nodeList[i]
-    if (openingDelimiterNode) {
-      openingDelimiterNode.textContent = node.nodeType === 3 ? node.textContent : node.outerHTML
-      if (containsClosingDelimiter) {
-        openingDelimiterNode = false
-      }
-      node.parentNode.removeChild(node)
+    if (openingDelimiterNode && node.nodeType === 1) {
+      node.parentNode.replaceChild(document.createTextNode(node.outerHTML), node)
+    } else if (openingDelimiterNode && node.nodeType == 3 && containsClosingDelimiter(node)) {
+      openingDelimiterNode = false
     } else {
       node = nodeList[i]
       if (containsOpeningDelimiter(node)) {

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -859,7 +859,7 @@ function flatifyNodeList (nodeList) {
     var node = nodeList[i]
     if (openingDelimiterNode && node.nodeType === 1) {
       node.parentNode.replaceChild(document.createTextNode(node.outerHTML), node)
-    } else if (openingDelimiterNode && node.nodeType == 3 && containsClosingDelimiter(node)) {
+    } else if (openingDelimiterNode && node.nodeType === 3 && containsClosingDelimiter(node)) {
       openingDelimiterNode = false
     } else {
       node = nodeList[i]

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -717,7 +717,8 @@ describe('Compile', function () {
   })
 
   it('should interpolate string with html', function (done) {
-    var vm = new Vue({
+    /* disable no-new */
+    new Vue({
       el: el,
       template: "<div>{{ '<strong>hello</strong> world' }}</div>"
     })
@@ -726,5 +727,4 @@ describe('Compile', function () {
       done()
     })
   })
-
 })

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -716,7 +716,7 @@ describe('Compile', function () {
     })
   })
 
-  fit('should interpolate string with html', function (done) {
+  it('should interpolate string with html', function (done) {
     var vm = new Vue({
       el: el,
       template: "<div>{{ '<strong>hello</strong> world' }}</div>"

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -715,4 +715,16 @@ describe('Compile', function () {
       done()
     })
   })
+
+  fit('should interpolate string with html', function (done) {
+    var vm = new Vue({
+      el: el,
+      template: "<div>{{ '<strong>hello</strong> world' }}</div>"
+    })
+    _.nextTick(function () {
+      expect(el.textContent).toBe('<strong>hello</strong> world')
+      done()
+    })
+  })
+
 })


### PR DESCRIPTION
Partial Fix for issue #3323 

This fix allow `<p>{{ '<strong>hello</strong> world' }}</p>`
but `<p>{{{ '<strong>hello</strong> world' }}}</p>` won't work due to the way the compiler works :(. It would force a lots of changes for an edge case.