### PR TITLE
Fix the type of VNodeComponentOptions.Ctor

### DIFF
--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -24,7 +24,7 @@ export interface VNode {
 }
 
 export interface VNodeComponentOptions {
-  Ctor: Vue;
+  Ctor: typeof Vue;
   propsData?: Object;
   listeners?: Object;
   children?: VNodeChildren;


### PR DESCRIPTION
As `Ctor` is actually a constructor, its type should be `typeof Vue`.