### PR TITLE
Add missing string handler in v-for

### DIFF
--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -178,7 +178,7 @@ export function renderMixin (Vue: Class<Component>) {
     render: () => VNode
   ): ?Array<VNode> {
     let ret: ?Array<VNode>, i, l, keys, key
-    if (Array.isArray(val)) {
+    if (Array.isArray(val) || typeof val === 'string') {
       ret = new Array(val.length)
       for (i = 0, l = val.length; i < l; i++) {
         ret[i] = render(val[i], i)

--- a/test/unit/features/directives/for.spec.js
+++ b/test/unit/features/directives/for.spec.js
@@ -428,4 +428,22 @@ describe('Directive v-for', () => {
       expect(vm.$el.textContent).toMatch(/\s+foo\s+bar\s+/)
     }).then(done)
   })
+
+  it('strings', done => {
+    const vm = new Vue({
+      data: {
+        text: 'foo'
+      },
+      template: `
+        <div>
+          <span v-for="letter in text">{{ letter }}.</span
+        </div>
+      `
+    }).$mount()
+    expect(vm.$el.textContent).toMatch('f.o.o.')
+    vm.text += 'bar'
+    waitForUpdate(() => {
+      expect(vm.$el.textContent).toMatch('f.o.o.b.a.r.')
+    }).then(done)
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Fix #4497 

At first I added an else if at the end since strings are rarely used in v-for loops but it felt wrong not to reuse the first if