### PR TITLE
Init injections before state

### DIFF
--- a/src/core/instance/init.js
+++ b/src/core/instance/init.js
@@ -49,8 +49,8 @@ export function initMixin (Vue: Class<Component>) {
     initEvents(vm)
     initRender(vm)
     callHook(vm, 'beforeCreate')
-    initState(vm)
     initInjections(vm)
+    initState(vm)
     callHook(vm, 'created')
 
     /* istanbul ignore if */


### PR DESCRIPTION
This makes it possible to provide an injected value as the default for a prop

```js
export default {
  inject: ['_searchStore'],
  props: {
    searchStore: {
      type: Object,
      default () {
        return this._searchStore
      }
    }
  }
}
```

That way the user can either explicitly pass the property, or otherwise we resolve it with the injected one.

From my understanding, `initInjections` doesn't really conflict with `initState`, is there a specific reason for having initState before initInjections?