### PR TITLE
improve debug message for invalid dynamic component

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -261,10 +261,16 @@ export function compileRoot (el, options, contextOptions) {
       })
     if (names.length) {
       var plural = names.length > 1
+
+      var componentName = options.el.tagName.toLowerCase()
+      if (componentName === 'component' && options.name) {
+        componentName += ':' + options.name
+      }
+
       warn(
         'Attribute' + (plural ? 's ' : ' ') + names.join(', ') +
         (plural ? ' are' : ' is') + ' ignored on component ' +
-        '<' + options.el.tagName.toLowerCase() + '> because ' +
+        '<' + componentName + '> because ' +
         'the component is a fragment instance: ' +
         'http://vuejs.org/guide/components.html#Fragment-Instance'
       )


### PR DESCRIPTION
I was in this case:

```html
<component :is='componentName' :foo='foo' ></component>
```

And the component pointed had invalid template, leading to this error:

<pre>
[Vue warn]: Attribute ":foo" is ignored on component <b>&lt;component&gt;</b> because the component is a fragment instance: http://vuejs.org/guide/components.html#Fragment-Instance
</pre>

Now this error also gives the name of the component that failed:

<pre>
[Vue warn]: Attribute ":foo" is ignored on component <b>&lt;component:myComponent&gt;</b> because the component is a fragment instance: http://vuejs.org/guide/components.html#Fragment-Instance
</pre>