### PR TITLE
[next] [discussion] Add warning for those using Vue.set with only two arguments, as in Vue 1

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -190,8 +190,8 @@ export function defineReactive (
 export function set (obj: Array<any> | Object, key: any, val: any) {
   if (arguments.length < 3) {
     process.env.NODE_ENV !== 'production' && warn(
-      'Set now requires you to specifiy the object you are modifying' +
-      'as the first argument. See: http://rc.vuejs.org/api/#Vue-set'
+      'Vue.set / this.$set now requires you to specify the object you are ' +
+      'modifying as the first argument. See: http://rc.vuejs.org/api/#Vue-set'
     )
     return
   }

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -188,6 +188,13 @@ export function defineReactive (
  * already exist.
  */
 export function set (obj: Array<any> | Object, key: any, val: any) {
+  if (arguments.length < 3) {
+    process.env.NODE_ENV !== 'production' && warn(
+      'Set now requires you to specifiy the object you are modifying' +
+      'as the first argument. See: http://rc.vuejs.org/api/#Vue-set'
+    )
+    return
+  }
   if (Array.isArray(obj)) {
     obj.splice(key, 1, val)
     return val


### PR DESCRIPTION
Currently using `vm.$set` with only two arguments, as in Vue.js 1 results in a somewhat cryptic TypeError.

```
Uncaught TypeError: Cannot create property [VAL] on string [KEY]
```

Since it would appear that in no scenario can `set` take less than three arguments, I've added a development warning in this case that directs the user to the new documentation for `Vue.set`:

```
Set now requires you to specify the object you are modifying as the first argument. See: http://rc.vuejs.org/api/#Vue-set
```

I understand if this is deemed not needed or potentially volatile due to the fact it references the temporary rc.vuejs.org site. Just thought it might be useful to users who are migrating as the difference isn't immediately clear. I answered this exact question twice on Gittr within two hours.

Thanks!