### PR TITLE
[weex] Expose version and config on subVue

### DIFF
--- a/src/entries/weex-framework.js
+++ b/src/entries/weex-framework.js
@@ -103,7 +103,7 @@ export function createInstance (
   subVue.options._base = subVue
 
   // expose global utility
-  ;['util', 'set', 'delete', 'nextTick'].forEach(name => {
+  ;['util', 'set', 'delete', 'nextTick', 'version', 'weexVersion', 'config'].forEach(name => {
     subVue[name] = Vue[name]
   })
 


### PR DESCRIPTION
In Weex, the `Vue` variable in each js bundle is generate by `Vue.extend({})` actually, and pass some global properties to it. But forget to expose the `version` and `config` on subVue.

I additionally exposed three props to subVue:

+ `version`
+ `weexVersion`
+ `config`

Some libs, such as `Vuex`, may relay on the `version` and `config`.