### PR TITLE
Warn when not passing props in kebab-case

### DIFF
--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -287,6 +287,17 @@ function extractProps (data: VNodeData, Ctor: Class<Component>): ?Object {
   if (attrs || props || domProps) {
     for (const key in propOptions) {
       const altKey = hyphenate(key)
+      const keyInLowerCase = key.toLowerCase()
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        key !== keyInLowerCase &&
+        attrs && attrs.hasOwnProperty(keyInLowerCase)
+      ) {
+        warn(
+          `HTML attributes are case-insensitive. camelCased prop names need ` +
+          `to use their kebab-case equivalents. ${key} should be ${altKey}.`
+        )
+      }
       checkProp(res, props, key, altKey, true) ||
       checkProp(res, attrs, key, altKey) ||
       checkProp(res, domProps, key, altKey)

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -287,16 +287,17 @@ function extractProps (data: VNodeData, Ctor: Class<Component>): ?Object {
   if (attrs || props || domProps) {
     for (const key in propOptions) {
       const altKey = hyphenate(key)
-      const keyInLowerCase = key.toLowerCase()
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        key !== keyInLowerCase &&
-        attrs && attrs.hasOwnProperty(keyInLowerCase)
-      ) {
-        warn(
-          `HTML attributes are case-insensitive. camelCased prop names need ` +
-          `to use their kebab-case equivalents. ${key} should be ${altKey}.`
-        )
+      if (process.env.NODE_ENV !== 'production') {
+        const keyInLowerCase = key.toLowerCase()
+        if (
+          key !== keyInLowerCase &&
+          attrs && attrs.hasOwnProperty(keyInLowerCase)
+        ) {
+          warn(
+            `HTML attributes are case-insensitive. camelCased prop names need ` +
+            `to use their kebab-case equivalents. ${key} should be ${altKey}.`
+          )
+        }
       }
       checkProp(res, props, key, altKey, true) ||
       checkProp(res, attrs, key, altKey) ||

--- a/test/unit/features/component/component.spec.js
+++ b/test/unit/features/component/component.spec.js
@@ -258,6 +258,25 @@ describe('Component', () => {
     expect(vm.$el.outerHTML).toBe('<ul><li>1</li><li>2</li></ul>')
   })
 
+  it('should warn when not passing props in kebab-case', () => {
+    new Vue({
+      data: {
+        list: [{ a: 1 }, { a: 2 }]
+      },
+      template: '<test :somecollection="list"></test>',
+      components: {
+        test: {
+          template: '<ul><li v-for="item in someCollection">{{item.a}}</li></ul>',
+          props: ['someCollection']
+        }
+      }
+    }).$mount()
+    expect(
+      'HTML attributes are case-insensitive. camelCased prop names need ' +
+      'to use their kebab-case equivalents. someCollection should be some-collection.'
+    ).toHaveBeenWarned()
+  })
+
   it('not found component should not throw', () => {
     expect(function () {
       new Vue({


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

Hi,

Please see #5145 

This patch adds a warning when user is not passing props in kebab-case mistakenly, for example:

```html
<foo someProp="bar"></foo>
should be
<foo some-prop="bar"></foo>
```

I know this is stated on the guide, but since it's a very common mistake (based on the questions on stackoverflow (see the issue above) [and the](https://forum.vuejs.org/t/unable-to-pass-data-from-parent-to-child-component/1763/1) [forum](https://forum.vuejs.org/t/need-help-with-passing-a-boolean-prop-to-a-comonent/3996/1 )), I think it is worth to add a warning and I believe this will save a lot of people's debugging time and provide a more friendly development experience.

And for the performance, this is not a complex algorithm. It only adds a fews operations (both `toLowerCase` and `hasOwnProperty` are fast enough) in O(n) so I would say the impact on performance is negligible (almost no impact when running unit test on my machine). 

thanks!