### PR TITLE
adapt index.d.ts for end users

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.4",
   "description": "Reactive, component-oriented view layer for modern web interfaces.",
   "main": "dist/vue.common.js",
-  "typings": "index.d.ts",
+  "typings": "types/index.d.ts",
   "files": [
     "dist/vue.common.js",
     "dist/vue.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,6 @@
-import {Vue} from "./vue.d";
+import {Vue as _Vue} from "./vue.d";
+// `Vue` in `export = Vue` must be a namespace
+declare namespace Vue {}
+// TS cannot merge imported class with namespace, declare a subclass to bypass
+declare class Vue extends _Vue {}
 export = Vue;

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,4 +1,4 @@
-import { Vue } from "../vue.d";
+import Vue = require("../index.d");
 import { ComponentOptions } from "../options.d";
 
 interface Component extends Vue {

--- a/types/test/plugin-test.ts
+++ b/types/test/plugin-test.ts
@@ -1,4 +1,4 @@
-import { Vue } from "../vue.d";
+import Vue = require("../index.d");
 import { PluginFunction, PluginObject } from "../plugin.d";
 
 class Option {

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -1,4 +1,4 @@
-import { Vue } from "../vue.d";
+import Vue = require("../index.d");
 
 class Test extends Vue {
   testProperties() {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -53,7 +53,7 @@ export declare class Vue {
     keyCodes: { [key: string]: number };
   }
 
-  static extend(options: ComponentOptions): Vue;
+  static extend(options: ComponentOptions): typeof Vue;
   static nextTick(callback: () => void, context?: any[]): void;
   static set<T>(object: Object, key: string, value: T): T;
   static set<T>(array: T[], key: number, value: T): T;


### PR DESCRIPTION
Related to https://github.com/vuejs/vue/pull/3509

TS declaration files need much hacks, as comments point out.
`import Vue = require("vue")` is the recommended way to import vue because it does not confuse TS/JS users whether to `import default` or `import * as Vue` and it does remind user the difference of commonjs module and es module.