### PR TITLE
[weex] wrap IFFE and use strict mode to run js bundle

### DIFF
--- a/src/platforms/weex/framework.js
+++ b/src/platforms/weex/framework.js
@@ -102,6 +102,10 @@ export function createInstance (
     weex: weexInstanceVar,
     __weex_require_module__: weexInstanceVar.requireModule // deprecated
   }, timerAPIs)
+
+  // wrap IFFE and use strict mode
+  appCode = `(function(global){"use strict";\n ${appCode} \n})(Object.create(this))`
+
   callFunction(instanceVars, appCode)
 
   // Send `createFinish` signal to native.


### PR DESCRIPTION
This is a corresponding change with https://github.com/alibaba/weex/pull/1483 and https://github.com/alibaba/weex/pull/1626 .

Both legacy `.we` and  Rax are using strict mode to run the js bundle.
