### PR TITLE
a bit more random _uids

### DIFF
--- a/src/core/instance/init.js
+++ b/src/core/instance/init.js
@@ -13,7 +13,7 @@ export function initMixin (Vue: Class<Component>) {
   Vue.prototype._init = function (options?: Object) {
     const vm: Component = this
     // a uid
-    vm._uid = uid++
+    vm._uid = (Math.floor(Math.random() * 100) + 1) + uid++
     // a flag to avoid this being observed
     vm._isVue = true
     // merge options


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Continuing the work done in https://github.com/vuejs/vue-devtools/pull/260, I'm proposing a change for a bit more dynamic `_uid`s, by adding a small random offset to them.

This will allow components from multiple Vue dependencies to be inspectable in `vue-devtools` without any hassle. Also, one thing to note is the fact that [transitions](https://github.com/vuejs/vue/blob/f7062b9b75179a0a515205e47cfe6227f33b95f0/src/platforms/web/runtime/components/transition.js#L134) may break in some rare cases.