### PR TITLE
add process.env.VUE_DISMISS_DEVTOOLS guard around __vue__ property

### DIFF
--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -101,12 +101,18 @@ export function lifecycleMixin (Vue: Class<Component>) {
     }
     activeInstance = prevActiveInstance
     // update __vue__ reference
-    if (prevEl) {
-      prevEl.__vue__ = null
+    if (process.env.VUE_DISMISS_DEVTOOLS !== 'yes') {
+      if (prevEl) {
+        prevEl.__vue__ = null
+      }
     }
-    if (vm.$el) {
-      vm.$el.__vue__ = vm
+
+    if (process.env.VUE_DISMISS_DEVTOOLS !== 'yes') {
+      if (vm.$el) {
+        vm.$el.__vue__ = vm
+      }
     }
+
     // if parent is an HOC, update its $el as well
     if (vm.$vnode && vm.$parent && vm.$vnode === vm.$parent._vnode) {
       vm.$parent.$el = vm.$el
@@ -208,10 +214,14 @@ export function lifecycleMixin (Vue: Class<Component>) {
     callHook(vm, 'destroyed')
     // turn off all instance listeners.
     vm.$off()
-    // remove __vue__ reference
-    if (vm.$el) {
-      vm.$el.__vue__ = null
+
+    if (process.env.VUE_DISMISS_DEVTOOLS !== 'yes') {
+      // remove __vue__ reference
+      if (vm.$el) {
+        vm.$el.__vue__ = null
+      }
     }
+
     // invoke destroy hooks on current rendered tree
     vm.__patch__(vm._vnode, null)
   }


### PR DESCRIPTION
By following up from #4957, I'm adding that guard against `__vue__` properties.

This won't change existing builds in any way, as long as you don't have a `VUE_DISMISS_DEVTOOLS` environment variable.

@yyx990803 Maybe there should be a better name for that thing?