### PR TITLE
Add main tag to commonTagRE

### DIFF
--- a/src/util/component.js
+++ b/src/util/component.js
@@ -2,7 +2,7 @@ import { warn } from './debug'
 import { resolveAsset } from './options'
 import { getBindAttr } from './dom'
 
-export const commonTagRE = /^(div|p|span|img|a|b|i|br|ul|ol|li|h1|h2|h3|h4|h5|h6|code|pre|table|th|td|tr|form|label|input|select|option|nav|article|section|header|footer)$/i
+export const commonTagRE = /^(div|p|span|img|a|b|i|br|ul|ol|li|h1|h2|h3|h4|h5|h6|code|pre|table|th|td|tr|form|label|input|select|option|nav|article|section|header|footer|main)$/i
 export const reservedTagRE = /^(slot|partial|component)$/i
 
 let isUnknownElement


### PR DESCRIPTION
Due to project requirements and deadlines, we're unable to upgrade to Vue 2.0. I'm backporting this change from v2.0. A `<main>` tag is being flagged as a component and causing this error. 

`[Vue warn]: Unknown custom element: <main> - did you register the component correctly? For recursive components, make sure to provide the "name" option.`

