### PR TITLE
fix `addClass` utlil bug

### DIFF
--- a/src/platforms/web/runtime/class-util.js
+++ b/src/platforms/web/runtime/class-util.js
@@ -6,13 +6,12 @@
  */
 export function addClass (el: Element, cls: ?string) {
   /* istanbul ignore if */
-  if (!cls || !cls.trim()) {
+  if (!cls || !(cls = cls.trim())) {
     return
   }
 
   /* istanbul ignore else */
   if (el.classList) {
-    cls = cls.trim()
     if (cls.indexOf(' ') > -1) {
       cls.split(/\s+/).forEach(c => el.classList.add(c))
     } else {
@@ -32,7 +31,7 @@ export function addClass (el: Element, cls: ?string) {
  */
 export function removeClass (el: Element, cls: ?string) {
   /* istanbul ignore if */
-  if (!cls || !cls.trim()) {
+  if (!cls || !(cls = cls.trim())) {
     return
   }
 

--- a/src/platforms/web/runtime/class-util.js
+++ b/src/platforms/web/runtime/class-util.js
@@ -12,6 +12,7 @@ export function addClass (el: Element, cls: ?string) {
 
   /* istanbul ignore else */
   if (el.classList) {
+    cls = cls.trim()
     if (cls.indexOf(' ') > -1) {
       cls.split(/\s+/).forEach(c => el.classList.add(c))
     } else {

--- a/test/unit/features/transition/transition.spec.js
+++ b/test/unit/features/transition/transition.spec.js
@@ -73,7 +73,7 @@ if (!isIE9) {
               enter-to-class="hello-to"
               leave-class="bye"
               leave-to-class="bye-to"
-              leave-active-class="byebye active">
+              leave-active-class="byebye active more ">
               <div v-if="ok" class="test">foo</div>
             </transition>
           </div>
@@ -85,9 +85,9 @@ if (!isIE9) {
       expect(vm.$el.innerHTML).toBe('<div class="test">foo</div>')
       vm.ok = false
       waitForUpdate(() => {
-        expect(vm.$el.children[0].className).toBe('test bye byebye active')
+        expect(vm.$el.children[0].className).toBe('test bye byebye active more')
       }).thenWaitFor(nextFrame).then(() => {
-        expect(vm.$el.children[0].className).toBe('test byebye active bye-to')
+        expect(vm.$el.children[0].className).toBe('test byebye active more bye-to')
       }).thenWaitFor(duration + buffer).then(() => {
         expect(vm.$el.children.length).toBe(0)
         vm.ok = true


### PR DESCRIPTION
`<transition-group move-class=“ value with leading or trailing whitespace ” />`

reproduced:
http://output.jsbin.com/nijuhow/1