### PR TITLE
introduce a warning with misusage binding in dev mode

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -367,7 +367,7 @@ function processAttrs (el) {
       }
       if (bindRE.test(name)) { // v-bind
         if (process.env.NODE_ENV !== 'production') {
-          checkVBindingVal(name, value)
+          checkVBindingVal(rawName, value)
         }
         name = name.replace(bindRE, '')
         if (modifiers && modifiers.prop) {

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -416,7 +416,7 @@ function processAttrs (el) {
   }
 }
 
-function checkVBindingVal (name, value) {
+function checkVBindingVal (name: string, value: string): void {
   let func
 
   // there may be template error, leave it to the compiler detectErrors

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -280,6 +280,11 @@ describe('parser', () => {
     expect(ast.props[0].value).toBe('msg')
   })
 
+  it('warn v-bind with literal', () => {
+    parse('<my-component :value="{}"></my-component>', baseOptions)
+    expect('You are using v-bind with literal').toHaveBeenWarned()
+  })
+
   it('attribute with v-on', () => {
     const ast = parse('<input type="text" name="field1" :value="msg" @input="onInput">', baseOptions)
     expect(ast.events.input.value).toBe('onInput')


### PR DESCRIPTION
As discused in #4060 , we could introduce a warning in dev mode for v-bind with literal to avoid unnessary rendering. 