### PR TITLE
Add promise support to nextTick

### DIFF
--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -26,7 +26,7 @@ export function initRender (vm: Component) {
 
 export function renderMixin (Vue: Class<Component>) {
   Vue.prototype.$nextTick = function (fn: Function) {
-    nextTick(fn, this)
+    return nextTick(fn, this)
   }
 
   Vue.prototype._render = function (): VNode {

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -87,13 +87,17 @@ export const nextTick = (function () {
   }
 
   return function queueNextTick (cb: Function, ctx?: Object) {
-    const func = ctx
-      ? function () { cb.call(ctx) }
-      : cb
-    callbacks.push(func)
-    if (!pending) {
-      pending = true
-      timerFunc()
+    if (cb) {
+      var func = ctx
+        ? function () { cb.call(ctx) }
+        : cb
+      callbacks.push(func)
+      if (!pending) {
+        pending = true
+        timerFunc()
+      }
+    } else if (typeof Promise !== 'undefined') {
+      return Promise.resolve(ctx)
     }
   }
 })()

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -86,7 +86,7 @@ export const nextTick = (function () {
     }
   }
 
-  return function queueNextTick (cb: Function, ctx?: Object) {
+  return function queueNextTick (cb?: ?Function, ctx?: Object) {
     if (cb) {
       var func = ctx
         ? function () { cb.call(ctx) }

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -86,7 +86,7 @@ export const nextTick = (function () {
     }
   }
 
-  return function queueNextTick (cb?: ?Function, ctx?: Object) {
+  return function queueNextTick (cb: Function, ctx?: Object) {
     if (cb) {
       var func = ctx
         ? function () { cb.call(ctx) }

--- a/test/unit/features/instance/methods-lifecycle.spec.js
+++ b/test/unit/features/instance/methods-lifecycle.spec.js
@@ -109,5 +109,22 @@ describe('Instance methods lifecycle', () => {
         done()
       })
     })
+
+    if (typeof Promise !== 'undefined') {
+      it('should be called after DOM update in correct context, when using Promise syntax', done => {
+        const vm = new Vue({
+          template: '<div>{{ msg }}</div>',
+          data: {
+            msg: 'foo'
+          }
+        }).$mount()
+        vm.msg = 'bar'
+        vm.$nextTick().then(function (ctx) {
+          expect(ctx).toBe(vm)
+          expect(vm.$el.textContent).toBe('bar')
+          done()
+        })
+      })
+    }
   })
 })

--- a/test/unit/modules/util/next-tick.spec.js
+++ b/test/unit/modules/util/next-tick.spec.js
@@ -9,13 +9,7 @@ describe('nextTick', () => {
     expect(typeof nextTick(() => {})).toBe('undefined')
   })
 
-  if (typeof Promise === 'undefined') {
-    it('raises an error when provided no callback with no Promise support', () => {
-      spyOn(console, 'error')
-      nextTick()
-      expect(console.error).toHaveBeenCalledWith('Vue.nextTick requires a callback as its first argument or an environment that supports Promises')
-    })
-  } else {
+  if (typeof Promise !== 'undefined') {
     it('returns a Promise when provided no callback', done => {
       nextTick().then(done)
     })

--- a/test/unit/modules/util/next-tick.spec.js
+++ b/test/unit/modules/util/next-tick.spec.js
@@ -1,0 +1,31 @@
+import { nextTick } from 'core/util/env'
+
+describe('nextTick', () => {
+  it('accepts a callback', done => {
+    nextTick(done)
+  })
+
+  it('returns undefined when passed a callback', () => {
+    expect(typeof nextTick(() => {})).toBe('undefined')
+  })
+
+  if (typeof Promise === 'undefined') {
+    it('raises an error when provided no callback with no Promise support', () => {
+      spyOn(console, 'error')
+      nextTick()
+      expect(console.error).toHaveBeenCalledWith('Vue.nextTick requires a callback as its first argument or an environment that supports Promises')
+    })
+  } else {
+    it('returns a Promise when provided no callback', done => {
+      nextTick().then(done)
+    })
+
+    it('returns a Promise with a context argument when provided a falsy callback and an object', done => {
+      const obj = {}
+      nextTick(undefined, obj).then(ctx => {
+        expect(ctx).toBe(obj)
+        done()
+      })
+    })
+  }
+})


### PR DESCRIPTION
This might seem like a very naive implementation, but I _think_ it should work as expected. When we pass a callback to `nextTick`, we just defer it (ideally to the microtask queue), with our preferred strategy being native promises. In cases where promises are polyfilled, it seems projects like Bluebird actually use [very similar scheduling fallbacks](https://github.com/petkaantonov/bluebird/blob/master/src/schedule.js) to `nextTick`, so we should see similar results.
