### PR TITLE
Remove dead link

### DIFF
--- a/examples/todomvc/readme.md
+++ b/examples/todomvc/readme.md
@@ -13,7 +13,6 @@ Here are some links you may find helpful:
 * [Official Guide](https://vuejs.org/guide/)
 * [API Reference](https://vuejs.org/api/)
 * [Examples](https://vuejs.org/examples/)
-* [Building Larger Apps with Vue.js](https://vuejs.org/guide/application.html)
 
 Get help from other Vue.js users:
 


### PR DESCRIPTION
"Building Larger Apps with Vue.js" is not in the 2.X documentation anymore. 

Alternatives:
- link to the original page: https://v1.vuejs.org/guide/application.html
- link to vue-cli, as the previous page suggests? https://github.com/vuejs/vue-cli

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
