### PR TITLE
Typo fix: optimizier -> optimizer

### DIFF
--- a/src/compiler/optimizer.js
+++ b/src/compiler/optimizer.js
@@ -8,7 +8,7 @@ let isPlatformReservedTag
 const genStaticKeysCached = cached(genStaticKeys)
 
 /**
- * Goal of the optimizier: walk the generated template AST tree
+ * Goal of the optimizer: walk the generated template AST tree
  * and detect sub-trees that are purely static, i.e. parts of
  * the DOM that never needs to change.
  *


### PR DESCRIPTION
Fixed the spelling error of optimizier to optimizer in compiler src. 