### PR TITLE
Fix #3824 Allow text nodes on static templates in components

### DIFF
--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -117,8 +117,10 @@ export function renderMixin (Vue: Class<Component>) {
     tree = this._staticTrees[index] = this.$options.staticRenderFns[index].call(this._renderProxy)
     if (Array.isArray(tree)) {
       for (let i = 0; i < tree.length; i++) {
-        tree[i].isStatic = true
-        tree[i].key = `__static__${index}_${i}`
+        if (typeof tree[i] !== 'string') {
+          tree[i].isStatic = true
+          tree[i].key = `__static__${index}_${i}`
+        }
       }
     } else {
       tree.isStatic = true

--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -523,4 +523,17 @@ describe('Component slot', () => {
       expect(spy).toHaveBeenCalled()
     }).then(done)
   })
+
+  it('renders static tree with text', () => {
+    const vm = new Vue({
+      template: `<div><test><template><div></div>Hello<div></div></template></test></div>`,
+      components: {
+        test: {
+          template: '<div><slot></slot></div>'
+        }
+      }
+    })
+    vm.$mount()
+    expect('Error when rendering root').not.toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
It may be a better way to move the textnode out of the static render tree