### PR TITLE
Standardize the JSFiddle starter link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Hi! I’m really excited that you are interested in contributing to Vue.js. Befo
 
 - Issues with no clear repro steps will not be triaged. If an issue labeled "need repro" receives no further input from the issue author for more than 5 days, it will be closed.
 
-- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](http://jsfiddle.net/df4Lnuw6/) that already includes the latest version of Vue.
+- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/z11fe07p/) that already includes the latest version of Vue.
 
 - For potential SSR (Server Side Rendering) issue or bugs that involves build setups, you can create a reproduction repository with steps in the README.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,7 +22,7 @@ Reporting a bug?
 
 - It is **required** that you clearly describe the steps necessary to reproduce the issue you are running into. Issues with no clear repro steps will not be triaged. If an issue labeled "need repro" receives no further input from the issue author for more than 5 days, it will be closed.
 
-- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](http://jsfiddle.net/5sH6A/) that already includes the latest version of Vue.
+- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/z11fe07p/) that already includes the latest version of Vue.
 
 - For potential SSR (Server Side Rendering) issue or bugs that involves build setups, you can create a reproduction repository with steps in the README.
 
@@ -39,7 +39,7 @@ Remove the template from below and provide thoughtful commentary *and code sampl
 
 ### Reproduction Link
 <!-- A minimal JSBin, JSFiddle, Codepen, or a GitHub repository that can reproduce the bug. -->
-<!-- You could start with this template: http://jsfiddle.net/df4Lnuw6/ -->
+<!-- You could start with this template: https://jsfiddle.net/z11fe07p/ -->
 
 ### Steps to reproduce
 


### PR DESCRIPTION
We have two different JSFiddle starter links here, none of which is the version on Gitter.im (which appears to be more aligned with Vue's coding standard i.e. no root `<body>` tag, spacings and such). Modifying this issue template to use the Gitter.im version instead.