### PR TITLE
add license information to vue.common.js

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -19,14 +19,16 @@ const builds = {
   'web-runtime-dev': {
     entry: path.resolve(__dirname, '../src/entries/web-runtime.js'),
     dest: path.resolve(__dirname, '../dist/vue.common.js'),
-    format: 'cjs'
+    format: 'cjs',
+    banner
   },
   // Minified runtime, only for filze size monitoring
   'web-runtime-prod': {
     entry: path.resolve(__dirname, '../src/entries/web-runtime.js'),
     dest: path.resolve(__dirname, '../dist/vue.common.min.js'),
     format: 'umd',
-    env: 'production'
+    env: 'production',
+    banner
   },
   // Runtime+compiler standalone developement build.
   'web-standalone-dev': {


### PR DESCRIPTION
The license information in `vue.common.js` is needed for compiling bundles with webpack.

Without the license, an app that does `require('vue')` and is compiled with webpack will not give proper attribution to the grat work done by Vue.