### PR TITLE
Fix unnecessary conditional.

### DIFF
--- a/src/core/util/lang.js
+++ b/src/core/util/lang.js
@@ -29,14 +29,13 @@ const bailRE = /[^\w.$]/
 export function parsePath (path: string): any {
   if (bailRE.test(path)) {
     return
-  } else {
-    const segments = path.split('.')
-    return function (obj) {
-      for (let i = 0; i < segments.length; i++) {
-        if (!obj) return
-        obj = obj[segments[i]]
-      }
-      return obj
+  }
+  const segments = path.split('.')
+  return function (obj) {
+    for (let i = 0; i < segments.length; i++) {
+      if (!obj) return
+      obj = obj[segments[i]]
     }
+    return obj
   }
 }


### PR DESCRIPTION
I found unnecessary conditional in lang.js.
https://github.com/vuejs/vue/blob/dev/src/core/util/lang.js#L30-L32

if `bailRE.test(path)` is true, It's return.
So, the next else clause is unnecessary.