### PR TITLE
Fix JSFiddle links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Hi! I’m really excited that you are interested in contributing to Vue.js. Befo
 
 - Issues with no clear repro steps will not be triaged. If an issue labeled "need repro" receives no further input from the issue author for more than 5 days, it will be closed.
 
-- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/z11fe07p/) that already includes the latest version of Vue.
+- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/39epgLj0/) that already includes the latest version of Vue.
 
 - For potential SSR (Server Side Rendering) issue or bugs that involves build setups, you can create a reproduction repository with steps in the README.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,7 +22,7 @@ Reporting a bug?
 
 - It is **required** that you clearly describe the steps necessary to reproduce the issue you are running into. Issues with no clear repro steps will not be triaged. If an issue labeled "need repro" receives no further input from the issue author for more than 5 days, it will be closed.
 
-- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/z11fe07p/) that already includes the latest version of Vue.
+- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/39epgLj0/) that already includes the latest version of Vue.
 
 - For potential SSR (Server Side Rendering) issue or bugs that involves build setups, you can create a reproduction repository with steps in the README.
 
@@ -39,7 +39,7 @@ Remove the template from below and provide thoughtful commentary *and code sampl
 
 ### Reproduction Link
 <!-- A minimal JSBin, JSFiddle, Codepen, or a GitHub repository that can reproduce the bug. -->
-<!-- You could start with this template: https://jsfiddle.net/z11fe07p/ -->
+<!-- You could start with this template: https://jsfiddle.net/39epgLj0/ -->
 
 ### Steps to reproduce
 


### PR DESCRIPTION
Use an inline script tag with unpkg to explicitly show what we're
including. It allows to easily test regressions by appending @2.x.x at
the end of the of the link.
It also allows to directly check if the repro is using the latest
version

Following #4890

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
