### PR TITLE
improve Vue.config.keyCode typing

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -11,7 +11,7 @@ export type Config = {
   devtools: boolean;
   errorHandler: ?(err: Error, vm: Component, info: string) => void;
   ignoredElements: Array<string>;
-  keyCodes: { [key: string]: number };
+  keyCodes: { [key: string]: number | Array<number> };
   // platform
   isReservedTag: (x?: string) => boolean;
   parsePlatformTagName: (x: string) => string;


### PR DESCRIPTION
I found it, when I'm working flowtype definition of vue into [`flow-typed`](https://github.com/flowtype/flow-typed). (registration soon 😉 ) 

`Vue.config.keyCodes` allow the `Array<number>`.
https://github.com/vuejs/vue/blob/0e2dafa74ccecf57fbbac6f828884558a8fbd794/test/unit/features/directives/on.spec.js#L272

related:
https://vuejs.org/v2/api/#keyCodes

