### PR TITLE
Fix links to docs in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Vue.js is an MIT-licensed open source project. Its ongoing development is made p
 
 Vue.js is a library for building interactive web interfaces. It provides data-reactive components with a simple and flexible API. Core features include:
 
-- [Dead simple, unobtrusive reactivity using plain JavaScript objects.](http://vuejs.org/guide/overview.html#Reactive-Data-Binding)
-- [Component-oriented development style with tooling support](http://vuejs.org/guide/overview.html#Component-System)
+- [Dead simple, unobtrusive reactivity using plain JavaScript objects.](http://vuejs.org/guide/index.html#Declarative-Rendering)
+- [Component-oriented development style with tooling support](http://vuejs.org/guide/index.html#Composing-with-Components)
 - Lean and extensible core
 - [Flexible transition effect system](http://vuejs.org/guide/transitions.html)
 - Fast without the need for complex optimization


### PR DESCRIPTION
I'm unsure about the first link update because there's no real equivalent on the v2 docs. It may be worth to update the whole line