### PR TITLE
Warn when defining a method with same name as a prop

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -183,14 +183,23 @@ function createComputedGetter (key) {
 }
 
 function initMethods (vm: Component, methods: Object) {
+  const props = vm.$options.props
   for (const key in methods) {
     vm[key] = methods[key] == null ? noop : bind(methods[key], vm)
-    if (process.env.NODE_ENV !== 'production' && methods[key] == null) {
-      warn(
-        `method "${key}" has an undefined value in the component definition. ` +
-        `Did you reference the function correctly?`,
-        vm
-      )
+    if (process.env.NODE_ENV !== 'production') {
+      if (methods[key] == null) {
+        warn(
+          `method "${key}" has an undefined value in the component definition. ` +
+          `Did you reference the function correctly?`,
+          vm
+        )
+      }
+      if (props && hasOwn(props, key)) {
+        warn(
+          `method "${key}" has already been defined as a property value.`,
+          vm
+        )
+      }
     }
   }
 }

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -196,7 +196,7 @@ function initMethods (vm: Component, methods: Object) {
       }
       if (props && hasOwn(props, key)) {
         warn(
-          `method "${key}" has already been defined as a property value.`,
+          `method "${key}" has already been defined as a prop.`,
           vm
         )
       }

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -323,7 +323,7 @@ describe('Options props', () => {
         }
       }
     }).$mount()
-    expect(`method "a" has already been defined as a property`).toHaveBeenWarned()
+    expect(`method "a" has already been defined as a prop`).toHaveBeenWarned()
     expect(`Avoid mutating a prop directly`).toHaveBeenWarned()
   })
 

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -306,6 +306,27 @@ describe('Options props', () => {
     expect('already declared as a prop').toHaveBeenWarned()
   })
 
+  it('should warn methods already defined as a prop', () => {
+    new Vue({
+      template: '<test a="1"></test>',
+      components: {
+        test: {
+          template: '<div></div>',
+          props: {
+            a: null
+          },
+          methods: {
+            a () {
+
+            }
+          }
+        }
+      }
+    }).$mount()
+    expect(`method "a" has already been defined as a property`).toHaveBeenWarned()
+    expect(`Avoid mutating a prop directly`).toHaveBeenWarned()
+  })
+
   it('treat boolean props properly', () => {
     const vm = new Vue({
       template: '<comp ref="child" prop-a prop-b="prop-b"></comp>',


### PR DESCRIPTION
When you specify a method on a component with the same name as a prop you get an error about mutating a prop directly, but it can be hard for people new to vue to figure out what this means.

This PR adds a more explicit warning message indicating exactly what went wrong.