### PR TITLE
Add `parsePlatformTagName` config

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -12,6 +12,7 @@ export type Config = {
   keyCodes: { [key: string]: number };
   // platform
   isReservedTag: (x?: string) => boolean;
+  parsePlatformTagName: (x: string) => string;
   isUnknownElement: (x?: string) => boolean;
   getTagNamespace: (x?: string) => string | void;
   mustUseProp: (tag?: string, x?: string) => boolean;
@@ -68,6 +69,11 @@ const config: Config = {
    * Get the namespace of an element
    */
   getTagNamespace: noop,
+
+  /**
+   * Parse the real tag name for the specific platform.
+   */
+  parsePlatformTagName: (x: string): string => x,
 
   /**
    * Check if an attribute must be bound using property, e.g. value

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -61,7 +61,7 @@ export function _createElement (
     if (config.isReservedTag(tag)) {
       // platform built-in elements
       vnode = new VNode(
-        tag, data, children,
+        config.parsePlatformTagName(tag), data, children,
         undefined, undefined, context
       )
     } else if ((Ctor = resolveAsset(context.$options, 'components', tag))) {


### PR DESCRIPTION
 > As described in [How to implement the `<div>` component on the web](https://github.com/weexteam/weex-vue-framework/issues/12), this is a way to achieve solution 1.

### Notes

Add a global configuration function `parsePlatformTagName` to be able to parse the real tag name for the specific platform. It takes a string and return it directly by default.

This function should be used in conjunction with `isReservedTag`.

