### PR TITLE
Use ES2015 destructuring assignment to swap variables

### DIFF
--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -125,13 +125,11 @@ export default class Watcher {
         dep.removeSub(this)
       }
     }
-    let tmp = this.depIds
-    this.depIds = this.newDepIds
-    this.newDepIds = tmp
-    this.newDepIds.clear()
-    tmp = this.deps
-    this.deps = this.newDeps
-    this.newDeps = tmp
+    // $FlowFixMe
+    [this.depIds, this.newDepIds] = [this.newDepIds, this.depIds]
+    this.newDepIds.clear();
+    // $FlowFixMe
+    [this.deps, this.newDeps] = [this.newDeps, this.deps]
     this.newDeps.length = 0
   }
 


### PR DESCRIPTION
This commit uses ES2015 destructuring assignment to swap two variables instead of using a `tmp` var. Flow has an open issue (facebook/flow#183) with this feature, though, so `// $FlowFixMe` is used to temporarily suppress the error.