### PR TITLE
Allow for function as child

### DIFF
--- a/flow/component.js
+++ b/flow/component.js
@@ -25,6 +25,7 @@ declare interface Component {
   $children: Array<Component>;
   $refs: { [key: string]: Component | Element | Array<Component | Element> | void };
   $slots: { [key: string]: Array<VNode> };
+  $slotFn: ?() => VNode;
   $vnode: VNode;
   $isServer: boolean;
 

--- a/flow/vnode.js
+++ b/flow/vnode.js
@@ -1,4 +1,4 @@
-declare type VNodeChildren = Array<?VNode | string | VNodeChildren> | string
+declare type VNodeChildren = Array<?VNode | string | VNodeChildren> | string | ?() => ?VNode
 
 declare type VNodeComponentOptions = {
   Ctor: Class<Component>;

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -15,6 +15,7 @@ export function initRender (vm: Component) {
   vm._vnode = null // the root of the child tree
   vm._staticTrees = null
   vm.$slots = resolveSlots(vm.$options._renderChildren)
+  vm.$slotFn = resolveSlotFn(vm.$options._renderChildren)
   // bind the public createElement fn to this instance
   // so that we get proper render context inside it.
   vm.$createElement = bind(createElement, vm)
@@ -214,6 +215,20 @@ export function renderMixin (Vue: Class<Component>) {
   }
 }
 
+export function resolveSlotFn (
+  children: ?VNodeChildren
+): ?() => ?VNode {
+  if (typeof (children) === 'function') {
+    return children
+  }
+
+  if (Array.isArray(children)) {
+    const child = children[0]
+
+    if (child && typeof (child) === 'function') return child
+  }
+}
+
 export function resolveSlots (
   renderChildren: ?VNodeChildren
 ): { [key: string]: Array<VNode> } {
@@ -224,7 +239,6 @@ export function resolveSlots (
   const children = normalizeChildren(renderChildren) || []
 
   if (typeof children === 'function') {
-    slots.default = children
     return slots
   }
 

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -246,6 +246,9 @@ export function resolveSlots (
   let name, child
   for (let i = 0, l = children.length; i < l; i++) {
     child = children[i]
+
+    if (typeof child === 'function') continue;
+
     if (child.data && (name = child.data.slot)) {
       delete child.data.slot
       const slot = (slots[name] || (slots[name] = []))

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -222,6 +222,12 @@ export function resolveSlots (
     return slots
   }
   const children = normalizeChildren(renderChildren) || []
+
+  if (typeof children === 'function') {
+    slots.default = children
+    return slots
+  }
+
   const defaultSlot = []
   let name, child
   for (let i = 0, l = children.length; i < l; i++) {

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -223,9 +223,17 @@ export function resolveSlotFn (
   }
 
   if (Array.isArray(children)) {
-    const child = children[0]
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i]
 
-    if (child && typeof (child) === 'function') return child
+      if (typeof child === 'function') return child
+
+      if (child && Array.isArray(child.children)) {
+        const func = resolveSlotFn(child.children)
+
+        if (func) return func
+      }
+    }
   }
 }
 
@@ -247,7 +255,7 @@ export function resolveSlots (
   for (let i = 0, l = children.length; i < l; i++) {
     child = children[i]
 
-    if (typeof child === 'function') continue;
+    if (typeof child === 'function') continue
 
     if (child.data && (name = child.data.slot)) {
       delete child.data.slot

--- a/src/core/vdom/helpers.js
+++ b/src/core/vdom/helpers.js
@@ -13,7 +13,7 @@ export function normalizeChildren (
   }
 
   if (typeof (children) === 'function') {
-    return children
+    return
   }
 
   if (Array.isArray(children)) {
@@ -46,7 +46,7 @@ export function normalizeChildren (
           res.push(c)
         }
       } else if (typeof c === 'function') {
-        return c;
+        continue
       }
     }
     return res

--- a/src/core/vdom/helpers.js
+++ b/src/core/vdom/helpers.js
@@ -11,6 +11,11 @@ export function normalizeChildren (
   if (isPrimitive(children)) {
     return [createTextVNode(children)]
   }
+
+  if (typeof (children) === 'function') {
+    return children
+  }
+
   if (Array.isArray(children)) {
     const res = []
     for (let i = 0, l = children.length; i < l; i++) {
@@ -40,6 +45,8 @@ export function normalizeChildren (
           }
           res.push(c)
         }
+      } else if (typeof c === 'function') {
+        return c;
       }
     }
     return res

--- a/src/core/vdom/helpers.js
+++ b/src/core/vdom/helpers.js
@@ -13,7 +13,7 @@ export function normalizeChildren (
   }
 
   if (typeof (children) === 'function') {
-    return
+    return children
   }
 
   if (Array.isArray(children)) {
@@ -46,7 +46,7 @@ export function normalizeChildren (
           res.push(c)
         }
       } else if (typeof c === 'function') {
-        continue
+        res.push(c)
       }
     }
     return res

--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -269,11 +269,43 @@ describe('Component slot', () => {
     Vue.config.preserveWhitespace = false
   })
 
-  it('slot can be a function', () => {
+  it('slots will not contain any functions', () => {
+    const test1 = {
+      render () {
+        expect(this.$slots.default).toBe(undefined)
+        return null
+      }
+    }
+
+    const test2 = {
+      render () {
+        expect(this.$slots.default.length).toBe(1)
+        return null
+      }
+    }
+
+    new Vue({ // eslint-disable-line no-new
+      render (h) {
+        return h(test1, null, function (data) {
+          return h('div', null, data)
+        })
+      }
+    }).$mount()
+
+    new Vue({ // eslint-disable-line no-new
+      render (h) {
+        return h(test2, null, ['text', function (data) {
+          return h('div', null, data)
+        }])
+      }
+    }).$mount()
+  })
+
+  it('if children is a function,  make sure $slotFn is a function', () => {
     const test = {
       render () {
-        expect(typeof (this.$slots.default) === 'function')
-        return this.$slots.default('Hello, World!')
+        expect(typeof (this.$slotFn)).toBe('function')
+        return this.$slotFn('Hello, World!')
       }
     }
     const vm = new Vue({
@@ -287,21 +319,18 @@ describe('Component slot', () => {
     expect(vm.$el.textContent).toBe('Hello, World!')
   })
 
-  it('a function will override all other children', () => {
+  it('if children is an array and children[0] is a function, make sure $slotFn is a function', () => {
     const test = {
       render () {
-        expect(typeof (this.$slots.default) === 'function')
-        return this.$slots.default('Hello, World!')
+        expect(typeof (this.$slotFn)).toBe('function')
+        return this.$slotFn('Hello, World!')
       }
     }
     const vm = new Vue({
       render (h) {
-        return h(test, null, [
-          h('div', null, "this shouldn't appear"),
-          function (data) {
-            return h('div', null, data)
-          }
-        ])
+        return h(test, null, [function (data) {
+          return h('div', null, data)
+        }])
       }
     }).$mount()
 

--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -269,6 +269,45 @@ describe('Component slot', () => {
     Vue.config.preserveWhitespace = false
   })
 
+  it('slot can be a function', () => {
+    const test = {
+      render () {
+        expect(typeof (this.$slots.default) === 'function')
+        return this.$slots.default('Hello, World!')
+      }
+    }
+    const vm = new Vue({
+      render (h) {
+        return h(test, null, function (data) {
+          return h('div', null, data)
+        })
+      }
+    }).$mount()
+
+    expect(vm.$el.textContent).toBe('Hello, World!')
+  })
+
+  it('a function will override all other children', () => {
+    const test = {
+      render () {
+        expect(typeof (this.$slots.default) === 'function')
+        return this.$slots.default('Hello, World!')
+      }
+    }
+    const vm = new Vue({
+      render (h) {
+        return h(test, null, [
+          h('div', null, "this shouldn't appear"),
+          function (data) {
+            return h('div', null, data)
+          }
+        ])
+      }
+    }).$mount()
+
+    expect(vm.$el.textContent).toBe('Hello, World!')
+  })
+
   it('programmatic access to $slots', () => {
     const vm = new Vue({
       template: '<test><p slot="a">A</p><div>C</div><p slot="b">B</div></p></test>',

--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -337,6 +337,22 @@ describe('Component slot', () => {
     expect(vm.$el.textContent).toBe('Hello, World!')
   })
 
+  it('if children is a function and nested in tags,  make sure $slotFn is a function', () => {
+    const test = {
+      render () {
+        expect(typeof (this.$slotFn)).toBe('function')
+        return this.$slotFn('Hello, World!')
+      }
+    }
+    const vm = new Vue({
+      render (h) {
+        return h(test, null, [h('div', null, [(data) => h('span', null, [data])])])
+      }
+    }).$mount()
+
+    expect(vm.$el.outerHTML).toBe('<span>Hello, World!</span>')
+  })
+
   it('programmatic access to $slots', () => {
     const vm = new Vue({
       template: '<test><p slot="a">A</p><div>C</div><p slot="b">B</div></p></test>',


### PR DESCRIPTION
Function as a child is a very powerful pattern employed in react.  It allows the consumer of a component to choose how to render a component, while having access to data passed down by the parent.

It is similar to slots, in a way, except slots only gain you access to the data in the hosting component.

For more information on the possibilities that this pattern enables, please see [this blog post](https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9), [this presentation from Ryan Florence at React Rally](https://www.youtube.com/watch?v=kp-NOggyz54), as well as the new API for [React Router 4.0](https://react-router.now.sh/).

Before I go on, I do want to say that the pattern is achievable right now using props:


It is possible now to mimic this using props with the following pattern:

```
const ComponentWithInfo = {
    props: ['render'],
    render (h) {
       return this.render('Hello, World');
    }
}

new Vue({
    render (h) {
         return <ComponentWithData render={data => <span>{data}</span>}></ComponentWithData>
    }
})
```

However, "first-class" support would be nice.

As far as the vue flavor, the API looks like this:

```
const ComponentWithInfo = {
    render (h) {
       return this.$slots.default('Hello, World')
    }
}

new Vue({
    render (h) {
         return <ComponentWithData>{data => <span>{data}</span>}</ComponentWithData>
    }
})
```

A couple of things:

1) In my implementation, if an array is passed for children, and any of the children are a function, that will throw away all children, except for the function
2) I understand that there is an API freeze, but this is not breaking any existing APIs, only adding on.
3) Please feel free to reject this specific PR, although if you do, I think this is worthwhile feature to consider.