### PR TITLE
Add some functions related to render

### DIFF
--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -47,6 +47,23 @@ class Test extends Vue {
     });
     this.$nextTick().then(() => {});
     this.$createElement("div", {}, "message");
+
+    this._h('div', 'Hello world.')
+    this._s(true)
+    this._n('10')
+    this._e()
+    this._q(true, false)
+    this._i([true], true)
+    this._m(1, false)
+    this._o(this._e(), 0, 'key')
+    this._o([this._e()], 0, 'key')[0]
+    this._f('filter')
+    this._l(['hello'], (val) => this._h('div', val))
+    this._l(10, (val) => this._h('div', this._s(val)))
+    this._l({a: '0', b: '1'} as { [key: string]: string }, (v, k, i) => this._h('div', `${k}: ${v}`))
+    this._t('child', [this._e()], {})
+    this._b({}, 'key', {}, true)
+    this._k('enter')
   }
 
   static testConfig() {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -38,7 +38,7 @@ export declare class Vue {
   readonly $parent: Vue;
   readonly $root: Vue;
   readonly $children: Vue[];
-  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[]};
+  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[] };
   readonly $slots: { [key: string]: VNode[] };
   readonly $scopedSlots: { [key: string]: ScopedSlot };
   readonly $isServer: boolean;
@@ -60,6 +60,47 @@ export declare class Vue {
   $nextTick(callback: (this: this) => void): void;
   $nextTick(): Promise<void>;
   $createElement: CreateElement;
+
+  /** shorthands used in render functions */
+  _h: CreateElement;
+
+  /** toString for mustaches */
+  _s(val: any): string;
+
+  /** number conversion */
+  _n(val: string): number | string;
+
+  /** empty vnode */
+  _e(): VNode;
+
+  /** loose equal */
+  _q(a: any, b: any): boolean;
+
+  /** loose indexOf */
+  _i(arr: any[], val: any): number;
+
+  /** render static tree by index */
+  _m(index: number, isInFor?: boolean): VNode | VNode[];
+
+  /** mark node as static (v-once) */
+  _o<T extends (VNode | VNode[])>(tree: T, index: number, key: string): T;
+
+  /** filter resolution helper */
+  _f(id: string): Function;
+
+  /** render v-for */
+  _l<T>(val: T[], render: (val: T, index: number) => VNode): VNode[];
+  _l(val: number, render: (val: number, index: number) => VNode): VNode[];
+  _l<T>(val: { [key: string]: T }, render: (val: T, key: string, index: number) => VNode): VNode[];
+
+  /** renderSlot */
+  _t(name: string, fallback?: VNode[], props?: { [key: string]: any }): VNode[] | null;
+
+  /** apply v-bind object */
+  _b(data: any, tag: string, value: any, asProp?: boolean): VNodeData;
+
+  /** expose v-on keyCodes */
+  _k(key: string): any;
 
   static config: {
     silent: boolean;


### PR DESCRIPTION
Although these methods' prefix is `_`, using them are beneficial when writing `render`, I think.
So, I added them into the definitions.