### PR TITLE
Let userland remove the production tips info

### DIFF
--- a/src/entries/web-runtime.js
+++ b/src/entries/web-runtime.js
@@ -38,7 +38,10 @@ Vue.prototype.$mount = function (
 }
 
 if (process.env.NODE_ENV !== 'production' &&
-    inBrowser && typeof console !== 'undefined') {
+    inBrowser &&
+    typeof console !== 'undefined' &&
+    process.env.ADD_DEV_WARNING
+  ) {
   console[console.info ? 'info' : 'log'](
     `You are running Vue in development mode.\n` +
     `Make sure to turn on production mode when deploying for production.\n` +

--- a/src/entries/web-runtime.js
+++ b/src/entries/web-runtime.js
@@ -40,7 +40,7 @@ Vue.prototype.$mount = function (
 if (process.env.NODE_ENV !== 'production' &&
     inBrowser &&
     typeof console !== 'undefined' &&
-    !process.env.REMOVE_DEV_WARNING
+    !process.env.REMOVE_PROD_TIP
   ) {
   console[console.info ? 'info' : 'log'](
     `You are running Vue in development mode.\n` +

--- a/src/entries/web-runtime.js
+++ b/src/entries/web-runtime.js
@@ -40,7 +40,7 @@ Vue.prototype.$mount = function (
 if (process.env.NODE_ENV !== 'production' &&
     inBrowser &&
     typeof console !== 'undefined' &&
-    process.env.ADD_DEV_WARNING
+    !process.env.REMOVE_DEV_WARNING
   ) {
   console[console.info ? 'info' : 'log'](
     `You are running Vue in development mode.\n` +


### PR DESCRIPTION
Hi,

From the discussions here:

https://forum.vuejs.org/t/hide-notify-you-are-running-vue-in-development-mode/5661

and here:

https://github.com/vuejs/vue/commit/aa6f7b4cdb889fba9575710c5a100234ccfb7975

and because it also annoys me, I decided to try and set up a flag, which will allow a dev to "consciously" remove the production tips info. 

It is also related to (requires) this PR for the webpack template.

https://github.com/vuejs-templates/webpack/pull/510

The flag is currently set to "false", so the client dev will have to go into the file and set it to true, to remove the production tips info. 

If you let me know how to best document the availability of the flag (if the two PRs get accepted), I'd be also glad to add into about the flag to the docs too. 

Also, this currently only works for the webpack setup. I haven't looked into the other build possibilities. 

Scott
