### PR TITLE
Fix when functional component render method retrun null (fix #5536)

### DIFF
--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -99,7 +99,7 @@ export function _createElement (
     // direct component options / constructor
     vnode = createComponent(tag, data, context, children)
   }
-  if (vnode != null) {
+  if (isDef(vnode)) {
     if (ns) applyNS(vnode, ns)
     return vnode
   } else {

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -99,7 +99,7 @@ export function _createElement (
     // direct component options / constructor
     vnode = createComponent(tag, data, context, children)
   }
-  if (vnode !== undefined) {
+  if (vnode != null) {
     if (ns) applyNS(vnode, ns)
     return vnode
   } else {

--- a/test/unit/features/options/functional.spec.js
+++ b/test/unit/features/options/functional.spec.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { createEmptyVNode } from 'core/vdom/vnode'
 
 describe('Options functional', () => {
   it('should work', done => {
@@ -166,5 +167,22 @@ describe('Options functional', () => {
       document.body.removeChild(vm.$el)
       vm.$destroy()
     }).then(done)
+  })
+
+  it('create empty vnode when render return null', () => {
+    const child = {
+      functional: true,
+      render () {
+        return null
+      }
+    }
+    const vm = new Vue({
+      components: {
+        child
+      }
+    })
+    const h = vm.$createElement
+    const vnode = h('child')
+    expect(vnode).toEqual(createEmptyVNode())
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

issue: https://github.com/vuejs/vue/issues/5536

Originally I wanted to use `isDef` but the flow was a bit of a problem

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**