### PR TITLE
Avoid to drop scope id by applying global mixin

### DIFF
--- a/src/core/instance/init.js
+++ b/src/core/instance/init.js
@@ -72,6 +72,7 @@ export function resolveConstructorOptions (Ctor: Class<Component>) {
       Ctor.superOptions = superOptions
       extendOptions.render = options.render
       extendOptions.staticRenderFns = options.staticRenderFns
+      extendOptions._scopeId = options._scopeId
       options = Ctor.options = mergeOptions(superOptions, extendOptions)
       if (options.name) {
         options.components[options.name] = Ctor

--- a/test/unit/features/global-api/mixin.spec.js
+++ b/test/unit/features/global-api/mixin.spec.js
@@ -70,4 +70,18 @@ describe('Global API: mixin', () => {
 
     expect(vm.$el.textContent).toBe('hello')
   })
+
+  // #4266
+  it('should not drop scopedId', () => {
+    const Test = Vue.extend({})
+    Test.options._scopeId = 'foo'
+
+    Vue.mixin({})
+
+    const vm = new Test({
+      template: '<div><p>hi<p></div>'
+    }).$mount()
+
+    expect(vm.$el.children[0].hasAttribute('foo')).toBe(true)
+  })
 })


### PR DESCRIPTION
Fix #4266

This PR fixes the problem that `_scopeId` will be dropped after applying global mixin.
reproduction: https://jsfiddle.net/tutjybnv/

Looks like same problem as vuejs/vue-loader#433