### PR TITLE
according  $option._scopeUseClass to set scopeId to attribute or class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.vscode
 node_modules
 *.log
 explorations

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 node_modules
 *.log
 explorations

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -279,7 +279,7 @@ export function createPatchFunction (backend) {
     let ancestor = vnode
     while (ancestor) {
       if (isDef(i = ancestor.context) && isDef(i = i.$options._scopeId)) {
-        nodeOps.setAttribute(vnode.elm, i, '')
+        nodeOps.addClass(vnode.elm, i)
       }
       ancestor = ancestor.parent
     }
@@ -287,7 +287,7 @@ export function createPatchFunction (backend) {
     if (isDef(i = activeInstance) &&
         i !== vnode.context &&
         isDef(i = i.$options._scopeId)) {
-      nodeOps.setAttribute(vnode.elm, i, '')
+      nodeOps.addClass(vnode.elm, i)
     }
   }
 

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -271,23 +271,27 @@ export function createPatchFunction (backend) {
     }
   }
 
-  // set scope id attribute for scoped CSS.
+  // set scope id attribute/class for scoped CSS.
   // this is implemented as a special case to avoid the overhead
   // of going through the normal attribute patching process.
   function setScope (vnode) {
-    let i
+    let i, v
     let ancestor = vnode
     while (ancestor) {
-      if (isDef(i = ancestor.context) && isDef(i = i.$options._scopeId)) {
-        nodeOps.addClass(vnode.elm, i)
+      if (isDef(i = ancestor.context) && isDef(v = i.$options._scopeId)) {
+        i.$options._scopeUseClass
+          ? nodeOps.addClass(vnode.elm, v)
+          : nodeOps.setAttribute(vnode.elm, v, '')
       }
       ancestor = ancestor.parent
     }
     // for slot content they should also get the scopeId from the host instance.
     if (isDef(i = activeInstance) &&
         i !== vnode.context &&
-        isDef(i = i.$options._scopeId)) {
-      nodeOps.addClass(vnode.elm, i)
+        isDef(v = i.$options._scopeId)) {
+      i.$options._scopeUseClass
+        ? nodeOps.addClass(vnode.elm, v)
+        : nodeOps.setAttribute(vnode.elm, v, '')
     }
   }
 

--- a/src/platforms/web/runtime/node-ops.js
+++ b/src/platforms/web/runtime/node-ops.js
@@ -2,6 +2,8 @@
 
 import { namespaceMap } from 'web/util/index'
 
+export { addClass, removeClass } from './class-util'
+
 export function createElement (tagName: string, vnode: VNode): Element {
   const elm = document.createElement(tagName)
   if (tagName !== 'select') {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:
  
This feature is using with the [vue-loader's RP](https://github.com/vuejs/vue-loader/pull/778), according to the the template generated by vue-loader, it can decision to generate the scopeid  to the element`s  attribute or class, if the choice is generated to the class, then the scope style will query faster than attribue.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
