### PR TITLE
Specify that tags with side-effects will not be parsed.

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -91,7 +91,7 @@ export function parse (
         process.env.NODE_ENV !== 'production' && warn(
           'Templates should only be responsible for mapping the state to the ' +
           'UI. Avoid placing tags with side-effects in your templates, such as ' +
-          `<${tag}>.`
+          `<${tag}>` + ', as they will not be parsed.'
         )
       }
 


### PR DESCRIPTION
Where I work, it's not uncommon to come across `<script>` tags in templates that would not be trivial to move into separate files. If Vue will prevent the execution of the contents of these tags, I think the warning should say so. As it is, it reads more like a recommendation than a requirement:

`Templates should only be responsible for mapping the state to the UI. Avoid placing tags with side-effects in your templates, such as <script>`. 

I don't know if the language I've added is best, but it's an example of text that tells the user they should not expect their code to run. Feel free to edit as desired.
