### PR TITLE
Replace special terminators chars in attrs

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -363,7 +363,8 @@ function processAttrs (el) {
   let i, l, name, rawName, value, arg, modifiers, isProp
   for (i = 0, l = list.length; i < l; i++) {
     name = rawName = list[i].name
-    value = list[i].value
+    // #4268 Use an ecmascript valid lf character
+    value = list[i].value.replace(specialNewlineRE, '\n')
     if (dirRE.test(name)) {
       // mark element as dynamic
       el.hasBindings = true


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Fix #4268
Related to #3903
I just applied the same strategy as @defcc to make it work for the moment but there's a difference here:

Using the U+2028 character in a title actually makes the title to wrap: http://jsfiddle.net/posva/rjzbxgea/
So instead of eliminating it, I'm replacing it with another newline