### PR TITLE
Enforce to loop through children to get the correct normalize type (fix #4564)

### DIFF
--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -307,18 +307,20 @@ function genChildren (el: ASTElement, checkSkip?: boolean): string | void {
 // 1: simple normalization needed (possible 1-level deep nested array)
 // 2: full nomralization needed
 function getNormalizationType (children): number {
+  let res = 0
   for (let i = 0; i < children.length; i++) {
     const el: any = children[i]
     if (needsNormalization(el) ||
         (el.if && el.ifConditions.some(c => needsNormalization(c.block)))) {
-      return 2
+      res = 2
+      break
     }
     if (maybeComponent(el) ||
         (el.if && el.ifConditions.some(c => maybeComponent(c.block)))) {
-      return 1
+      res = 1
     }
   }
-  return 0
+  return res
 }
 
 function needsNormalization (el: ASTElement) {

--- a/test/unit/modules/compiler/codegen.spec.js
+++ b/test/unit/modules/compiler/codegen.spec.js
@@ -434,6 +434,14 @@ describe('codegen', () => {
     )
   })
 
+  it('generate component with v-for', () => {
+    // normalize type: 2
+    assertCodegen(
+      '<div><child></child><template v-for="item in list">{{ item }}</template></div>',
+      `with(this){return _c('div',[_c('child'),_l((list),function(item){return [_v(_s(item))]})],2)}`
+    )
+  })
+
   it('not specified ast type', () => {
     const res = generate(null, baseOptions)
     expect(res.render).toBe(`with(this){return _c("div")}`)


### PR DESCRIPTION
fix #4564 