### PR TITLE
Support custom blocks in SFC parser

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -142,6 +142,16 @@ declare type SFCDescriptor = {
   template: ?SFCBlock;
   script: ?SFCBlock;
   styles: Array<SFCBlock>;
+  customBlocks: Array<SFCCustomBlock>;
+}
+
+declare type SFCCustomBlock = {
+  type: string;
+  content: string;
+  start?: number;
+  end?: number;
+  src?: string;
+  attrs: {[attribute:string]: string};
 }
 
 declare type SFCBlock = {

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -77,4 +77,50 @@ describe('Single File Component parser', () => {
     `)
     expect(res.template.content.trim()).toBe(`div\n  h1(v-if='1 < 2') hello`)
   })
+
+  it('should handle custom blocks without without parsing them', () => {
+    const res = parseComponent(`
+      <template>
+        <div></div>
+      </template>
+      <example name="simple">
+        <my-button ref="button">Hello</my-button>
+      </example>
+      <example name="with props">
+        <my-button color="red">Hello</my-button>
+      </example>
+      <test name="simple" foo="bar">
+      export default function simple (vm) {
+        describe('Hello', () => {
+          it('should display Hello', () => {
+            this.vm.$refs.button.$el.innerText.should.equal('Hello')
+          }))
+        }))
+      }
+      </test>
+    `)
+    expect(res.customBlocks.length).toBe(3)
+
+    const simpleExample = res.customBlocks[0]
+    expect(simpleExample.type).toBe('example')
+    expect(simpleExample.content.trim()).toBe('<my-button ref="button">Hello</my-button>')
+    expect(simpleExample.attrs.name).toBe('simple')
+
+    const withProps = res.customBlocks[1]
+    expect(withProps.type).toBe('example')
+    expect(withProps.content.trim()).toBe('<my-button color="red">Hello</my-button>')
+    expect(withProps.attrs.name).toBe('with props')
+
+    const simpleTest = res.customBlocks[2]
+    expect(simpleTest.type).toBe('test')
+    expect(simpleTest.content.trim()).toBe(`export default function simple (vm) {
+  describe('Hello', () => {
+    it('should display Hello', () => {
+      this.vm.$refs.button.$el.innerText.should.equal('Hello')
+    }))
+  }))
+}`)
+    expect(simpleTest.attrs.name).toBe('simple')
+    expect(simpleTest.attrs.foo).toBe('bar')
+  })
 })


### PR DESCRIPTION
The approach is simple and experimental. Worth discussing

This allow to use other block appart from `template`, `script` or
`style` in the SFC parser. This allows such things as writing tests or
examples directly into the SFC file. Those are meant to be handled by
programs others than vue-loader like vue-play.

an usage example could be:

```vue
<example name="simple">
  <my-button some-prop="red">Hello</my-button>
</example>
```

custom playground. The content wouldn't be parsed by the SFC parser. Its third parties' programs responsibility to do so
```vue
<play name="simple">
  <template>
    <my-button @click.native="increment">Hello</my-button>
  </template>
  <script>
    export default {
      data () { return { count: 0 }},
      methods: {
        increment () { this.count++ }
      }
    }
  </script>
</play>

<!-- src hasn't be added yet -->
<play src="./MyButton.play"></play>
```