### PR TITLE
Add missing lifecycle definition

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -32,6 +32,8 @@ export interface ComponentOptions<V extends Vue> {
   mounted?(this: V): void;
   beforeUpdate?(this: V): void;
   updated?(this: V): void;
+  activated?(this: V): void;
+  deactivated?(this: V): void;
 
   directives?: { [key: string]: DirectiveOptions | DirectiveFunction };
   components?: { [key: string]: Component | AsyncComponent };

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -123,6 +123,8 @@ Vue.component('component', {
   mounted() {},
   beforeUpdate() {},
   updated() {},
+  activated() {},
+  deactivated() {},
 
   directives: {
     a: {


### PR DESCRIPTION
We forget about activated/deactivated in keep-alive component :scream:  @ktsn @kaorun343 

Adding two optional fields are compatible to older typing API, so this is not a breaking change.