### PR TITLE
data/store to normal object

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -41,6 +41,9 @@ export class Observer {
     this.dep = new Dep()
     this.vmCount = 0
     def(value, '__ob__', this)
+    def(value, 'normalize', function(){
+      return JSON.parse(JSON.stringify(this))
+    })
     if (Array.isArray(value)) {
       const augment = hasProto
         ? protoAugment

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -38,6 +38,19 @@ describe('Observer', () => {
     const ob2 = observe(obj)
     expect(ob2).toBe(ob1)
   })
+  
+  it('normalize', () => {
+    // on object
+    const obj = {
+      a: {},
+      b: {}
+    }
+    const ob1 = observe(obj)
+    expect(typeof obj.normalize).toBe('function')
+    expect(obj.__ob__ instanceof Observer).toBe(true)
+    expect(obj.normalize().__ob__).toBeUndefined()
+    expect(obj.normalize().a).toEqual(ob1.value.a)
+  })
 
   it('create on null', () => {
     // on null


### PR DESCRIPTION
Hello i work on a project with vue.js.
But sometimes i need the raw data.
Actually same problem with this issue; [How to convert the object of Vue to normal object?
](https://github.com/vuejs/Discussion/issues/292)

```javascript
JSON.parse(JSON.stringify(vm.$data))
```
this solution is great but if you need it more than few times it's uncomfortable. so i wrote normalize; 
```javascript
/** vue */
vm.$data.normalize(); // return to normal object

/** vuex */
this.$store.state.normalize(); // return to normal object
```
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

