### PR TITLE
[EXPERIMENTAL] Try to really improve flowtype

### DIFF
--- a/src/compiler/codegen/events.js
+++ b/src/compiler/codegen/events.js
@@ -4,7 +4,7 @@ const fnExpRE = /^\s*([\w$_]+|\([^)]*?\))\s*=>|^function\s*\(/
 const simplePathRE = /^\s*[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\['.*?']|\[".*?"]|\[\d+]|\[[A-Za-z_$][\w$]*])*\s*$/
 
 // keyCode aliases
-const keyCodes = {
+const keyCodes: { [k: any]: number | [number, number] } = {
   esc: 27,
   tab: 9,
   enter: 13,
@@ -16,7 +16,7 @@ const keyCodes = {
   'delete': [8, 46]
 }
 
-const modifierCode = {
+const modifierCode: { [k: string]: string } = {
   stop: '$event.stopPropagation();',
   prevent: '$event.preventDefault();',
   self: 'if($event.target !== $event.currentTarget)return;',

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -5,10 +5,14 @@ import { baseWarn, pluckModuleFunction } from '../helpers'
 import baseDirectives from '../directives/index'
 import { camelize, no } from 'shared/util'
 
+type TransformFunction = (el: ASTElement, code: string) => string
+type DataGenFunction = (el: ASTElement) => string
+type DirctiveFunction = (el: ASTElement, dir: ASTDirective, warn: Function) => boolean
+
 // configurable state
 let warn
-let transforms
-let dataGenFns
+let transforms: Array<TransformFunction>
+let dataGenFns: Array<DataGenFunction>
 let platformDirectives
 let isPlatformReservedTag
 let staticRenderFns
@@ -225,7 +229,7 @@ function genDirectives (el: ASTElement): string | void {
   for (i = 0, l = dirs.length; i < l; i++) {
     dir = dirs[i]
     needRuntime = true
-    const gen = platformDirectives[dir.name] || baseDirectives[dir.name]
+    const gen: DirctiveFunction = platformDirectives[dir.name] || baseDirectives[dir.name]
     if (gen) {
       // compile-time directive that manipulates AST.
       // returns true if it also needs a runtime counterpart.
@@ -317,11 +321,11 @@ function getNormalizationType (children): number {
   return 0
 }
 
-function needsNormalization (el) {
+function needsNormalization (el: ASTElement) {
   return el.for || el.tag === 'template' || el.tag === 'slot'
 }
 
-function maybeComponent (el) {
+function maybeComponent (el: ASTElement) {
   return el.type === 1 && !isPlatformReservedTag(el.tag)
 }
 

--- a/src/compiler/directives/index.js
+++ b/src/compiler/directives/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import bind from './bind'
 import { noop } from 'shared/util'
 

--- a/src/compiler/helpers.js
+++ b/src/compiler/helpers.js
@@ -6,10 +6,10 @@ export function baseWarn (msg: string) {
   console.error(`[Vue parser]: ${msg}`)
 }
 
-export function pluckModuleFunction (
+export function pluckModuleFunction<F: Function> (
   modules: ?Array<Object>,
   key: string
-): Array<Function> {
+): Array<F> {
   return modules
     ? modules.map(m => m[key]).filter(_ => _)
     : []

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -104,7 +104,7 @@ function assertProp (
     }
     for (let i = 0; i < type.length && !valid; i++) {
       const assertedType = assertType(value, type[i])
-      expectedTypes.push(assertedType.expectedType)
+      expectedTypes.push(assertedType.expectedType || '')
       valid = assertedType.valid
     }
   }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -73,12 +73,12 @@ export function isPrimitive (value: any): boolean {
 /**
  * Create a cached version of a pure function.
  */
-export function cached (fn: Function): Function {
+export function cached<F: Function> (fn: F): F {
   const cache = Object.create(null)
-  return function cachedFn (str: string): any {
+  return (function cachedFn (str: string) {
     const hit = cache[str]
     return hit || (cache[str] = fn(str))
-  }
+  }: any)
 }
 
 /**


### PR DESCRIPTION
This is an experiment striving to fix #4410. The improvement is based on [CLI tool](https://flowtype.org/docs/cli.html#_). The following command is used to inspect source. 

```bash
flow coverage $TARGET.js --json | jq '.expressions .uncovered_locs[] .start .line'
```

Which prints out all the line number of potential unsound `any` type. Only files under `src/compiler/codegen/` are checked.

To my consternation, we have a lot of `implictAny` in code base, (and I have no idea why). Fixing these `any` needs some weird typing and dependency on how flow works (in my conjecture).

While I really appreciate @thejameskyle 's suggestion, I'm afraid maybe our team's capability does not match Flow's type system.

As the title indicates, this pull request is experimental, feel free to close it. 