### PR TITLE
[weex] Fix the memory crosstalk between multiple instance

### DIFF
--- a/src/core/observer/dep.js
+++ b/src/core/observer/dep.js
@@ -46,7 +46,7 @@ export default class Dep {
 // this is globally unique because there could be only one
 // watcher being evaluated at any time.
 Dep.target = null
-const targetStack = []
+let targetStack = []
 
 export function pushTarget (_target: Watcher) {
   if (Dep.target) targetStack.push(Dep.target)
@@ -55,4 +55,9 @@ export function pushTarget (_target: Watcher) {
 
 export function popTarget () {
   Dep.target = targetStack.pop()
+}
+
+export function resetTarget () {
+  Dep.target = null
+  targetStack = []
 }

--- a/src/core/observer/dep.js
+++ b/src/core/observer/dep.js
@@ -46,7 +46,7 @@ export default class Dep {
 // this is globally unique because there could be only one
 // watcher being evaluated at any time.
 Dep.target = null
-let targetStack = []
+const targetStack = []
 
 export function pushTarget (_target: Watcher) {
   if (Dep.target) targetStack.push(Dep.target)
@@ -59,5 +59,5 @@ export function popTarget () {
 
 export function resetTarget () {
   Dep.target = null
-  targetStack = []
+  targetStack.length = 0
 }

--- a/src/core/observer/scheduler.js
+++ b/src/core/observer/scheduler.js
@@ -19,7 +19,7 @@ let index = 0
 /**
  * Reset the scheduler's state.
  */
-function resetSchedulerState () {
+export function resetSchedulerState () {
   queue.length = 0
   has = {}
   if (process.env.NODE_ENV !== 'production') {

--- a/src/platforms/weex/framework.js
+++ b/src/platforms/weex/framework.js
@@ -1,5 +1,6 @@
 import Vue from 'weex/runtime/index'
 import renderer from 'weex/runtime/config'
+import { resetTarget } from 'core/observer/dep'
 
 Vue.weexVersion = '__WEEX_VERSION__'
 export { Vue }
@@ -63,6 +64,9 @@ export function createInstance (
   data,
   env = {}
 ) {
+  // reset the state of Dep.target
+  resetTarget()
+
   // Set active instance id and put some information into `instances` map.
   activeId = instanceId
 
@@ -126,6 +130,7 @@ export function createInstance (
  * @param {string} instanceId
  */
 export function destroyInstance (instanceId) {
+  resetTarget()
   const instance = instances[instanceId] || {}
   if (instance.app instanceof Vue) {
     instance.app.$destroy()

--- a/src/platforms/weex/framework.js
+++ b/src/platforms/weex/framework.js
@@ -1,6 +1,7 @@
 import Vue from 'weex/runtime/index'
 import renderer from 'weex/runtime/config'
 import { resetTarget } from 'core/observer/dep'
+import { resetSchedulerState } from 'core/observer/scheduler'
 
 Vue.weexVersion = '__WEEX_VERSION__'
 export { Vue }
@@ -67,6 +68,8 @@ export function createInstance (
   // reset the state of Dep.target
   resetTarget()
 
+  resetSchedulerState()
+
   // Set active instance id and put some information into `instances` map.
   activeId = instanceId
 
@@ -131,6 +134,7 @@ export function createInstance (
  */
 export function destroyInstance (instanceId) {
   resetTarget()
+  resetSchedulerState()
   const instance = instances[instanceId] || {}
   if (instance.app instanceof Vue) {
     instance.app.$destroy()


### PR DESCRIPTION
In Weex, all instance share a same runtime, the closure of `Dep`, `Scheduler` and so on, are also shared by multiple instance.

If the previous instance was crashed by accident, some shared variables might still remain the old value when creating the new instance.

## Modification

In particular, the following variables have the protential risk of memory crosstalk:

+ [`core/observer/dep.js`](https://github.com/vuejs/vue/blob/994aee4f869d68a00c3b9d87daa9c8d84623ac42/src/core/observer/dep.js#L48-L49)
  + `Dep.target`
  + `targetStack`
+ [`core/observer/scheduler.js`](https://github.com/vuejs/vue/blob/994aee4f869d68a00c3b9d87daa9c8d84623ac42/src/core/observer/scheduler.js#L12-L16)
  + `queue`
  + `has`
  + `circular`
  + `waiting`
  + `flushing`

The modification is simple: Just reset those variables to its initial value before `createInstance` and `destroyInstance`. (*Actually, reset the value in `createInstance` is enough, but do likewise in `destroyInstance` is more reliable*)

## Example

Here is an example:

```html
<template>
  <div class="list">
    <div class="group">
      <div class="panel" v-for="obj in lists">
        <text class="text">{{obj.name}}</text>
      </div>
    </div>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        lists: [
          { name: '1' },
          { name: '2' }
        ],
      }
    },
    mounted () {
      Vue.set(this.lists, 0, { name: 'A'})

      setTimeout(() => {
        Vue.delete(this.lists, 1)
        // this.lists.length--
      }, 1000)
    }
  }
</script>

<style scoped>
  .panel {
    width: 250px;
    height: 250px;
    flex-direction: column;
    justify-content: center;
    border-width: 2px;
    border-style: solid;
    border-color: rgb(162, 217, 192);
    background-color: rgba(162, 217, 192, 0.2);
  }
  .group {
    flex-direction: row;
    justify-content:space-between;
    width: 600px;
    margin-left: 75px;
    margin-top: 100px;
  }
  .text {
    font-size: 128px;
    text-align: center;
    color: #41B883;
  }
</style>
```

> Compile the code into js bundle by `weex-loader`, and run the code in Android or iOS device with WeexSDK would recurrence this bug.

The page will show `A` and `2` initially. After one second, the `Vue.delete` statement will occur an error, the call stack would be canceled, but right now, the `flushing` variable in scheduler is `true`.

Refresh the page (on native), will get `1` and `2`, which is not correct. Because the initial value of `flushing` is `true` in scheduler, the watcher of `lists` will never run.
