### PR TITLE
Remove the License badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
   <a href="https://codecov.io/github/vuejs/vue?branch=dev"><img src="https://img.shields.io/codecov/c/github/vuejs/vue/dev.svg" alt="Coverage Status"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/dt/vue.svg" alt="Downloads"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/v/vue.svg" alt="Version"></a>
-  <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/l/vue.svg" alt="License"></a>
   <br>
   <a href="https://saucelabs.com/u/vuejs"><img src="https://saucelabs.com/browser-matrix/vuejs.svg" alt="Sauce Test Status"></a>
 </p>


### PR DESCRIPTION
The License is already in interfaces:

**github.com:**
![](https://i.imgur.com/NAyK39n.png)

**npmjs.com:**
![](https://i.imgur.com/oiZvnBW.png)

No need to duplicate this info.
