### PR TITLE
Small refactor for template parser

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -271,7 +271,7 @@ export function parseHTML (html, options) {
     if (end == null) end = index
 
     if (tagName) {
-      const lowerCasedTagName = tagName.toLowerCase()
+      lowerCasedTagName = tagName.toLowerCase()
     }
 
     // Find the closest opened tag of the same type

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -47,18 +47,6 @@ let IS_REGEX_CAPTURING_BROKEN = false
 
 // Special Elements (can contain anything)
 const isScriptOrStyle = makeMap('script,style', true)
-const hasLang = attr => attr.name === 'lang' && attr.value !== 'html'
-const isSpecialTag = (tag, isSFC, stack) => {
-  if (isScriptOrStyle(tag)) {
-    return true
-  }
-  return (isSFC &&
-    stack.length === 1 &&
-    tag === 'template' &&
-    stack[0].attrs.some(hasLang)
-  )
-}
-
 const reCache = {}
 
 const ltRE = /&lt;/g
@@ -87,7 +75,7 @@ export function parseHTML (html, options) {
   while (html) {
     last = html
     // Make sure we're not in a script or style element
-    if (!lastTag || !isSpecialTag(lastTag, options.sfc, stack)) {
+    if (!lastTag || !isScriptOrStyle(lastTag)) {
       let textEnd = html.indexOf('<')
       if (textEnd === 0) {
         // Comment:

--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -109,8 +109,7 @@ export function parseComponent (
 
   parseHTML(content, {
     start,
-    end,
-    sfc: true
+    end
   })
 
   return sfc


### PR DESCRIPTION
1. Remove the unnecessary argument of parseEndTag.
2. Store the lowerCasedTag in the stack and use it directly.
3. Remove isSpecialTag logic for simplification.

As for **isSpecialTag** logic, the original implementation checks the tagName and its attribute. If it's a **template** with **lang attribute**, it will skip to parse the content inside the template. I think maybe we could simplify it, because the template element is guaranteed by the SFC parser.

```js
const hasLang = attr => attr.name === 'lang' && attr.value !== 'html'
```
For this line, is it an edge case?  There is no proper test case about it, I am not very sure.

Please let me know if anything I missed.