### PR TITLE
Select fix for IE & Edge

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -95,12 +95,11 @@ function setSelected (el, binding, vm) {
   if (!isMultiple) {
     el.selectedIndex = -1
   }
-  if ((isIE || isEdge) && el.selectedIndex === -1) {
-    vm.$on('hook:mounted', () => {
-      setTimeout(() => {
-        setSelected(el, binding, vm)
-      }, 0)
-    })
+  if ((isIE || isEdge) && el.selectedIndex === -1 && !el._v_ieselectdone) {
+    el._v_ieselectdone = true;
+    setTimeout(() => {
+      setSelected(el, binding, vm)
+    }, 0)
   }
 }
 

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -5,7 +5,7 @@
 
 import { looseEqual, looseIndexOf } from 'shared/util'
 import { warn } from 'core/util/index'
-import { isAndroid, isIE9 } from 'web/util/index'
+import { isAndroid, isIE9, isEdge, isIE } from 'web/util/index'
 
 const modelableTagRE = /^input|select|textarea|vue-component-[0-9]+(-[0-9a-zA-Z_\-]*)?$/
 
@@ -94,6 +94,13 @@ function setSelected (el, binding, vm) {
   }
   if (!isMultiple) {
     el.selectedIndex = -1
+  }
+  if ((isIE || isEdge) && el.selectedIndex === -1) {
+    vm.$on('hook:mounted', () => {
+      setTimeout(() => {
+        setSelected(el, binding, vm)
+      }, 0)
+    })
   }
 }
 

--- a/src/platforms/web/util/index.js
+++ b/src/platforms/web/util/index.js
@@ -9,6 +9,7 @@ export * from './element'
 const UA = inBrowser && window.navigator.userAgent.toLowerCase()
 export const isIE = UA && /msie|trident/.test(UA)
 export const isIE9 = UA && UA.indexOf('msie 9.0') > 0
+export const isEdge = UA && UA.indexOf('edge/') > 0
 export const isAndroid = UA && UA.indexOf('android') > 0
 
 /**


### PR DESCRIPTION
RE: https://github.com/vuejs/vue/issues/3689

Fixes select (and multiple) for IE9, IE10, IE11 and Edge

`setTimeout` isn't ideal but `nextTick` doesn't work once an option has been selected and page refreshed.

