### PR TITLE
[weex] Use weex.requireModule instead of weex.require

### DIFF
--- a/src/entries/weex-framework.js
+++ b/src/entries/weex-framework.js
@@ -91,7 +91,7 @@ export function createInstance (
   const weexInstanceVar = {
     config,
     document,
-    require: moduleGetter
+    requireModule: moduleGetter
   }
   Object.freeze(weexInstanceVar)
 

--- a/src/entries/weex-framework.js
+++ b/src/entries/weex-framework.js
@@ -112,7 +112,7 @@ export function createInstance (
   const instanceVars = Object.assign({
     Vue: subVue,
     weex: weexInstanceVar,
-    __weex_require_module__: weexInstanceVar.require // deprecated
+    __weex_require_module__: weexInstanceVar.requireModule // deprecated
   }, timerAPIs)
   callFunction(instanceVars, appCode)
 


### PR DESCRIPTION
After a discussion, we feel the `weex.require` api is ambiguity, use `weex.requireModule` is more reliable.