### PR TITLE
fixed error of can't read length of null when use broadcast and there no child component

### DIFF
--- a/src/instance/api/events.js
+++ b/src/instance/api/events.js
@@ -137,6 +137,7 @@ export default function (Vue) {
     // then there's no need to broadcast.
     if (!this._eventsCount[event]) return
     var children = this.$children
+    if (typeof children === null) return
     var args = toArray(arguments)
     if (isSource) {
       // use object event to indicate non-source emit


### PR DESCRIPTION
当子组件是空的时候，调用$broadcast会报can't read length of null错误
