### PR TITLE
Use shields.io compliant badge for SauceLabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
   <a href="https://codecov.io/github/vuejs/vue?branch=dev"><img src="https://img.shields.io/codecov/c/github/vuejs/vue/dev.svg" alt="Coverage Status"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/dt/vue.svg" alt="Downloads"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/v/vue.svg" alt="Version"></a>
-  <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/l/vue.svg" alt="License"></a>
+  <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/l/vue.svg" alt="License"></a> 
+  <br />
   <a href="https://saucelabs.com/u/vuejs"><img src="https://badges.herokuapp.com/sauce/vuejs" alt="Sauce Test Status"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/dt/vue.svg" alt="Downloads"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/v/vue.svg" alt="Version"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/l/vue.svg" alt="License"></a>
-  <br>
-  <a href="https://saucelabs.com/u/vuejs"><img src="https://saucelabs.com/browser-matrix/vuejs.svg" alt="Sauce Test Status"></a>
+  <a href="https://saucelabs.com/u/vuejs"><img src="https://badges.herokuapp.com/sauce/vuejs" alt="Sauce Test Status"></a>
 </p>
 
 ## Supporting Vue.js


### PR DESCRIPTION
Just a small change to make the readme nicer.

![image](https://cloud.githubusercontent.com/assets/5382443/21961170/cfe0f282-db02-11e6-8643-819304e5ce78.png)

(I'm pushing to master since this change affects only the readme file)