### PR TITLE
Avoid double-decoding on attribute value

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -49,21 +49,17 @@ let IS_REGEX_CAPTURING_BROKEN = false
 const isScriptOrStyle = makeMap('script,style', true)
 const reCache = {}
 
-const ltRE = /&lt;/g
-const gtRE = /&gt;/g
-const nlRE = /&#10;/g
-const ampRE = /&amp;/g
-const quoteRE = /&quot;/g
+const decodingMap = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&amp;': '&',
+  '&#10;': '\n'
+}
 
 function decodeAttr (value, shouldDecodeNewlines) {
-  if (shouldDecodeNewlines) {
-    value = value.replace(nlRE, '\n')
-  }
-  return value
-    .replace(ltRE, '<')
-    .replace(gtRE, '>')
-    .replace(ampRE, '&')
-    .replace(quoteRE, '"')
+  const re = shouldDecodeNewlines ? /&(lt|gt|quot|amp|#10);/g : /&(lt|gt|quot|amp);/g
+  return value.replace(re, match => decodingMap[match])
 }
 
 export function parseHTML (html, options) {

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -56,9 +56,11 @@ const decodingMap = {
   '&amp;': '&',
   '&#10;': '\n'
 }
+const encodedAttr = /&(lt|gt|quot|amp);/g
+const encodedAttrWithNewLines = /&(lt|gt|quot|amp|#10);/g
 
 function decodeAttr (value, shouldDecodeNewlines) {
-  const re = shouldDecodeNewlines ? /&(lt|gt|quot|amp|#10);/g : /&(lt|gt|quot|amp);/g
+  const re = shouldDecodeNewlines ? encodedAttrWithNewLines : encodedAttr
   return value.replace(re, match => decodingMap[match])
 }
 


### PR DESCRIPTION
Chained `replace`s here may cause problems if the order isn't carefully arranged.Currently we get `"` after decoding `&amp;quot;` while `&quot;` is expected.

For a quick fix, I could move the `replace` which replaces `&amp;`s to the last.However, I prefer one single `replace` so that we don't bother with chaining order.

