### PR TITLE
More informative warning message for comp name (closes #4428)

### DIFF
--- a/src/core/global-api/extend.js
+++ b/src/core/global-api/extend.js
@@ -28,7 +28,8 @@ export function initExtend (Vue: GlobalAPI) {
       if (!/^[a-zA-Z][\w-]*$/.test(name)) {
         warn(
           'Invalid component name: "' + name + '". Component names ' +
-          'can only contain alphanumeric characaters and the hyphen.'
+          'can only contain alphanumeric characters and the hyphen, ' +
+          'and must start with a letter.'
         )
       }
     }

--- a/test/unit/features/options/name.spec.js
+++ b/test/unit/features/options/name.spec.js
@@ -15,7 +15,16 @@ describe('Options name', () => {
     })
 
     /* eslint-disable */
-    expect(`Invalid component name: "Hyper*Vue". Component names can only contain alphanumeric characaters and the hyphen.`)
+    expect(`Invalid component name: "Hyper*Vue". Component names can only contain alphanumeric characters and the hyphen, and must start with a letter.`)
+      .toHaveBeenWarned()
+    /* eslint-enable */
+
+    Vue.extend({
+      name: '2Cool2BValid'
+    })
+
+    /* eslint-disable */
+    expect(`Invalid component name: "2Cool2BValid". Component names can only contain alphanumeric characters and the hyphen, and must start with a letter.`)
       .toHaveBeenWarned()
     /* eslint-enable */
   })


### PR DESCRIPTION
This commit adds a more informative warning message for invalid component names. Also fixes a typo.