### PR TITLE
Allow tag selectors in render functions

### DIFF
--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -4,7 +4,7 @@ import VNode, { emptyVNode } from './vnode'
 import config from '../config'
 import { createComponent } from './create-component'
 import { normalizeChildren } from './helpers/index'
-import { warn, resolveAsset } from '../util/index'
+import { warn, resolveAsset, toArray } from '../util/index'
 
 // wrapper function for providing a more flexible interface
 // without getting yelled at by flow
@@ -13,6 +13,73 @@ export function createElement (
   data: any,
   children: any
 ): VNode | void {
+  var len = arguments.length
+  var str = typeof tag === 'string'
+  var yes
+
+  // check for enhanced render arguments
+  if (len > 3 || tag === '' || (str && (tag.charAt(0) === '.' || tag.match(/[.@!]/)))) {
+    yes = 1
+  } else if (str && len > 1) {
+    var end = arguments[len - 1]
+    var aos = Array.isArray(end) || typeof end === 'string'
+    if (!(len === 2 && aos)) {
+      var uno = data === undefined || data === null || typeof data === 'object' && data.constructor.name === 'Object'
+      yes = !((len === 2 && uno) || (len === 3 && uno && aos))
+    }
+  }
+
+  // process enhanced render arguments
+  if (yes) {
+    var raw
+    var ary = toArray(arguments)
+    var cls = []
+    var id
+
+    // check for tag, class, id, and trailing "!" (unsafe HTML)
+    tag = ary.shift()
+    if (str) {
+      len = tag.length
+      if (tag.charAt(len - 1) === '!') {
+        raw = true
+        tag = tag.slice(0, len - 1)
+      }
+
+      // check for tag, class, and id values
+      var all = tag.split(/([.@])/)
+      tag = all[0] || 'div'
+      len = all.length
+      for (var pos = 0; ++pos < len;) {
+        if (all[pos++].charAt(0) === '.') {
+          cls.push(all[pos])
+        } else {
+          id = all[pos]
+        }
+      }
+    }
+
+    // process obj
+    var obj = ary.shift()
+    str = obj != null ? obj.constructor.name : null
+    if (str === 'Number' || str === 'Boolean') {
+      if (!obj) return
+      obj = undefined
+    } else if (str !== 'Object') {
+      ary.unshift(obj)
+      obj = undefined
+    }
+
+    if (cls || id || raw) {
+      if (!obj) obj = {}
+      if (cls) obj.staticClass = cls.join(' ')
+      if (id) obj.attrs = { id: id }
+      if (raw) obj.domProps = { innerHTML: ary.shift() }
+    }
+
+    // invoke virtual dom
+    return _createElement(this._self, tag, obj, ary)
+  }
+
   if (data && (Array.isArray(data) || typeof data !== 'object')) {
     children = data
     data = undefined

--- a/test/unit/features/component/component.spec.js
+++ b/test/unit/features/component/component.spec.js
@@ -104,11 +104,11 @@ describe('Component', () => {
     vm.view = 'view-b'
     waitForUpdate(() => {
       expect(vm.$el.outerHTML).toBe('<div view="view-b">bar</div>')
-      vm.view = ''
+      vm.view = undefined
     })
     .then(() => {
       expect(vm.$el.nodeType).toBe(8)
-      expect(vm.$el.data).toBe('')
+      expect(vm.$el.outerHTML).toBeUndefined()
     }).then(done)
   })
 

--- a/test/unit/features/component/component.spec.js
+++ b/test/unit/features/component/component.spec.js
@@ -108,7 +108,7 @@ describe('Component', () => {
     })
     .then(() => {
       expect(vm.$el.nodeType).toBe(8)
-      expect(vm.$el.outerHTML).toBeUndefined()
+      expect(vm.$el.data).toBe('')
     }).then(done)
   })
 

--- a/test/unit/features/ref.spec.js
+++ b/test/unit/features/ref.spec.js
@@ -82,7 +82,7 @@ describe('ref', () => {
     vm.test = 'test2'
     waitForUpdate(() => {
       expect(vm.$refs.test.$options.id).toBe('test2')
-      vm.test = ''
+      vm.test = undefined
     }).then(() => {
       expect(vm.$refs.test).toBeUndefined()
     }).then(done)


### PR DESCRIPTION
This allows tags such as `section.active.admin@intro`, which would yield `<section class='active admin' id='intro'>`.

Allowing these types of selectors, when used in combination with another tiny enhancement (https://github.com/shreeve/coffeescript/pull/1) to `CoffeeScript` allows us to write native `CoffeeScript` that looks a lot like `JSX`, but is actually full fledged `CoffeeScript`. Here's an example of something we're working on (a work in progress, but coming along!):

![conversation coffee lite 2016-10-22 23-08-41](https://cloud.githubusercontent.com/assets/142875/19623874/7fd0582a-98ac-11e6-9f33-1ca8512df786.png)
