### PR TITLE
Fix using one delay to control all transitions.

### DIFF
--- a/src/platforms/web/runtime/transition-util.js
+++ b/src/platforms/web/runtime/transition-util.js
@@ -131,10 +131,10 @@ export function getTransitionInfo (el: Element, expectedType?: ?string): {
 }
 
 function getTimeout (delays: Array<string>, durations: Array<string>): number {
-  while(delays.length < durations.length) {
-    delays = delays.concat(delays);
+  while (delays.length < durations.length) {
+    delays = delays.concat(delays)
   }
-  
+
   return Math.max.apply(null, durations.map((d, i) => {
     return toMs(d) + toMs(delays[i])
   }))

--- a/src/platforms/web/runtime/transition-util.js
+++ b/src/platforms/web/runtime/transition-util.js
@@ -131,6 +131,10 @@ export function getTransitionInfo (el: Element, expectedType?: ?string): {
 }
 
 function getTimeout (delays: Array<string>, durations: Array<string>): number {
+  while(delays.length < durations.length) {
+    delays = delays.concat(delays);
+  }
+  
   return Math.max.apply(null, durations.map((d, i) => {
     return toMs(d) + toMs(delays[i])
   }))


### PR DESCRIPTION
Vue transitions have a wrong timing when having CSS like the following:

```
.[transition-name]-enter-active, .[transition-name]-leave-active {
  transition: opacity 0.8s ease, transform 0.7s ease;
  transition-delay: 0.4s;
}
```

Which in turn bubbles errors to the console. This PR fixes the bug.

I have a question though: Is parameter re-assign allowed in Vue? It's not configured in the ESlint setup.