### PR TITLE
[wip] Error mapping option for server render bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "rollup-plugin-replace": "^1.1.0",
     "rollup-watch": "^2.5.0",
     "selenium-server": "2.53.1",
+    "source-map-stack": "^0.1.7",
     "typescript": "^2.0.9",
     "uglify-js": "^2.6.2",
     "webpack": "^1.13.2",

--- a/src/server/create-bundle-renderer.js
+++ b/src/server/create-bundle-renderer.js
@@ -4,6 +4,7 @@ import { PassThrough } from 'stream'
 export function createBundleRendererCreator (createRenderer) {
   return (code, rendererOptions) => {
     const renderer = createRenderer(rendererOptions)
+    const errorMapper = rendererOptions && rendererOptions.errorMapper
     return {
       renderToString: (context, cb) => {
         if (typeof context === 'function') {
@@ -11,19 +12,35 @@ export function createBundleRendererCreator (createRenderer) {
           context = {}
         }
         runInVm(code, context).then(app => {
-          renderer.renderToString(app, cb)
-        }).catch(cb)
+          renderer.renderToString(app, (err, html) => {
+            if (err && errorMapper) {
+              errorMapper(err)
+            }
+            cb(err, html)
+          })
+        }).catch(err => {
+          if (err && errorMapper) {
+            errorMapper(err)
+          }
+          cb(err)
+        })
       },
       renderToStream: (context) => {
         const res = new PassThrough()
         runInVm(code, context).then(app => {
           const renderStream = renderer.renderToStream(app)
           renderStream.on('error', err => {
+            if (errorMapper) {
+              errorMapper(err)
+            }
             res.emit('error', err)
           })
           renderStream.pipe(res)
         }).catch(err => {
           process.nextTick(() => {
+            if (errorMapper) {
+              errorMapper(err)
+            }
             res.emit('error', err)
           })
         })

--- a/test/ssr/fixtures/error-bundle.js
+++ b/test/ssr/fixtures/error-bundle.js
@@ -1,0 +1,5 @@
+export default context => {
+  return new Promise(resolve => {
+    require('./error')
+  })
+}


### PR DESCRIPTION
POC to improve mapping sourcemaps for better dev experience.

- Has to be contained to the initial error stack, if using the emitted error the stack trace will no longer map up casing an error.

- Todo: if accepted add documentation to use the feature to improve development experience of error traces