### PR TITLE
Check and warn for falsy class name (fixes #4050)

### DIFF
--- a/src/platforms/web/runtime/class-util.js
+++ b/src/platforms/web/runtime/class-util.js
@@ -1,10 +1,17 @@
 /* @flow */
 
+import { warn } from 'core/util/index'
+
 /**
  * Add class with compatibility for SVG since classList is not supported on
  * SVG elements in IE
  */
-export function addClass (el: Element, cls: string) {
+export function addClass (el: Element, cls: ?string) {
+  if (!cls || cls.trim() === '') {
+    process.env.NODE_ENV !== 'production' && warn('Ignoring empty class name.')
+    return
+  }
+
   /* istanbul ignore else */
   if (el.classList) {
     if (cls.indexOf(' ') > -1) {
@@ -24,7 +31,12 @@ export function addClass (el: Element, cls: string) {
  * Remove class with compatibility for SVG since classList is not supported on
  * SVG elements in IE
  */
-export function removeClass (el: Element, cls: string) {
+export function removeClass (el: Element, cls: ?string) {
+  if (!cls || cls.trim() === '') {
+    process.env.NODE_ENV !== 'production' && warn('Ignoring empty class name.')
+    return
+  }
+
   /* istanbul ignore else */
   if (el.classList) {
     if (cls.indexOf(' ') > -1) {


### PR DESCRIPTION
This commit adds a check for falsy names (null or empty string) before attempting to add or remove them, to prevent a DOM exception. A warning will also be triggered if in development env.
