### PR TITLE
fine-tuning of toNumber function

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -16,8 +16,8 @@ export function _toString (val: any): string {
  * If the conversion fails, return original string.
  */
 export function toNumber (val: string): number | string {
-  const n = parseFloat(val, 10)
-  return (n || n === 0) ? n : val
+  const n = parseFloat(val)
+  return isNaN(n) ? val : n
 }
 
 /**


### PR DESCRIPTION
1. parseFloat() support only one param, see MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat
2. maybe it's better to use isNaN() to judge the conversion result?

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
