### PR TITLE
upgrade flow type to 0.33

### DIFF
--- a/flow/options.js
+++ b/flow/options.js
@@ -57,7 +57,8 @@ declare type ComponentOptions = {
   _propKeys?: Array<string>;
   _parentVnode?: VNode;
   _parentListeners?: ?Object;
-  _renderChildren?: ?VNodeChildren
+  _renderChildren?: ?VNodeChildren;
+  _componentTag: ?string;
 }
 
 declare type PropOptions = {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-loader": "^1.3.0",
     "eslint-plugin-flowtype": "^2.16.0",
     "eslint-plugin-html": "^1.5.2",
-    "flow-bin": "^0.32.0",
+    "flow-bin": "^0.33.0",
     "he": "^1.1.0",
     "http-server": "^0.9.0",
     "jasmine": "2.4.x",

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -53,9 +53,10 @@ function genElement (el: ASTElement): string {
     // component or element
     let code
     if (el.component) {
-      code = genComponent(el)
+      code = genComponent(el.component, el)
     } else {
-      const data = genData(el)
+      const data = el.plain ? undefined : genData(el)
+
       const children = el.inlineTemplate ? null : genChildren(el)
       code = `_h('${el.tag}'${
         data ? `,${data}` : '' // data
@@ -95,11 +96,7 @@ function genFor (el: any): string {
     '})'
 }
 
-function genData (el: ASTElement): string | void {
-  if (el.plain) {
-    return
-  }
-
+function genData (el: ASTElement): string {
   let data = '{'
 
   // directives first.
@@ -229,9 +226,10 @@ function genSlot (el: ASTElement): string {
     : `_t(${slotName})`
 }
 
-function genComponent (el: any): string {
+// componentName is el.component, take it as argument to shun flow's pessimistic refinement
+function genComponent (componentName, el): string {
   const children = el.inlineTemplate ? null : genChildren(el)
-  return `_h(${el.component},${genData(el)}${
+  return `_h(${componentName},${genData(el)}${
     children ? `,${children}` : ''
   })`
 }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -126,7 +126,7 @@ function assertProp (
  */
 function assertType (value: any, type: Function): {
   valid: boolean,
-  expectedType: string
+  expectedType: ?string
 } {
   let valid
   let expectedType = getType(type)


### PR DESCRIPTION
Upgrading flow finds several typing issues (largely due to flow limitation) in compiler.

The first modification is to change `genData` to always return `string`, this requires extracting `plain` ASTElement out.

The second modification is to ensure `el.component` presents when called with `genComponent`. The checker does not flow type refinement information to function call. So we need a new parameter for the information.

Remaining modifications are solely at type level.
