### PR TITLE
Update `$refs` type declaration

### DIFF
--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -13,6 +13,13 @@ class Test extends Vue {
     this.$isServer;
   }
 
+  // test property reification
+  $refs: { vue: Vue, element: HTMLInputElement}
+  testReification() {
+    this.$refs.element.value;
+    this.$refs.vue.$data;
+  }
+
   testMethods() {
     this.$mount("#app", false);
     this.$forceUpdate();

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -14,10 +14,17 @@ class Test extends Vue {
   }
 
   // test property reification
-  $refs: { vue: Vue, element: HTMLInputElement}
+  $refs: {
+    vue: Vue,
+    element: HTMLInputElement,
+    vues: Vue[],
+    elements: HTMLInputElement[]
+  }
   testReification() {
-    this.$refs.element.value;
     this.$refs.vue.$data;
+    this.$refs.element.value;
+    this.$refs.vues[0].$data;
+    this.$refs.elements[0].value;
   }
 
   testMethods() {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -19,7 +19,7 @@ export declare class Vue {
   readonly $parent: Vue;
   readonly $root: Vue;
   readonly $children: Vue[];
-  readonly $refs: { [key: string]: Vue | Element };
+  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[]};
   readonly $slots: { [key: string]: VNode[] };
   readonly $isServer: boolean;
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -19,7 +19,7 @@ export declare class Vue {
   readonly $parent: Vue;
   readonly $root: Vue;
   readonly $children: Vue[];
-  readonly $refs: { [key: string]: Vue };
+  readonly $refs: { [key: string]: Vue | Element };
   readonly $slots: { [key: string]: VNode[] };
   readonly $isServer: boolean;
 


### PR DESCRIPTION
According to the [doc](https://rc.vuejs.org/api/#ref), `$refs` is a dictionary of `Vue` instance or `Element`. This pull request reflect this by a union type. So users can declare html elements in `$refs`. 

A test is also added. User defined components may have better knowledge about `$refs`' data structure. So users can also reify special properties to more specific types.

@ktsn your review is appreciated, thanks.
