### PR TITLE
Add node using nextSibling as reference

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -405,7 +405,15 @@ export function createPatchFunction (backend) {
       }
     }
     if (oldStartIdx > oldEndIdx) {
-      refElm = isUndef(newCh[newEndIdx + 1]) ? null : newCh[newEndIdx + 1].elm
+      if (isUndef(newCh[newEndIdx + 1])) {
+        if (isUndef(newCh[newEndIdx - 1]) || newCh[newEndIdx - 1].elm === undefined) {
+          refElm = null
+        } else {
+          refElm = newCh[newEndIdx - 1].elm.nextSibling
+        }
+      } else {
+        refElm = newCh[newEndIdx + 1].elm
+      }
       addVnodes(parentElm, refElm, newCh, newStartIdx, newEndIdx, insertedVnodeQueue)
     } else if (newStartIdx > newEndIdx) {
       removeVnodes(parentElm, oldCh, oldStartIdx, oldEndIdx)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

When an item is appended to the end of a list being rendered using v-for, it is appended as a new child to the parent element. If an element has been appended after the list in the meantime, it will appear in the middle of this list instead of after.

For an illustration see https://jsfiddle.net/39epgLj0/30/

This PR fixes this by using nextSibling of the previous node as a reference where available.