### PR TITLE
Fix comment typo

### DIFF
--- a/src/core/vdom/helpers/normalize-children.js
+++ b/src/core/vdom/helpers/normalize-children.js
@@ -24,7 +24,7 @@ export function simpleNormalizeChildren (children: any) {
   return children
 }
 
-// 2. When the children contains constrcuts that always generated nested Arrays,
+// 2. When the children contains constructs that always generated nested Arrays,
 // e.g. <template>, <slot>, v-for, or when the children is provided by user
 // with hand-written render functions / JSX. In such cases a full normalization
 // is needed to cater to all possible types of children values.


### PR DESCRIPTION
Fix comment typo in normalize-children.js
Ignoring this typo that also appears in `dist` and `packages`.