### PR TITLE
Add type augmentation test 

### DIFF
--- a/types/test/augmentation-test.ts
+++ b/types/test/augmentation-test.ts
@@ -1,0 +1,35 @@
+import Vue = require("../index");
+
+declare module "../vue" {
+  // add instance property and method
+  interface Vue {
+    $instanceProperty: string;
+    $instanceMethod(): void;
+  }
+
+  // add static property and method
+  namespace Vue {
+    const staticProperty: string;
+    function staticMethod(): void;
+  }
+}
+
+// augment ComponentOptions
+declare module "../options" {
+  interface ComponentOptions<V extends Vue> {
+    foo?: string;
+  }
+}
+
+const vm = new Vue({
+  data: {
+    a: true
+  },
+  foo: "foo"
+});
+
+vm.$instanceProperty;
+vm.$instanceMethod();
+
+Vue.staticProperty;
+Vue.staticMethod();

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -14,7 +14,8 @@
     "../vue.d.ts",
     "options-test.ts",
     "plugin-test.ts",
-    "vue-test.ts"
+    "vue-test.ts",
+    "augmentation-test.ts"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
Plugins of Vue.js usually add some static or instance properties/methods to `Vue` and some new options to component options.
I think it is good to provide how to augment their typings for the plugin developers.

I add the test code of such augmentation by this PR and it would be the example for it.