### PR TITLE
fix #4872, use context agnostic Function constructor check

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -71,7 +71,7 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
   }
   // call factory function for non-Function types
   // a value is Function if its prototype is function even across different execution context
-  return typeof def === 'function' && (!prop.type || typeof prop.type.prototype !== 'function')
+  return typeof def === 'function' && getType(prop.type) === 'Function'
     ? def.call(vm)
     : def
 }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -71,7 +71,7 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
   }
   // call factory function for non-Function types
   // a value is Function if its prototype is function even across different execution context
-  return typeof def === 'function' && getType(prop.type) === 'Function'
+  return typeof def === 'function' && getType(prop.type) !== 'Function'
     ? def.call(vm)
     : def
 }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -70,7 +70,8 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
     return vm[key]
   }
   // call factory function for non-Function types
-  return typeof def === 'function' && prop.type !== Function
+  // a value is Function if its prototype is function even across different execution context
+  return typeof def === 'function' && (!prop.type || typeof prop.type.prototype !== 'function')
     ? def.call(vm)
     : def
 }

--- a/test/ssr/ssr-string.spec.js
+++ b/test/ssr/ssr-string.spec.js
@@ -1,4 +1,5 @@
 import Vue from '../../dist/vue.runtime.common.js'
+import VM from 'vm'
 import { createRenderer } from '../../packages/vue-server-renderer'
 const { renderToString } = createRenderer()
 
@@ -698,6 +699,23 @@ describe('SSR: renderToString', () => {
       )
       done()
     }, context)
+  })
+
+  it('default value Foreign Function', () => {
+    const FunctionConstructor = VM.runInNewContext('Function')
+    const func = () => 123
+    const vm = new Vue({
+      props: {
+        a: {
+          type: FunctionConstructor,
+          default: func
+        }
+      },
+      propsData: {
+        a: undefined
+      }
+    })
+    expect(vm.a).toBe(func)
   })
 })
 

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -98,6 +98,22 @@ describe('Options props', () => {
     }).then(done)
   })
 
+  it('default value Function', () => {
+    const func = () => 132
+    const vm = new Vue({
+      props: {
+        a: {
+          type: Function,
+          default: func
+        }
+      },
+      propsData: {
+        a: undefined
+      }
+    })
+    expect(vm.a).toBe(func)
+  })
+
   it('warn object/array default values', () => {
     new Vue({
       props: {


### PR DESCRIPTION
If the prototype of a function is also a function, we treat it as `Function` constructor.

This check is context independent, so server side can safely extract vue as an external library. And it is not expensive.

Of course it is not silver bullet. Users can pass a value of which the prototype is set to a function. But naughty users can also rewrite `Function` global, so I think this change is at most as bad as current check.

Other counter examples are welcome!