### PR TITLE
Refactor version replacement

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -8,20 +8,6 @@ if (!fs.existsSync('dist')) {
   fs.mkdirSync('dist')
 }
 
-// Update main file
-const version = process.env.VERSION || require('../package.json').version
-const main = fs
-  .readFileSync('src/core/index.js', 'utf-8')
-  .replace(/Vue\.version = '[^']+'/, "Vue.version = '" + version + "'")
-fs.writeFileSync('src/core/index.js', main)
-
-// update weex subversion
-const weexVersion = process.env.WEEX_VERSION || require('../packages/weex-vue-framework/package.json').version
-const weexMain = fs
-  .readFileSync('src/entries/weex-framework.js', 'utf-8')
-  .replace(/Vue\.version = '[^']+'/, "Vue.version = '" + weexVersion + "'")
-fs.writeFileSync('src/entries/weex-framework.js', weexMain)
-
 let builds = require('./config').getAllBuilds()
 
 // filter builds via command line arg

--- a/build/config.js
+++ b/build/config.js
@@ -4,6 +4,7 @@ const buble = require('rollup-plugin-buble')
 const replace = require('rollup-plugin-replace')
 const alias = require('rollup-plugin-alias')
 const version = process.env.VERSION || require('../package.json').version
+const weexVersion = process.env.WEEX_VERSION || require('../packages/weex-vue-framework/package.json').version
 
 const banner =
   '/*!\n' +
@@ -103,7 +104,9 @@ function genConfig (opts) {
     moduleName: 'Vue',
     plugins: [
       replace({
-        __WEEX__: !!opts.weex
+        __WEEX__: !!opts.weex,
+        __WEEX_VERSION__: weexVersion,
+        __VERSION__: version
       }),
       flow(),
       buble(),

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -8,6 +8,6 @@ Object.defineProperty(Vue.prototype, '$isServer', {
   get: isServerRendering
 })
 
-Vue.version = '2.1.4'
+Vue.version = '__VERSION__'
 
 export default Vue

--- a/src/entries/weex-framework.js
+++ b/src/entries/weex-framework.js
@@ -1,7 +1,7 @@
 import Vue from 'weex/runtime/index'
 import renderer from 'weex/runtime/config'
 
-Vue.weexVersion = '2.0.5-weex.1'
+Vue.weexVersion = '__WEEX_VERSION__'
 export { Vue }
 
 const {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Use the rollup replace plugin to replace weexVersion and (Vue) version
inside the files.

I checked the built files and it looked fine but since I don't know how weex works, I'll like a second check @Jinjiang 🙏

edit: ~~I realised this approach doesn't work with the current release workflow~~ nvm, it uses the env variables