### PR TITLE
Fix filters parsing incorrectly because of missing spaces (fix #4881)

### DIFF
--- a/src/parsers/directive.js
+++ b/src/parsers/directive.js
@@ -115,9 +115,7 @@ function parseExpression () {
       if (chr === pipeChr) {
         next()
       } else {
-        if (state === startState || state === filterArgState) {
-          state = filterState
-        }
+        state = filterState
         break
       }
     } else if (chr === spaceChr && (state === filterNameState || state === filterArgState)) {
@@ -149,12 +147,15 @@ function parseFilter () {
   state = filterState
   filter.name = parseExpression().trim()
 
-  state = filterArgState
-  args = parseFilterArguments()
+  if (state === filterNameState) {
+    state = filterArgState
+    args = parseFilterArguments()
 
-  if (args.length) {
-    filter.args = args
+    if (args.length) {
+      filter.args = args
+    }
   }
+
   return filter
 }
 

--- a/test/unit/specs/parsers/directive_spec.js
+++ b/test/unit/specs/parsers/directive_spec.js
@@ -6,22 +6,46 @@ describe('Directive Parser', function () {
     expect(res.expression).toBe('exp')
   })
 
-  it('with filters', function () {
-    var res = parse('exp | abc de \'ok\' \'\' 123 | bcd')
-    expect(res.expression).toBe('exp')
-    expect(res.filters.length).toBe(2)
-    expect(res.filters[0].name).toBe('abc')
-    expect(res.filters[0].args.length).toBe(4)
-    expect(res.filters[0].args[0].value).toBe('de')
-    expect(res.filters[0].args[0].dynamic).toBe(true)
-    expect(res.filters[0].args[1].value).toBe('ok')
-    expect(res.filters[0].args[1].dynamic).toBe(false)
-    expect(res.filters[0].args[2].value).toBe('')
-    expect(res.filters[0].args[2].dynamic).toBe(false)
-    expect(res.filters[0].args[3].value).toBe(123)
-    expect(res.filters[0].args[3].dynamic).toBe(false)
-    expect(res.filters[1].name).toBe('bcd')
-    expect(res.filters[1].args).toBeUndefined()
+  describe('with filters', function () {
+    it('defined correctly', function () {
+      var res = parse('exp | abc de \'ok\' \'\' 123 | bcd')
+      expect(res.filters).toEqual([
+        {
+          name: 'abc',
+          args: [
+            { value: 'de', dynamic: true },
+            { value: 'ok', dynamic: false },
+            { value: '', dynamic: false },
+            { value: 123, dynamic: false }
+          ]
+        },
+        { name: 'bcd' }
+      ])
+    })
+
+    it('missing some spaces', function () {
+      var res = parse('exp|abc de \'ok\' \'\' 123|bcd')
+      expect(res.filters).toEqual([
+        {
+          name: 'abc',
+          args: [
+            { value: 'de', dynamic: true },
+            { value: 'ok', dynamic: false },
+            { value: '', dynamic: false },
+            { value: 123, dynamic: false }
+          ]
+        },
+        { name: 'bcd' }
+      ])
+    })
+
+    it('not containing spaces at all', function () {
+      var res = parse('exp|abc|bcd')
+      expect(res.filters).toEqual([
+        { name: 'abc' },
+        { name: 'bcd' }
+      ])
+    })
   })
 
   it('reserved filter args', function () {


### PR DESCRIPTION
Fixing parseFilter returning only the first filter of a chain in case of expression missing spaces.
See #4881