### PR TITLE
Support async component hydration in SSR

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -536,6 +536,9 @@ export function createPatchFunction (backend) {
         vnode.tag.indexOf('vue-component') === 0 ||
         vnode.tag.toLowerCase() === (node.tagName && node.tagName.toLowerCase())
       )
+    } else if (vnode.isAsyncPlaceholder) {
+      // skip checking if component hasn't been resolved
+      return true
     } else {
       return _toString(vnode.text) === node.data
     }

--- a/src/core/vdom/vnode.js
+++ b/src/core/vdom/vnode.js
@@ -19,6 +19,7 @@ export default class VNode {
   isComment: boolean; // empty comment placeholder?
   isCloned: boolean; // is a cloned node?
   isOnce: boolean; // is a v-once node?
+  isAsyncPlaceholder: boolean; // placeholder node for async component
 
   constructor (
     tag?: string,
@@ -54,6 +55,12 @@ export const createEmptyVNode = () => {
   const node = new VNode()
   node.text = ''
   node.isComment = true
+  return node
+}
+
+export const createAsyncPlaceholder = () => {
+  const node = createEmptyVNode()
+  node.isAsyncPlaceholder = true
   return node
 }
 

--- a/test/unit/modules/vdom/create-component.spec.js
+++ b/test/unit/modules/vdom/create-component.spec.js
@@ -61,7 +61,7 @@ describe('create-component', () => {
     }
     function go () {
       vnode = createComponent(async, data, vm, vm)
-      expect(vnode).toBeUndefined() // not to be loaded yet.
+      expect(vnode.isAsyncPlaceholder).toBe(true) // not to be loaded yet.
     }
     function loaded () {
       vnode = createComponent(async, data, vm, vm)
@@ -93,7 +93,7 @@ describe('create-component', () => {
     }
     function go () {
       vnode = createComponent(async, data, vm, vm)
-      expect(vnode).toBeUndefined() // not to be loaded yet.
+      expect(vnode.isAsyncPlaceholder).toBe(true) // not to be loaded yet.
     }
     function failed () {
       vnode = createComponent(async, data, vm, vm)


### PR DESCRIPTION
Fix #4387. Improve async component SSR performance by reducing bailing.

The basic idea here is, skip checking async component when hydration. To support this, I introduced a new flag on VNode `isAsyncPlaceholder`. A placeholder VNode is same as an emptyVNode, except the new flag set to true. Before this commit, an async component will be rendered to emptyVNode(in `createElement`). After this commit, an async component will be rendered to placeholderVNode. So the behavior in client-side rendering or bailed SSR rendering should be kept.

In SSR hydration, we skip checking a placeholder VNode against a real element. After component is resolved, the Vue instance in question will `$forceUpdate` in callback. So even if the real element dismatches with resolved VNode, rendered dom structure should be up to date. 

**Current implementation cannot reuse dom for async component because `isHydrating` is not available in `createComponent`.**

Another potential problem is that third party code can attach event handler / store data on SSR element. Those information will be lost in `$forceUpdate` callback. But I would suggest library users should care about it because I wonder if a library can provide a silver-bullet strategy.