### PR TITLE
Fix nested templates in SFC

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -92,7 +92,7 @@ export function parseHTML (html, options) {
   let last, lastTag
   while (html) {
     last = html
-    // Make sure we're not in a specia tag
+    // Make sure we're not in a special tag
     if (!lastTag || !isSpecialTag(lastTag, options.sfc, stack, depth)) {
       let textEnd = html.indexOf('<')
       if (textEnd === 0) {

--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -85,7 +85,8 @@ export function parseComponent (
   }
 
   function end (tag: string, start: number, end: number) {
-    if (depth === 1 && currentBlock) {
+    depth--
+    if (depth === 0 && currentBlock) {
       currentBlock.end = start
       let text = deindent(content.slice(currentBlock.start, currentBlock.end))
       // pad content so that linters and pre-processors can output correct
@@ -96,7 +97,6 @@ export function parseComponent (
       currentBlock.content = text
       currentBlock = null
     }
-    depth--
   }
 
   function padContent (block: SFCBlock | SFCCustomBlock) {

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -123,4 +123,16 @@ describe('Single File Component parser', () => {
     expect(simpleTest.attrs.name).toBe('simple')
     expect(simpleTest.attrs.foo).toBe('bar')
   })
+
+  // Regression #4289
+  it('accepts nested template tag', () => {
+    const res = parseComponent(`
+      <template>
+        <div>
+          <template>hello</template>
+        </div>
+      </template>
+    `)
+    expect(res.template.content.trim()).toBe('<div>\n  <template>hello</template>\n</div>')
+  })
 })


### PR DESCRIPTION
If a tag was nested inside a template it would cause the initial block to be considered ended

- Check depth is 0 when checking special tag in SFC
- Moved depth decrement on SFC parser to make use clearer
- Updated tests to ensure regression is covered


Edit: See below comment