### PR TITLE
Allow setting of compiled render functions via template option

### DIFF
--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -40,6 +40,12 @@ export function lifecycleMixin (Vue: Class<Component>) {
   ): Component {
     const vm: Component = this
     vm.$el = el
+    const template = vm.$options.template
+    if (template && template.render && template.staticRenderFns) {
+      vm.$options.render = template.render
+      vm.$options.staticRenderFns = template.staticRenderFns
+      vm.$options.template = null
+    }
     if (!vm.$options.render) {
       vm.$options.render = emptyVNode
       if (process.env.NODE_ENV !== 'production') {

--- a/src/entries/web-runtime-with-compiler.js
+++ b/src/entries/web-runtime-with-compiler.js
@@ -40,6 +40,11 @@ Vue.prototype.$mount = function (
       } else if (template.nodeType) {
         isFromDOM = true
         template = template.innerHTML
+      } else if (template.render && template.staticRenderFns) {
+        options.render = template.render
+        options.staticRenderFns = template.staticRenderFns
+        options.template = null
+        template = null
       } else {
         if (process.env.NODE_ENV !== 'production') {
           warn('invalid template option:' + template, this)

--- a/test/unit/features/options/render.spec.js
+++ b/test/unit/features/options/render.spec.js
@@ -36,4 +36,17 @@ describe('Options render', () => {
     new Vue().$mount()
     expect('Failed to mount component: template or render function not defined.').toHaveBeenWarned()
   })
+
+  it('allow setting of render functions via template option', () => {
+    const obj = {
+      render: function (h) {
+        return h('p')
+      },
+      staticRenderFns: []
+    }
+    const vm = new Vue({
+      template: obj
+    }).$mount()
+    expect(vm.$el.tagName).toBe('P')
+  })
 })

--- a/test/unit/features/options/template.spec.js
+++ b/test/unit/features/options/template.spec.js
@@ -43,6 +43,19 @@ describe('Options template', () => {
     expect(vm.$el.textContent).toBe(vm.message)
   })
 
+  it('Object', () => {
+    const obj = {
+      render: function (h) {
+        return h('p')
+      },
+      staticRenderFns: []
+    }
+    const vm = new Vue({
+      template: obj
+    }).$mount()
+    expect(vm.$el.tagName).toBe('P')
+  })
+
   it('invalid template', () => {
     new Vue({
       template: Vue,


### PR DESCRIPTION
In scenarios where we have pre-compiled templates, `compiler.compileToFunctions()`, you need to set both `render` and `staticRenderFns` in component options or use a mixin.

This PR creates a shortcut, by allowing the `template` option receive an object of complied functions.

In conjunction with something like https://www.npmjs.com/package/vue-template-compiler-loader, the following would be possible (where the imported template is pre-compiled and not a string):

```javascript
new Vue({
    el: '#app',
    template: require('./template.html')
})
```

or

```javascript
import template from './component-a.html'
new Vue({
    el: '#app',
    template
})
```
