### PR TITLE
add $props

### DIFF
--- a/flow/component.js
+++ b/flow/component.js
@@ -28,6 +28,7 @@ declare interface Component {
   $scopedSlots: { [key: string]: () => VNodeChildren };
   $vnode: VNode;
   $isServer: boolean;
+  $props: Object;
 
   // public methods
   $mount: (el?: Element | string, hydrating?: boolean) => Component;

--- a/flow/component.js
+++ b/flow/component.js
@@ -53,6 +53,7 @@ declare interface Component {
   _watcher: Watcher;
   _watchers: Array<Watcher>;
   _data: Object;
+  _props: Object;
   _events: Object;
   _inactive: boolean;
   _isMounted: boolean;

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -143,15 +143,17 @@ export function lifecycleMixin (Vue: Class<Component>) {
       if (process.env.NODE_ENV !== 'production') {
         observerState.isSettingProps = true
       }
+      const props = vm._props
       const propKeys = vm.$options._propKeys || []
       for (let i = 0; i < propKeys.length; i++) {
         const key = propKeys[i]
-        vm[key] = validateProp(key, vm.$options.props, propsData, vm)
+        props[key] = validateProp(key, vm.$options.props, propsData, vm)
       }
       observerState.shouldConvert = true
       if (process.env.NODE_ENV !== 'production') {
         observerState.isSettingProps = false
       }
+      // keep a copy of raw propsData
       vm.$options.propsData = propsData
     }
     // update listeners

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -54,8 +54,8 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
   }
   const def = prop.default
   // warn against non-factory defaults for Object & Array
-  if (isObject(def)) {
-    process.env.NODE_ENV !== 'production' && warn(
+  if (process.env.NODE_ENV !== 'production' && isObject(def)) {
+    warn(
       'Invalid default value for prop "' + key + '": ' +
       'Props with type Object/Array must use a factory function ' +
       'to return the default value.',
@@ -66,8 +66,8 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
   // return previous default value to avoid unnecessary watcher trigger
   if (vm && vm.$options.propsData &&
     vm.$options.propsData[key] === undefined &&
-    vm[key] !== undefined) {
-    return vm[key]
+    vm._props[key] !== undefined) {
+    return vm._props[key]
   }
   // call factory function for non-Function types
   return typeof def === 'function' && prop.type !== Function

--- a/test/unit/features/instance/properties.spec.js
+++ b/test/unit/features/instance/properties.spec.js
@@ -79,4 +79,21 @@ describe('Instance properties', () => {
     }).$mount()
     expect(calls).toEqual(['outer:undefined', 'middle:outer', 'inner:middle', 'next:undefined'])
   })
+
+  it('$props', () => {
+    var Comp = Vue.extend({
+      props: ['msg'],
+      template: '<div>{{ msg }}</div>'
+    })
+    var vm = new Comp({
+      propsData: {
+        msg: 'foo'
+      }
+    })
+    // check existence
+    expect(vm.$props.msg).toBe('foo')
+    // check change
+    Vue.set(vm, 'msg', 'bar')
+    expect(vm.$props.msg).toBe('bar')
+  })
 })

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -42,7 +42,7 @@ export declare class Vue {
   readonly $slots: { [key: string]: VNode[] };
   readonly $scopedSlots: { [key: string]: ScopedSlot };
   readonly $isServer: boolean;
-  $props: Object;
+  readonly $props: any;
 
   $mount(elementOrSelector?: Element | String, hydrating?: boolean): this;
   $forceUpdate(): void;

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -42,6 +42,7 @@ export declare class Vue {
   readonly $slots: { [key: string]: VNode[] };
   readonly $scopedSlots: { [key: string]: ScopedSlot };
   readonly $isServer: boolean;
+  $props: Object;
 
   $mount(elementOrSelector?: Element | String, hydrating?: boolean): this;
   $forceUpdate(): void;


### PR DESCRIPTION
I've implemented a `$props` special attribute on components to access its props because I thought the feature proposed in #4571 was great.
For this implementation, I rewritten `proxy` function in src/core/instance/state.js to general purpose one.
Thanks for the wonderful suggestion, @akryum!
