### PR TITLE
Make forAlias regex lazy (fixes #3846)

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -16,7 +16,7 @@ import {
 } from '../helpers'
 
 export const dirRE = /^v-|^@|^:/
-export const forAliasRE = /(.*)\s+(?:in|of)\s+(.*)/
+export const forAliasRE = /(.*?)\s+(?:in|of)\s+(.*)/
 export const forIteratorRE = /\(([^,]*),([^,]*)(?:,([^,]*))?\)/
 const bindRE = /^:|^v-bind:/
 const onRE = /^@|^v-on:/


### PR DESCRIPTION
The current forAliasRE has the first rule greedy (`(.*)`), which will attempt to match whatever it can. This exposes a bug (#3846), where the regex fails if the template happens to have " in " or " of " in its last group. For instance, with the template `for key in [{body: 'Hey in body'}]`, current regex will capture the last group as `body'}]` instead of `[{body: 'Hey in body'}]`. This commit aims to fix this issue by making the first rule lazy instead.

I don't think this really needs a test, but let me know if it does.