### PR TITLE
select change event fix

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -60,7 +60,7 @@ export default {
       // option in the DOM.
       const needReset = el.multiple
         ? binding.value.some(v => hasNoMatchingOption(v, el.options))
-        : hasNoMatchingOption(binding.value, el.options)
+        : binding.value === binding.oldValue ? false : hasNoMatchingOption(binding.value, el.options)
       if (needReset) {
         trigger(el, 'change')
       }

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -166,16 +166,16 @@ describe('Directive v-model select', () => {
     const vm = new Vue({
       data: {
         id: 4,
-        list: [1,2,3],
+        list: [1, 2, 3],
         testChange: 5
       },
       template:
-      '<div>' +
-      '<select @change="test" v-model="id">' +
-      '<option v-for="item in list" :value="item">{{item}}</option>' +
-      '</select>' +
-      '{{testChange}}' +
-      '</div>',
+        '<div>' +
+          '<select @change="test" v-model="id">' +
+            '<option v-for="item in list" :value="item">{{item}}</option>' +
+          '</select>' +
+          '{{testChange}}' +
+        '</div>',
       methods: {
         test: spy
       }

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -161,6 +161,32 @@ describe('Directive v-model select', () => {
     }).then(done)
   })
 
+  it('should work with select which has no default selected options', (done) => {
+    const spy = jasmine.createSpy()
+    const vm = new Vue({
+      data: {
+        id: 4,
+        list: [1,2,3],
+        testChange: 5
+      },
+      template:
+      '<div>' +
+      '<select @change="test" v-model="id">' +
+      '<option v-for="item in list" :value="item">{{item}}</option>' +
+      '</select>' +
+      '{{testChange}}' +
+      '</div>',
+      methods: {
+        test: spy
+      }
+    }).$mount()
+    document.body.appendChild(vm.$el)
+    vm.testChange = 10
+    waitForUpdate(() => {
+      expect(spy.calls.count()).toBe(0)
+    }).then(done)
+  })
+
   it('multiple', done => {
     const vm = new Vue({
       data: {


### PR DESCRIPTION
If select binding not changed, then needRest should be set to false, and no **change** event should be emitted. fix #3917 