### PR TITLE
Fix v-move class when name isn't specified

### DIFF
--- a/src/platforms/web/runtime/components/transition-group.js
+++ b/src/platforms/web/runtime/components/transition-group.js
@@ -89,7 +89,7 @@ export default {
 
   updated () {
     const children = this.prevChildren
-    const moveClass = this.moveClass || (this.name + '-move')
+    const moveClass = this.moveClass || ((this.name || 'v') + '-move')
     if (!children.length || !this.hasMove(children[0].elm, moveClass)) {
       return
     }


### PR DESCRIPTION
If `name` isn't specified for a `<transition-group>`, then the class name vue uses for moving items will be `undefined-move` instead of `v-move`.