### PR TITLE
Fix $createElement and Vue.extend

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,8 @@ import * as VNode from "./vnode";
 // `Vue` in `export = Vue` must be a namespace
 // All available types are exported via this namespace
 declare namespace Vue {
+  export type Component = Options.Component;
+  export type AsyncComponent = Options.AsyncComponent;
   export type ComponentOptions<V extends Vue> = Options.ComponentOptions<V>;
   export type FunctionalComponentOptions = Options.FunctionalComponentOptions;
   export type RenderContext = Options.RenderContext;

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -7,6 +7,12 @@ type Constructor = {
 
 type $createElement = typeof Vue.prototype.$createElement;
 
+export type Component = typeof Vue | ComponentOptions<Vue> | FunctionalComponentOptions;
+export type AsyncComponent = (
+  resolve: (component: Component) => void,
+  reject: (reason?: any) => void
+) => Promise<Component> | Component | void;
+
 export interface ComponentOptions<V extends Vue> {
   data?: Object | ((this: V) => Object);
   props?: string[] | { [key: string]: PropOptions | Constructor | Constructor[] };
@@ -30,7 +36,7 @@ export interface ComponentOptions<V extends Vue> {
   updated?(this: V): void;
 
   directives?: { [key: string]: DirectiveOptions | DirectiveFunction };
-  components?: { [key: string]: ComponentOptions<Vue> | FunctionalComponentOptions | typeof Vue };
+  components?: { [key: string]: Component | AsyncComponent };
   transitions?: { [key: string]: Object };
   filters?: { [key: string]: Function };
 

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -89,6 +89,10 @@ Vue.component('component', {
       ref: 'myRef'
     }, [
       createElement("div", {}, "message"),
+      createElement(Vue.component("component")),
+      createElement({ mounted() {} }),
+      createElement({ functional: true }),
+      createElement(() => Vue.component("component")),
       "message",
       [createElement("div", {}, "message")]
     ]);

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -90,10 +90,23 @@ Vue.component('component', {
     }, [
       createElement("div", {}, "message"),
       createElement(Vue.component("component")),
-      createElement({ mounted() {} }),
+      createElement({} as ComponentOptions<Vue>),
       createElement({ functional: true }),
+
       createElement(() => Vue.component("component")),
+      createElement(() => ( {} as ComponentOptions<Vue> )),
+      createElement(() => {
+        return new Promise((resolve) => {
+          resolve({} as ComponentOptions<Vue>);
+        })
+      }),
+      createElement((resolve, reject) => {
+        resolve({} as ComponentOptions<Vue>);
+        reject();
+      }),
+
       "message",
+
       [createElement("div", {}, "message")]
     ]);
   },
@@ -158,3 +171,12 @@ Vue.component('functional-component', {
     return createElement("div", {}, context.children);
   }
 } as FunctionalComponentOptions);
+
+Vue.component("async-component", (resolve, reject) => {
+  setTimeout(() => {
+    resolve(Vue.component("component"));
+  }, 0);
+  return new Promise((resolve) => {
+    resolve({ functional: true } as FunctionalComponentOptions);
+  })
+});

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.promise",
+      "es2015.core"
+    ],
     "module": "commonjs",
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -45,7 +45,7 @@ class Test extends Vue {
     this.$nextTick(function() {
       this.$nextTick;
     });
-    this.$createElement("div", {}, "message", "");
+    this.$createElement("div", {}, "message");
   }
 
   static testConfig() {
@@ -77,6 +77,7 @@ class Test extends Vue {
     this.directive("", {bind() {}});
     this.filter("", (value: number) => value);
     this.component("", { data: () => ({}) });
+    this.component("", { functional: true });
     this.use;
     this.mixin(Test);
     this.compile("<div>{{ message }}</div>");

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -9,6 +9,8 @@ import {
 import { VNode, VNodeData, VNodeChildren } from "./vnode";
 import { PluginFunction, PluginObject } from "./plugin";
 
+type Component = typeof Vue | ComponentOptions<Vue> | FunctionalComponentOptions;
+
 export declare class Vue {
 
   constructor(options?: ComponentOptions<Vue>);
@@ -39,10 +41,9 @@ export declare class Vue {
   $emit(event: string, ...args: any[]): this;
   $nextTick(callback?: (this: this) => void): void;
   $createElement(
-    tag?: string | Vue,
+    tag?: string | Component | (() => string | Component),
     data?: VNodeData,
-    children?: VNodeChildren,
-    namespace?: string
+    children?: VNodeChildren
   ): VNode;
 
 
@@ -54,7 +55,7 @@ export declare class Vue {
     keyCodes: { [key: string]: number };
   }
 
-  static extend(options: ComponentOptions<Vue>): typeof Vue;
+  static extend(options: ComponentOptions<Vue> | FunctionalComponentOptions): typeof Vue;
   static nextTick(callback: () => void, context?: any[]): void;
   static set<T>(object: Object, key: string, value: T): T;
   static set<T>(array: T[], key: number, value: T): T;
@@ -65,10 +66,7 @@ export declare class Vue {
     definition?: DirectiveOptions | DirectiveFunction
   ): DirectiveOptions;
   static filter(id: string, definition?: Function): Function;
-  static component(
-    id: string,
-    definition?: ComponentOptions<Vue> | FunctionalComponentOptions | typeof Vue
-  ): typeof Vue;
+  static component(id: string, definition?: Component): typeof Vue;
 
   static use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): void;
   static mixin(mixin: typeof Vue | ComponentOptions<Vue>): void;

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,4 +1,6 @@
 import {
+  Component,
+  AsyncComponent,
   ComponentOptions,
   FunctionalComponentOptions,
   WatchOptions,
@@ -8,8 +10,6 @@ import {
 } from "./options.d";
 import { VNode, VNodeData, VNodeChildren } from "./vnode";
 import { PluginFunction, PluginObject } from "./plugin";
-
-type Component = typeof Vue | ComponentOptions<Vue> | FunctionalComponentOptions;
 
 export declare class Vue {
 
@@ -41,7 +41,7 @@ export declare class Vue {
   $emit(event: string, ...args: any[]): this;
   $nextTick(callback?: (this: this) => void): void;
   $createElement(
-    tag?: string | Component | (() => string | Component),
+    tag?: string | Component | AsyncComponent,
     data?: VNodeData,
     children?: VNodeChildren
   ): VNode;
@@ -66,7 +66,7 @@ export declare class Vue {
     definition?: DirectiveOptions | DirectiveFunction
   ): DirectiveOptions;
   static filter(id: string, definition?: Function): Function;
-  static component(id: string, definition?: Component): typeof Vue;
+  static component(id: string, definition?: Component | AsyncComponent): typeof Vue;
 
   static use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): void;
   static mixin(mixin: typeof Vue | ComponentOptions<Vue>): void;


### PR DESCRIPTION
According to 06b4703, `namespace` has been removed, so I updated the types.
Also, I fixed the first argument of `$createElement`.
In addition, add `FunctionalComponentOptions` to `Vue.extend`