### PR TITLE
warn user calling Vue() without new

### DIFF
--- a/src/core/instance/index.js
+++ b/src/core/instance/index.js
@@ -3,8 +3,13 @@ import { stateMixin } from './state'
 import { renderMixin } from './render'
 import { eventsMixin } from './events'
 import { lifecycleMixin } from './lifecycle'
+import { warn } from '../util/index'
 
 function Vue (options) {
+  if (process.env.NODE_ENV !== 'production' &&
+    !(this instanceof Vue)) {
+    warn('Vue is a constructor and should be called with the `new` keyword')
+  }
   this._init(options)
 }
 

--- a/test/unit/features/instance/init.spec.js
+++ b/test/unit/features/instance/init.spec.js
@@ -1,0 +1,12 @@
+import Vue from 'vue'
+
+describe('Initialization', () => {
+  it('without new', () => {
+    try { Vue() } catch (e) {}
+    expect('Vue is a constructor and should be called with the `new` keyword').toHaveBeenWarned()
+  })
+
+  it('with new', () => {
+    expect(new Vue() instanceof Vue).toBe(true)
+  })
+})


### PR DESCRIPTION
Hi,

Open to different wording on the error & I wasn't sure where to put these tests so I've put them in a new file for now. 

An alternative to this PR would be something like:

```diff
function Vue (options) {
+  if (!(this instanceof Vue)) {
+    return new Vue(options)
+  }
   this._init(options)
}
```

I'm not sure which would be better in the long run but the alternative would be more forgiving.

I could also wrap this in env check so this is left out of the production build, but it's also not a lot of code to leave in.

Let me know what you think.