### PR TITLE
Support auto-prefixed style value as array (client/ssr)

### DIFF
--- a/src/platforms/web/runtime/modules/style.js
+++ b/src/platforms/web/runtime/modules/style.js
@@ -12,7 +12,17 @@ const setProp = (el, name, val) => {
   } else if (importantRE.test(val)) {
     el.style.setProperty(name, val.replace(importantRE, ''), 'important')
   } else {
-    el.style[normalize(name)] = val
+    const normalizedName = normalize(name)
+    if (Array.isArray(val)) {
+      // Support values array created by autoprefixer, e.g.
+      // {display: ["-webkit-box", "-ms-flexbox", "flex"]}
+      // Set them one by one, and the browser will only set those it can recognize
+      for (let i = 0, len = val.length; i < len; i++) {
+        el.style[normalizedName] = val[i]
+      }
+    } else {
+      el.style[normalizedName] = val
+    }
   }
 }
 

--- a/src/platforms/web/server/modules/style.js
+++ b/src/platforms/web/server/modules/style.js
@@ -8,7 +8,15 @@ function genStyleText (vnode: VNode): string {
   let styleText = ''
   const style = getStyle(vnode, false)
   for (const key in style) {
-    styleText += `${hyphenate(key)}:${style[key]};`
+    const value = style[key]
+    const hyphenatedKey = hyphenate(key)
+    if (Array.isArray(value)) {
+      for (let i = 0, len = value.length; i < len; i++) {
+        styleText += `${hyphenatedKey}:${value[i]};`
+      }
+    } else {
+      styleText += `${hyphenatedKey}:${value};`
+    }
   }
   return styleText
 }

--- a/test/ssr/ssr-string.spec.js
+++ b/test/ssr/ssr-string.spec.js
@@ -123,6 +123,22 @@ describe('SSR: renderToString', () => {
     })
   })
 
+  it('auto-prefixed style value as array', done => {
+    renderVmWithOptions({
+      template: '<div :style="style"></div>',
+      data: {
+        style: {
+          display: ['-webkit-box', '-ms-flexbox', 'flex']
+        }
+      }
+    }, result => {
+      expect(result).toContain(
+        '<div data-server-rendered="true" style="display:-webkit-box;display:-ms-flexbox;display:flex;"></div>'
+      )
+      done()
+    })
+  })
+
   it('custom component style', done => {
     renderVmWithOptions({
       template: '<section><comp :style="style"></comp></section>',

--- a/test/unit/features/directives/style.spec.js
+++ b/test/unit/features/directives/style.spec.js
@@ -85,8 +85,12 @@ describe('Directive v-bind:style', () => {
 
   it('auto-prefixed style value as array', done => {
     vm.styles = { display: ['-webkit-box', '-ms-flexbox', 'flex'] }
+    const testEl = document.createElement('div')
+    vm.styles.display.forEach(value => {
+      testEl.style.display = value
+    })
     waitForUpdate(() => {
-      expect(vm.$el.style.display).toBe('flex')
+      expect(vm.$el.style.display).toBe(testEl.style.display)
     }).then(done)
   })
 

--- a/test/unit/features/directives/style.spec.js
+++ b/test/unit/features/directives/style.spec.js
@@ -83,6 +83,13 @@ describe('Directive v-bind:style', () => {
     }).then(done)
   })
 
+  it('auto-prefixed style value as array', done => {
+    vm.styles = { display: ['-webkit-box', '-ms-flexbox', 'flex'] }
+    waitForUpdate(() => {
+      expect(vm.$el.style.display).toBe('flex')
+    }).then(done)
+  })
+
   it('!important', done => {
     vm.styles = { display: 'block !important' }
     waitForUpdate(() => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**


When exploring [css-in-js solutions](https://github.com/MicheleBertoli/css-in-js) for vue, I came across the fact that some auto prefixed style objects (for example, by [postcss-js](https://github.com/postcss/postcss-js)) cannot be directly used as `style` option on elements, when they have an array as value, e.g.
```
{ display: ['-webkit-box', '-webkit-flex', '-ms-flexbox', 'flex'] }
```
...which happens when a rule value needs to be prefixed, other examples:
```
{ backgroundImage: ['radial-gradient(...)', '-webkit-radial-gradient(...)']
{ cursor: ['-webkit-grab','grab'] }
```
This PR adds support for directly consuming such objects as `style` option.        