### PR TITLE
Expose all types via index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ import * as Plugin from "./plugin";
 import * as VNode from "./vnode";
 
 // `Vue` in `export = Vue` must be a namespace
-// All avairable types are exported via this namespace
+// All available types are exported via this namespace
 declare namespace Vue {
   export type ComponentOptions = Options.ComponentOptions;
   export type FunctionalComponentOptions = Options.FunctionalComponentOptions;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,33 @@
 import {Vue as _Vue} from "./vue";
+import * as Options from "./options";
+import * as Plugin from "./plugin";
+import * as VNode from "./vnode";
+
 // `Vue` in `export = Vue` must be a namespace
-declare namespace Vue {}
+// All avairable types are exported via this namespace
+declare namespace Vue {
+  export type ComponentOptions = Options.ComponentOptions;
+  export type FunctionalComponentOptions = Options.FunctionalComponentOptions;
+  export type RenderContext = Options.RenderContext;
+  export type PropOptions = Options.PropOptions;
+  export type ComputedOptions = Options.ComputedOptions;
+  export type WatchHandler = Options.WatchHandler;
+  export type WatchOptions = Options.WatchOptions;
+  export type DirectiveFunction = Options.DirectiveFunction;
+  export type DirectiveOptions = Options.DirectiveOptions;
+
+  export type PluginFunction<T> = Plugin.PluginFunction<T>;
+  export type PluginObject<T> = Plugin.PluginObject<T>;
+
+  export type VNodeChildren = VNode.VNodeChildren;
+  export type VNodeChildrenArrayContents = VNode.VNodeChildrenArrayContents;
+  export type VNode = VNode.VNode;
+  export type VNodeComponentOptions = VNode.VNodeComponentOptions;
+  export type VNodeData = VNode.VNodeData;
+  export type VNodeDirective = VNode.VNodeDirective;
+}
+
 // TS cannot merge imported class with namespace, declare a subclass to bypass
 declare class Vue extends _Vue {}
+
 export = Vue;

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,5 +1,5 @@
 import Vue = require("../index");
-import { ComponentOptions, FunctionalComponentOptions } from "../options";
+import { ComponentOptions, FunctionalComponentOptions } from "../index";
 
 interface Component extends Vue {
   a: number;

--- a/types/test/plugin-test.ts
+++ b/types/test/plugin-test.ts
@@ -1,5 +1,5 @@
 import Vue = require("../index");
-import { PluginFunction, PluginObject } from "../plugin";
+import { PluginFunction, PluginObject } from "../index";
 
 class Option {
   prefix: string;


### PR DESCRIPTION
This patch allows us to import vue's types easier.
We can just import them like `import { ComponentOptions } from 'vue'`.

This is also useful for some plugin creators to use vue's types on their declarations.
