### PR TITLE
Be able to delete array item in `Vue.delete`

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -218,7 +218,11 @@ export function set (obj: Array<any> | Object, key: any, val: any) {
 /**
  * Delete a property and trigger change if necessary.
  */
-export function del (obj: Object, key: string) {
+export function del (obj: Array<any> | Object, key: any) {
+  if (Array.isArray(obj)) {
+    obj.splice(key, 1)
+    return
+  }
   const ob = obj.__ob__
   if (obj._isVue || (ob && ob.vmCount)) {
     process.env.NODE_ENV !== 'production' && warn(

--- a/test/unit/features/global-api/set-delete.spec.js
+++ b/test/unit/features/global-api/set-delete.spec.js
@@ -72,6 +72,7 @@ describe('Global API: set/delete', () => {
         expect(vm.$el.innerHTML).toBe('')
       }).then(done)
     })
+
     it('be able to delete an item in array', done => {
       const vm = new Vue({
         template: '<div><p v-for="obj in lists">{{obj.name}}</p></div>',
@@ -83,7 +84,6 @@ describe('Global API: set/delete', () => {
           ]
         }
       }).$mount()
-
       expect(vm.$el.innerHTML).toBe('<p>A</p><p>B</p><p>C</p>')
       Vue.delete(vm.lists, 1)
       waitForUpdate(() => {

--- a/test/unit/features/global-api/set-delete.spec.js
+++ b/test/unit/features/global-api/set-delete.spec.js
@@ -72,5 +72,29 @@ describe('Global API: set/delete', () => {
         expect(vm.$el.innerHTML).toBe('')
       }).then(done)
     })
+    it('be able to delete an item in array', done => {
+      const vm = new Vue({
+        template: '<div><p v-for="obj in lists">{{obj.name}}</p></div>',
+        data: {
+          lists: [
+            { name: 'A' },
+            { name: 'B' },
+            { name: 'C' }
+          ]
+        }
+      }).$mount()
+
+      expect(vm.$el.innerHTML).toBe('<p>A</p><p>B</p><p>C</p>')
+      Vue.delete(vm.lists, 1)
+      waitForUpdate(() => {
+        expect(vm.$el.innerHTML).toBe('<p>A</p><p>C</p>')
+        Vue.delete(vm.lists, 1)
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<p>A</p>')
+        Vue.delete(vm.lists, 0)
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('')
+      }).then(done)
+    })
   })
 })


### PR DESCRIPTION
Since the `Vue.set` support to insert an item to array, the `Vue.delete` should also support to delete an item from array.

Take the following code as an example:

```js
const vm = new Vue({
  template: '<div><span v-for="obj in lists">{{obj.name}}</span></div>',
  data: {
    lists: [
      { name: 'A' },
      { name: 'B' }
    ]
  }
}).$mount()

Vue.delete(vm.lists, 1)
// vm.lists.length--
```

The `Vue.delete(vm.lists, 1)` just delete the property `1` from the array, but the `vm.lists.length` is still be 2. Evaluating `obj.name` at the second time will caught a TypeError (undefined is not an object).