### PR TITLE
NonParsingTags should not be case-insensitive

### DIFF
--- a/src/platforms/web/compiler/util.js
+++ b/src/platforms/web/compiler/util.js
@@ -4,15 +4,13 @@ import { makeMap } from 'shared/util'
 
 export const isUnaryTag = makeMap(
   'area,base,br,col,embed,frame,hr,img,input,isindex,keygen,' +
-  'link,meta,param,source,track,wbr',
-  true
+  'link,meta,param,source,track,wbr'
 )
 
 // Elements that you can, intentionally, leave open
 // (and which close themselves)
 export const canBeLeftOpenTag = makeMap(
-  'colgroup,dd,dt,li,options,p,td,tfoot,th,thead,tr,source',
-  true
+  'colgroup,dd,dt,li,options,p,td,tfoot,th,thead,tr,source'
 )
 
 // HTML5 tags https://html.spec.whatwg.org/multipage/indices.html#elements-3
@@ -22,6 +20,5 @@ export const isNonPhrasingTag = makeMap(
   'details,dialog,div,dl,dt,fieldset,figcaption,figure,footer,form,' +
   'h1,h2,h3,h4,h5,h6,head,header,hgroup,hr,html,legend,li,menuitem,meta,' +
   'optgroup,option,param,rp,rt,source,style,summary,tbody,td,tfoot,th,thead,' +
-  'title,tr,track',
-  true
+  'title,tr,track'
 )


### PR DESCRIPTION
In vue 2.0, the template is parsed by a Virtual DOM. The paring process is case-sensitive. For example, the VDOM can distinguish between `<Button>` and `<button>`. However, the function is `isNonParsingTag` is case-insensitive which shouldn't be.
