### PR TITLE
Added the possibility to have function declared as required propOption

### DIFF
--- a/flow/options.js
+++ b/flow/options.js
@@ -70,6 +70,6 @@ declare type ComponentOptions = {
 declare type PropOptions = {
   type: Function | Array<Function> | null;
   default: any;
-  required: ?boolean;
+  required: ?any;
   validator: ?Function;
 }

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -85,9 +85,9 @@ function assertProp (
   vm: ?Component,
   absent: boolean
 ) {
-  const required = prop.required instanceof Function ?
-        prop.required() :
-        prop.required
+  const required = prop.required instanceof Function 
+    ? prop.required()
+    : prop.required
   if (required && absent) {
     warn(
       'Missing required prop: "' + name + '"',

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -7,7 +7,7 @@ import { warn } from './debug'
 type PropOptions = {
   type: Function | Array<Function> | null,
   default: any,
-  required: ?boolean,
+  required: ?any,
   validator: ?Function
 };
 
@@ -85,14 +85,17 @@ function assertProp (
   vm: ?Component,
   absent: boolean
 ) {
-  if (prop.required && absent) {
+  const required = prop.required instanceof Function ?
+        prop.required() :
+        prop.required
+  if (required && absent) {
     warn(
       'Missing required prop: "' + name + '"',
       vm
     )
     return
   }
-  if (value == null && !prop.required) {
+  if (value == null && !required) {
     return
   }
   let type = prop.type

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -85,7 +85,7 @@ function assertProp (
   vm: ?Component,
   absent: boolean
 ) {
-  const required = prop.required instanceof Function 
+  const required = prop.required instanceof Function
     ? prop.required()
     : prop.required
   if (required && absent) {

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -64,7 +64,7 @@ export interface RenderContext {
 
 export interface PropOptions {
   type?: Constructor | Constructor[] | null;
-  required?: boolean;
+  required?: any;
   default?: any;
   validator?(value: any): boolean;
 }


### PR DESCRIPTION
Added the possibility to declare a function as value for required PropOption which should return a truthy or falsy value as the following:
```JavaScript
props: {
  myProp: {
    type: String,
    required: function () {
      /* Treatment here */
      return result // truthy or falsy
    }
  }
}
```