### PR TITLE
allow an extended constructor as global mixin (fix vue-class-component#83)

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import Vue from '../instance/index'
 import config from '../config'
 import { warn } from './debug'
 import { set } from '../observer/index'
@@ -275,21 +274,20 @@ export function mergeOptions (
   if (process.env.NODE_ENV !== 'production') {
     checkComponents(child)
   }
+
+  if (typeof child === 'function') {
+    child = child.options
+  }
+
   normalizeProps(child)
   normalizeDirectives(child)
   const extendsFrom = child.extends
   if (extendsFrom) {
-    parent = typeof extendsFrom === 'function'
-      ? mergeOptions(parent, extendsFrom.options, vm)
-      : mergeOptions(parent, extendsFrom, vm)
+    parent = mergeOptions(parent, extendsFrom, vm)
   }
   if (child.mixins) {
     for (let i = 0, l = child.mixins.length; i < l; i++) {
-      let mixin = child.mixins[i]
-      if (mixin.prototype instanceof Vue) {
-        mixin = mixin.options
-      }
-      parent = mergeOptions(parent, mixin, vm)
+      parent = mergeOptions(parent, child.mixins[i], vm)
     }
   }
   const options = {}

--- a/test/unit/features/global-api/mixin.spec.js
+++ b/test/unit/features/global-api/mixin.spec.js
@@ -124,4 +124,21 @@ describe('Global API: mixin', () => {
     expect(Test.options.computed.$style()).toBe(123)
     expect(Test.options.beforeCreate).toEqual([mixinSpy, baseSpy, spy])
   })
+
+  // vue-class-component#83
+  it('should work for a constructor mixin', () => {
+    const spy = jasmine.createSpy('global mixin')
+    const Mixin = Vue.extend({
+      created () {
+        spy(this.$options.myOption)
+      }
+    })
+
+    Vue.mixin(Mixin)
+
+    new Vue({
+      myOption: 'hello'
+    })
+    expect(spy).toHaveBeenCalledWith('hello')
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (might be a new feature)
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
This PR moves a constructor check in `mergeOptions` to the head of the function so that we can use a extended Vue constructor not only as `mixins`/`extends` options but also as global mixin. This fixes vuejs/vue-class-component#83