### PR TITLE
support short prop declaration as prop: true

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -91,7 +91,7 @@ function assertProp (
     return
   }
   let type = prop.type
-  let valid = !type
+  let valid = !type || type === true
   const expectedTypes = []
   if (type) {
     if (!Array.isArray(type)) {

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -244,6 +244,19 @@ describe('Options props', () => {
       expect(console.error.calls.count()).toBe(2)
       expect('Expected Boolean').toHaveBeenWarned()
     })
+
+    it('optional prop of any type (type: true or prop: true)', () => {
+      makeInstance(1, true)
+      expect(console.error.calls.count()).toBe(0)
+      makeInstance('any', true)
+      expect(console.error.calls.count()).toBe(0)
+      makeInstance({}, true)
+      expect(console.error.calls.count()).toBe(0)
+      makeInstance(undefined, true)
+      expect(console.error.calls.count()).toBe(0)
+      makeInstance(null, true)
+      expect(console.error.calls.count()).toBe(0)
+    })
   })
 
   it('should warn data fields already defined as a prop', () => {


### PR DESCRIPTION
Vue 1 support this form of prop declaration:
`props: {
  someProp: true
}`
[https://jsfiddle.net/89a15uby/](https://jsfiddle.net/89a15uby/)
Vue 2 throw an error `Right-hand side of 'instanceof' is not an object`
[https://jsfiddle.net/jbovp90x/](https://jsfiddle.net/jbovp90x/)