### PR TITLE
[weex] fix the removeChild logic for text node

### DIFF
--- a/src/platforms/weex/runtime/node-ops.js
+++ b/src/platforms/weex/runtime/node-ops.js
@@ -34,8 +34,8 @@ export function insertBefore (node, target, before) {
 }
 
 export function removeChild (node, child) {
-  if (node.nodeType === 3) {
-    node.parentNode.setAttr('value', '')
+  if (child.nodeType === 3) {
+    node.setAttr('value', '')
     return
   }
   node.removeChild(child)


### PR DESCRIPTION
Fix #4046 . Should check the nodeType of child, not the node itself.
