### PR TITLE
Warn and handle missing get in computed (fix #5265)

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -147,7 +147,16 @@ function initComputed (vm: Component, computed: Object) {
 
   for (const key in computed) {
     const userDef = computed[key]
-    const getter = typeof userDef === 'function' ? userDef : userDef.get
+    let getter = typeof userDef === 'function' ? userDef : userDef.get
+    if (process.env.NODE_ENV !== 'production') {
+      if (getter === undefined) {
+        warn(
+          `No getter function has been defined for computed property "${key}".`,
+          vm
+        )
+        getter = noop
+      }
+    }
     // create internal watcher for the computed property.
     watchers[key] = new Watcher(vm, getter, noop, computedWatcherOptions)
 

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -48,6 +48,33 @@ describe('Options computed', () => {
     }).then(done)
   })
 
+  it('warn with setter and no getter', () => {
+    const vm = new Vue({
+      template: `
+        <div>
+          <test></test>
+        </div>
+      `,
+      components: {
+        test: {
+          data () {
+            return {
+              a: 1
+            }
+          },
+          computed: {
+            b: {
+              set (v) { this.a = v }
+            }
+          },
+          template: `<div>{{a}}</div>`
+        }
+      }
+    }).$mount()
+    expect(vm.$el.innerHTML).toBe('<div>1</div>')
+    expect('No getter function has been defined for computed property "b".').toHaveBeenWarned()
+  })
+
   it('watching computed', done => {
     const spy = jasmine.createSpy('watch computed')
     const vm = new Vue({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I ran all test locally. I'm having some failures related to SSR and selenium which appear to be completely unrelated. I've confirmed the new test works by reverting my change and adding it back in.


I am using `noop` for the getter if one does not exist to avoid exceptions when calling functions on the getter.
