### PR TITLE
replace special terminators chars

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -22,6 +22,7 @@ const bindRE = /^:|^v-bind:/
 const onRE = /^@|^v-on:/
 const argRE = /:(.*)$/
 const modifierRE = /\.[^\.]+/g
+const specialNewlineRE = /\u2028|\u2029/g
 
 const decodeHTMLCached = cached(decodeHTML)
 
@@ -222,6 +223,8 @@ export function parse (
             text
           })
         } else {
+          // #3895 special character
+          text = text.replace(specialNewlineRE, '')
           currentParent.children.push({
             type: 3,
             text


### PR DESCRIPTION
replace terminator chars  \u2028 and \u2029 to avoid syntax error. fix #3895 
