### PR TITLE
refactor TypeScript typings to use ES style exports

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,37 +1,35 @@
-import * as V from "./vue";
-import * as Options from "./options";
-import * as Plugin from "./plugin";
-import * as VNode from "./vnode";
+import { Vue } from "./vue";
 
-// `Vue` in `export = Vue` must be a namespace
-// All available types are exported via this namespace
-declare namespace Vue {
-  export type CreateElement = V.CreateElement;
+export default Vue;
 
-  export type Component = Options.Component;
-  export type AsyncComponent = Options.AsyncComponent;
-  export type ComponentOptions<V extends Vue> = Options.ComponentOptions<V>;
-  export type FunctionalComponentOptions = Options.FunctionalComponentOptions;
-  export type RenderContext = Options.RenderContext;
-  export type PropOptions = Options.PropOptions;
-  export type ComputedOptions<V extends Vue> = Options.ComputedOptions<V>;
-  export type WatchHandler<V extends Vue> = Options.WatchHandler<V, any>;
-  export type WatchOptions = Options.WatchOptions;
-  export type DirectiveFunction = Options.DirectiveFunction;
-  export type DirectiveOptions = Options.DirectiveOptions;
+export {
+  CreateElement
+} from "./vue";
 
-  export type PluginFunction<T> = Plugin.PluginFunction<T>;
-  export type PluginObject<T> = Plugin.PluginObject<T>;
+export {
+  Component,
+  AsyncComponent,
+  ComponentOptions,
+  FunctionalComponentOptions,
+  RenderContext,
+  PropOptions,
+  ComputedOptions,
+  WatchHandler,
+  WatchOptions,
+  DirectiveFunction,
+  DirectiveOptions
+} from "./options";
 
-  export type VNodeChildren = VNode.VNodeChildren;
-  export type VNodeChildrenArrayContents = VNode.VNodeChildrenArrayContents;
-  export type VNode = VNode.VNode;
-  export type VNodeComponentOptions = VNode.VNodeComponentOptions;
-  export type VNodeData = VNode.VNodeData;
-  export type VNodeDirective = VNode.VNodeDirective;
-}
+export {
+  PluginFunction,
+  PluginObject
+} from "./plugin";
 
-// TS cannot merge imported class with namespace, declare a subclass to bypass
-declare class Vue extends V.Vue {}
-
-export = Vue;
+export {
+  VNodeChildren,
+  VNodeChildrenArrayContents,
+  VNode,
+  VNodeComponentOptions,
+  VNodeData,
+  VNodeDirective
+} from "./vnode";

--- a/types/test/augmentation-test.ts
+++ b/types/test/augmentation-test.ts
@@ -1,4 +1,4 @@
-import Vue = require("../index");
+import Vue from "../index";
 
 declare module "../vue" {
   // add instance property and method

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,4 +1,4 @@
-import Vue = require("../index");
+import Vue from "../index";
 import { ComponentOptions, FunctionalComponentOptions } from "../index";
 
 interface Component extends Vue {

--- a/types/test/plugin-test.ts
+++ b/types/test/plugin-test.ts
@@ -1,4 +1,4 @@
-import Vue = require("../index");
+import Vue from "../index";
 import { PluginFunction, PluginObject } from "../index";
 
 class Option {

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -1,4 +1,4 @@
-import Vue = require("../index");
+import Vue from "../index";
 
 class Test extends Vue {
   a: number;


### PR DESCRIPTION
This PR will change Vue's TS typings to use ES-style exports so that it works better with the new ES module build + webpack 2 combo.

So instead of:

``` js
import Vue = require('vue')
```

TS users should now use:

``` js
import Vue from 'vue'
```

...which is consistent with recommended plain ES usage.

This is technically a breaking change, but since we've already unintentionally caused a breaking change for webpack 2 + TS users, we should probably just fully migrate to ES-based exports to avoid more breakage in the future.

Related:

- https://github.com/vuejs/vue-router/pull/1204
- https://github.com/vuejs/vuex/pull/658