### PR TITLE
[weex] Fix the text node could not be removed properly

### DIFF
--- a/src/platforms/weex/runtime/node-ops.js
+++ b/src/platforms/weex/runtime/node-ops.js
@@ -34,6 +34,10 @@ export function insertBefore (node, target, before) {
 }
 
 export function removeChild (node, child) {
+  if (node.nodeType === 3) {
+    node.parentNode.setAttr('value', '')
+    return
+  }
   node.removeChild(child)
 }
 


### PR DESCRIPTION
In Weex, the `TEXT_NODE` must be the child of `<text>`.

Added special treatment of `TEXT_NODE` in `removeChild`.