### PR TITLE
Add undefined check for instance methods

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -142,7 +142,9 @@ function initMethods (vm: Component) {
   const methods = vm.$options.methods
   if (methods) {
     for (const key in methods) {
-      vm[key] = bind(methods[key], vm)
+      if (methods[key] != null) {
+        vm[key] = bind(methods[key], vm)
+      }
     }
   }
 }

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -144,7 +144,7 @@ function initMethods (vm: Component) {
     for (const key in methods) {
       if (methods[key] != null) {
         vm[key] = bind(methods[key], vm)
-      } else {
+      } else if (process.env.NODE_ENV !== 'production') {
         warn(`The method ${key} on vue instance is undefined.`, vm)
       }
     }

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -144,6 +144,8 @@ function initMethods (vm: Component) {
     for (const key in methods) {
       if (methods[key] != null) {
         vm[key] = bind(methods[key], vm)
+      } else {
+        warn(`The method ${key} on vue instance is undefined.`, vm)
       }
     }
   }


### PR DESCRIPTION
Adding an undefined property to `methods` on vue components leads to a very ambiguous error message: `Uncaught TypeError: Cannot read property 'length' of undefined`

Example:
```js
import stuff from './stuff'

export default {
  template: '...',
  methods: {
    someMethod: stuff.someMetod // typo!!!
  }
}
```
It's an easy mistake to make. This checks for undefined properties and warns if it finds one.