### PR TITLE
add getTypeList to process mutli-type prop

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -21,7 +21,7 @@ export function validateProp (
   const absent = !hasOwn(propsData, key)
   let value = propsData[key]
   // handle boolean props
-  if (getTypeList(prop.type).indexOf('Boolean') >= 0) {
+  if (isBooleanType(prop.type)) {
     if (absent && !hasOwn(prop, 'default')) {
       value = false
     } else if (value === '' || value === hyphenate(key)) {
@@ -161,9 +161,16 @@ function getType (fn) {
   return match && match[1]
 }
 
-function getTypeList (fn) {
+function isBooleanType (fn) {
+  const isBoolean = (fnItem) => getType(fnItem) === 'Boolean'
+
   if (!Array.isArray(fn)) {
-    fn = [fn]
+    return isBoolean(fn)
   }
-  return fn.map(item => getType(item))
+  for (let i = 0, len = fn.length; i < len; i++) {
+    if (isBoolean(getType(fn[i]))) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -165,7 +165,5 @@ function getTypeList (fn) {
   if (!Array.isArray(fn)) {
     fn = [fn]
   }
-  return fn.map(function (item) {
-    return getType(item)
-  })
+  return fn.map(item => getType(item))
 }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -168,7 +168,7 @@ function isBooleanType (fn) {
     return isBoolean(fn)
   }
   for (let i = 0, len = fn.length; i < len; i++) {
-    if (isBoolean(getType(fn[i]))) {
+    if (isBoolean(fn[i])) {
       return true
     }
   }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -21,7 +21,7 @@ export function validateProp (
   const absent = !hasOwn(propsData, key)
   let value = propsData[key]
   // handle boolean props
-  if (getType(prop.type) === 'Boolean') {
+  if (getTypeList(prop.type).indexOf('Boolean') >= 0) {
     if (absent && !hasOwn(prop, 'default')) {
       value = false
     } else if (value === '' || value === hyphenate(key)) {
@@ -159,4 +159,13 @@ function assertType (value: any, type: Function): {
 function getType (fn) {
   const match = fn && fn.toString().match(/^\s*function (\w+)/)
   return match && match[1]
+}
+
+function getTypeList (fn) {
+  if (!Array.isArray(fn)) {
+    fn = [fn]
+  }
+  return fn.map(function (item) {
+    return getType(item)
+  })
 }


### PR DESCRIPTION
the getType func only returns the first prop type, even if the prop type is an array.

Add getTypeList func to get prop types. 
fix #3879