### PR TITLE
Add the runtime-only warning for el in-DOM HTML template

### DIFF
--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -141,8 +141,8 @@ export function mountComponent (
     vm.$options.render = createEmptyVNode
     if (process.env.NODE_ENV !== 'production') {
       /* istanbul ignore if */
-      if (vm.$options.template && vm.$options.template.charAt(0) !== '#' ||
-        vm.$options.el) {
+      if ((vm.$options.template && vm.$options.template.charAt(0) !== '#') ||
+        vm.$options.el || el) {
         warn(
           'You are using the runtime-only build of Vue where the template ' +
           'compiler is not available. Either pre-compile the templates into ' +

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -141,10 +141,11 @@ export function mountComponent (
     vm.$options.render = createEmptyVNode
     if (process.env.NODE_ENV !== 'production') {
       /* istanbul ignore if */
-      if (vm.$options.template && vm.$options.template.charAt(0) !== '#') {
+      if (vm.$options.template && vm.$options.template.charAt(0) !== '#' ||
+        vm.$options.el) {
         warn(
           'You are using the runtime-only build of Vue where the template ' +
-          'option is not available. Either pre-compile the templates into ' +
+          'compiler is not available. Either pre-compile the templates into ' +
           'render functions, or use the compiler-included build.',
           vm
         )


### PR DESCRIPTION
Make the warning more explicit for template complier.
Plus, el option which will be used to extract the template should also emit the warning.