### PR TITLE
fix(sfc): component contains '<' only

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -120,13 +120,10 @@ export function parseHTML (html, options) {
           handleStartTag(startTagMatch)
           continue
         }
-
-        // < in plain text, treat it as text
-        advance(1)
       }
 
       let text, rest, next
-      if (textEnd > 0) {
+      if (textEnd >= 0) {
         rest = html.slice(textEnd)
         while (
           !endTag.test(rest) &&

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -120,6 +120,9 @@ export function parseHTML (html, options) {
           handleStartTag(startTagMatch)
           continue
         }
+
+        // < in plain text, treat it as text
+        advance(1)
       }
 
       let text, rest, next

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -78,6 +78,15 @@ describe('Single File Component parser', () => {
     expect(res.template.content.trim()).toBe(`div\n  h1(v-if='1 < 2') hello`)
   })
 
+  it('should handle component contains "<" only', () => {
+    const res = parseComponent(`
+      <template>
+        <span><</span>
+      </template>
+    `)
+    expect(res.template.content.trim()).toBe(`<span><</span>`)
+  })
+
   it('should handle custom blocks without parsing them', () => {
     const res = parseComponent(`
       <template>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

```vue
<template>
    <span><</span>
</template>
```

Vue will run into infinite loop with such component.
It's better to give some warning?