### PR TITLE
fix directive sort compare

### DIFF
--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -122,20 +122,20 @@ function sortDirectives (dirs) {
 
   var groupedMap = {}
   var i, j, k, l
-  var keys = []
+  var index = 0
+  var priorities = []
   for (i = 0, j = dirs.length; i < j; i++) {
     var dir = dirs[i]
     var priority = dir.descriptor.def.priority || DEFAULT_PRIORITY
     var array = groupedMap[priority]
     if (!array) {
       array = groupedMap[priority] = []
-      keys.push(priority)
+      priorities.push(priority)
     }
     array.push(dir)
   }
 
-  var index = 0
-  var priorities = keys.sort(function (a, b) {
+  priorities.sort(function (a, b) {
     return a > b ? -1 : a === b ? 0 : 1
   })
   for (i = 0, j = priorities.length; i < j; i++) {

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -122,18 +122,20 @@ function sortDirectives (dirs) {
 
   var groupedMap = {}
   var i, j, k, l
+  var keys = []
   for (i = 0, j = dirs.length; i < j; i++) {
     var dir = dirs[i]
     var priority = dir.descriptor.def.priority || DEFAULT_PRIORITY
     var array = groupedMap[priority]
     if (!array) {
       array = groupedMap[priority] = []
+      keys.push(priority)
     }
     array.push(dir)
   }
 
   var index = 0
-  var priorities = Object.keys(groupedMap).sort(function (a, b) {
+  var priorities = keys.sort(function (a, b) {
     return a > b ? -1 : a === b ? 0 : 1
   })
   for (i = 0, j = priorities.length; i < j; i++) {

--- a/test/unit/specs/compiler/compile_spec.js
+++ b/test/unit/specs/compiler/compile_spec.js
@@ -53,8 +53,8 @@ describe('Compile', function () {
   it('normal directives', function () {
     el.setAttribute('v-a', 'b')
     el.innerHTML = '<p v-a:hello.a.b="a" v-b="1">hello</p><div v-b.literal="foo"></div>'
-    var defA = { priority: 1 }
-    var defB = { priority: 2 }
+    var defA = { priority: 250 }
+    var defB = { priority: 1100 }
     var options = _.mergeOptions(Vue.options, {
       directives: {
         a: defA,


### PR DESCRIPTION
fix #3768 

Object.keys(groupedMap) returns an array whose elements are strings, so it breaks the sort function.