### PR TITLE
fix Flow lifecycle method name [Vue@2.x]

### DIFF
--- a/flow/options.js
+++ b/flow/options.js
@@ -34,7 +34,7 @@ declare type ComponentOptions = {
   render: () => VNode;
   staticRenderFns?: Array<() => VNode>;
   // lifecycle
-  init?: Function;
+  beforeCreate?: Function;
   created?: Function;
   beforeMount?: Function;
   mounted?: Function;


### PR DESCRIPTION
fix lifecycle method name `init` to `beforeCreate`