### PR TITLE
Reference doc in component data function warning

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -77,7 +77,8 @@ function initData (vm: Component) {
   if (!isPlainObject(data)) {
     data = {}
     process.env.NODE_ENV !== 'production' && warn(
-      'data functions should return an object.',
+      'data functions should return an object:\n' +
+      'https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
       vm
     )
   }


### PR DESCRIPTION
The reason `data` has to be a function in components seems to be a point of confusion for many, so I've linked to an explanatory example in the warning.