### PR TITLE
Support Vue.delete(arr, index) in TypeScript definitions

### DIFF
--- a/src/server/webpack-plugin/util.js
+++ b/src/server/webpack-plugin/util.js
@@ -1,4 +1,4 @@
-const { red, yellow, gray } = require('chalk')
+const { red, yellow } = require('chalk')
 
 const prefix = `[vue-server-renderer-webpack-plugin]`
 const warn = exports.warn = msg => console.error(red(`${prefix} ${msg}\n`))
@@ -15,9 +15,8 @@ export const validate = compiler => {
 
   if (!compiler.options.externals) {
     tip(
-      'It is recommended to externalize dependencies for better ssr performance.\n' +
-      `See ${gray('https://github.com/vuejs/vue/tree/dev/packages/vue-server-renderer#externals')} ` +
-      'for more details.'
+      'It is recommended to externalize dependencies in the server build for ' +
+      'better build performance.'
     )
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -84,6 +84,7 @@ export declare class Vue {
   static set<T>(object: Object, key: string, value: T): T;
   static set<T>(array: T[], key: number, value: T): T;
   static delete(object: Object, key: string): void;
+  static delete<T>(array: T[], key: number): void;
 
   static directive(
     id: string,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: TypeScript Definition Update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Vue 2.2.0 added support for Vue.delete(arr, index). This updates the TypeScript definition to allow that.
Refs: https://github.com/vuejs/vue/releases/tag/v2.2.0
