### PR TITLE
[vue-server-renderer] ensure assets are unique

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "karma-webpack": "^2.0.1",
     "lodash": "^4.17.1",
     "lodash.template": "^4.4.0",
+    "lodash.uniq": "^4.5.0",
     "lru-cache": "^4.0.2",
     "nightwatch": "^0.9.9",
     "nightwatch-helpers": "^1.2.0",

--- a/packages/vue-server-renderer/package.json
+++ b/packages/vue-server-renderer/package.json
@@ -22,6 +22,7 @@
     "hash-sum": "^1.0.2",
     "he": "^1.1.0",
     "lodash.template": "^4.4.0",
+    "lodash.uniq": "^4.5.0",
     "resolve": "^1.2.0",
     "source-map": "0.5.6",
     "serialize-javascript": "^1.3.0"


### PR DESCRIPTION
Hello. During upgrade process of Nuxt.js to vue 2.3.x (nuxt/nuxt.js#633) we encounter strange behavior which adds duplicate entries to `initial` section of client manifest json file. This PR fixes this issue and also ensures every section's items are unique to prevent such kind of problem in future. This PR also prevents an unexpected exception when detecting and ignoring duplicated chunks.

```js
{
  "publicPath": "/_nuxt/",
  "all": [
    "0.nuxt.bundle.309097aded56ffb03943.js",
    "1.nuxt.bundle.38d034e2ba6054b908d2.js",
    "nuxt.bundle.83400ec2bd4f29e215ba.js",
    "vendor.bundle.5953dc67058e339c4b85.js",
    "manifest.5953dc67058e339c4b85.js",
    "index.html"
  ],
  "initial": [
    "manifest.5953dc67058e339c4b85.js",
    "vendor.bundle.5953dc67058e339c4b85.js",
    "nuxt.bundle.83400ec2bd4f29e215ba.js",
    "manifest.5953dc67058e339c4b85.js",
    "vendor.bundle.5953dc67058e339c4b85.js"
  ],
  "async": [
    "0.nuxt.bundle.309097aded56ffb03943.js",
    "1.nuxt.bundle.38d034e2ba6054b908d2.js"
  ],
}
```

-------------------
Type: **Bug Fix**
Breaking: **No**