### PR TITLE
Pass attributes to parseComponent (addresses #4914)

### DIFF
--- a/packages/vue-template-compiler/build.js
+++ b/packages/vue-template-compiler/build.js
@@ -5822,6 +5822,16 @@ function parseComponent (
   var depth = 0;
   var currentBlock = null;
 
+  function reduceAttrs(attrs) {
+    return attrs.reduce(function (cumulated, ref) {
+      var name = ref.name;
+      var value = ref.value;
+
+      cumulated[name] = value;
+      return cumulated
+    }, Object.create(null));
+  }
+
   function start (
     tag,
     attrs,
@@ -5834,7 +5844,8 @@ function parseComponent (
         currentBlock = {
           type: tag,
           content: '',
-          start: end
+          start: end,
+          attrs: reduceAttrs(attrs)
         };
         checkAttrs(currentBlock, attrs);
         if (tag === 'style') {
@@ -5847,13 +5858,7 @@ function parseComponent (
           type: tag,
           content: '',
           start: end,
-          attrs: attrs.reduce(function (cumulated, ref) {
-            var name = ref.name;
-            var value = ref.value;
-
-            cumulated[name] = value;
-            return cumulated
-          }, Object.create(null))
+          attrs: reduceAttrs(attrs)
         };
         sfc.customBlocks.push(currentBlock);
       }

--- a/packages/vue-template-compiler/build.js
+++ b/packages/vue-template-compiler/build.js
@@ -5822,16 +5822,6 @@ function parseComponent (
   var depth = 0;
   var currentBlock = null;
 
-  function reduceAttrs(attrs) {
-    return attrs.reduce(function (cumulated, ref) {
-      var name = ref.name;
-      var value = ref.value;
-
-      cumulated[name] = value;
-      return cumulated
-    }, Object.create(null));
-  }
-
   function start (
     tag,
     attrs,
@@ -5844,8 +5834,7 @@ function parseComponent (
         currentBlock = {
           type: tag,
           content: '',
-          start: end,
-          attrs: reduceAttrs(attrs)
+          start: end
         };
         checkAttrs(currentBlock, attrs);
         if (tag === 'style') {
@@ -5858,7 +5847,13 @@ function parseComponent (
           type: tag,
           content: '',
           start: end,
-          attrs: reduceAttrs(attrs)
+          attrs: attrs.reduce(function (cumulated, ref) {
+            var name = ref.name;
+            var value = ref.value;
+
+            cumulated[name] = value;
+            return cumulated
+          }, Object.create(null))
         };
         sfc.customBlocks.push(currentBlock);
       }

--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -36,12 +36,16 @@ export function parseComponent (
     end: number
   ) {
     if (depth === 0) {
+      currentBlock = {
+        type: tag,
+        content: '',
+        start: end,
+        attrs: attrs.reduce((cumulated, { name, value }) => {
+          cumulated[name] = value || true
+          return cumulated
+        }, Object.create(null))
+      }
       if (isSpecialTag(tag)) {
-        currentBlock = {
-          type: tag,
-          content: '',
-          start: end
-        }
         checkAttrs(currentBlock, attrs)
         if (tag === 'style') {
           sfc.styles.push(currentBlock)
@@ -49,15 +53,6 @@ export function parseComponent (
           sfc[tag] = currentBlock
         }
       } else { // custom blocks
-        currentBlock = {
-          type: tag,
-          content: '',
-          start: end,
-          attrs: attrs.reduce((cumulated, { name, value }) => {
-            cumulated[name] = value
-            return cumulated
-          }, Object.create(null))
-        }
         sfc.customBlocks.push(currentBlock)
       }
     }

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -16,7 +16,7 @@ describe('Single File Component parser', () => {
       <style module>
         h1 { font-weight: bold }
       </style>
-      <style custom-attr></style>
+      <style bool-attr val-attr="test"></style>
       <script>
         export default {}
       </script>
@@ -31,7 +31,8 @@ describe('Single File Component parser', () => {
     expect(res.styles[1].scoped).toBe(true)
     expect(res.styles[1].content.trim()).toBe('h1\n  color red\nh2\n  color green')
     expect(res.styles[2].module).toBe(true)
-    expect(res.styles[3].attrs['custom-attr']).toBe(true)
+    expect(res.styles[3].attrs['bool-attr']).toBe(true)
+    expect(res.styles[3].attrs['val-attr']).toBe('test')
     expect(res.script.content.trim()).toBe('export default {}')
   })
 

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -16,6 +16,7 @@ describe('Single File Component parser', () => {
       <style module>
         h1 { font-weight: bold }
       </style>
+      <style custom-attr></style>
       <script>
         export default {}
       </script>
@@ -24,12 +25,13 @@ describe('Single File Component parser', () => {
       </div>
     `)
     expect(res.template.content.trim()).toBe('<div>hi</div>')
-    expect(res.styles.length).toBe(3)
+    expect(res.styles.length).toBe(4)
     expect(res.styles[0].src).toBe('./test.css')
     expect(res.styles[1].lang).toBe('stylus')
     expect(res.styles[1].scoped).toBe(true)
     expect(res.styles[1].content.trim()).toBe('h1\n  color red\nh2\n  color green')
     expect(res.styles[2].module).toBe(true)
+    expect(res.styles[3].attrs['custom-attr']).toBe(true)
     expect(res.script.content.trim()).toBe('export default {}')
   })
 


### PR DESCRIPTION
See #4914 

This PR passes attributes down to `parseComponent` so that build tools layered on top of `vue-template-compiler` can have access to that information without having to parse the src to retrieve it. 