### PR TITLE
Remove warnings about inline value attributes for v-model

### DIFF
--- a/src/platforms/web/compiler/directives/model.js
+++ b/src/platforms/web/compiler/directives/model.js
@@ -159,23 +159,6 @@ function genDefaultModel (
   value: string,
   modifiers: ?ASTModifiers
 ): ?boolean {
-  if (process.env.NODE_ENV !== 'production') {
-    if (el.tag === 'input' && el.attrsMap.value) {
-      warn(
-        `<${el.tag} v-model="${value}" value="${el.attrsMap.value}">:\n` +
-        'inline value attributes will be ignored when using v-model. ' +
-        'Declare initial values in the component\'s data option instead.'
-      )
-    }
-    if (el.tag === 'textarea' && el.children.length) {
-      warn(
-        `<textarea v-model="${value}">:\n` +
-        'inline content inside <textarea> will be ignored when using v-model. ' +
-        'Declare initial values in the component\'s data option instead.'
-      )
-    }
-  }
-
   const type = el.attrsMap.type
   const { lazy, number, trim } = modifiers || {}
   const event = lazy || (isIE && type === 'range') ? 'change' : 'input'

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -204,30 +204,6 @@ describe('Directive v-model text', () => {
     })
   }
 
-  it('warn inline value attribute', () => {
-    const vm = new Vue({
-      data: {
-        test: 'foo'
-      },
-      template: '<input v-model="test" value="bar">'
-    }).$mount()
-    expect(vm.test).toBe('foo')
-    expect(vm.$el.value).toBe('foo')
-    expect('inline value attributes will be ignored').toHaveBeenWarned()
-  })
-
-  it('warn textarea inline content', function () {
-    const vm = new Vue({
-      data: {
-        test: 'foo'
-      },
-      template: '<textarea v-model="test">bar</textarea>'
-    }).$mount()
-    expect(vm.test).toBe('foo')
-    expect(vm.$el.value).toBe('foo')
-    expect('inline content inside <textarea> will be ignored').toHaveBeenWarned()
-  })
-
   it('warn invalid tag', () => {
     new Vue({
       data: {


### PR DESCRIPTION
This commit aims to close #4733, for the reason explained there.