### PR TITLE
fix #5539: improve `isDef` type definition

### DIFF
--- a/flow/component.js
+++ b/flow/component.js
@@ -42,7 +42,7 @@ declare interface Component {
   $once: (event: string, fn: Function) => Component;
   $off: (event?: string | Array<string>, fn?: Function) => Component;
   $emit: (event: string, ...args: Array<mixed>) => Component;
-  $nextTick: (fn: Function) => void;
+  $nextTick: (fn: Function) => void | Promise<*>;
   $createElement: (tag?: string | Component, data?: Object, children?: VNodeChildren) => VNode;
 
   // private properties

--- a/flow/global-api.js
+++ b/flow/global-api.js
@@ -7,7 +7,7 @@ declare interface GlobalAPI {
   extend: (options: Object) => Function;
   set: <T>(target: Object | Array<T>, key: string | number, value: T) => T;
   delete: <T>(target: Object| Array<T>, key: string | number) => void;
-  nextTick: (fn: Function, context?: Object) => void;
+  nextTick: (fn: Function, context?: Object) => void | Promise<*>;
   use: (plugin: Function | Object) => void;
   mixin: (mixin: Object) => void;
   compile: (template: string) => { render: Function, staticRenderFns: Array<Function> };

--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -12,6 +12,8 @@ import {
   handleError
 } from '../util/index'
 
+import type { ISet } from '../util/index'
+
 let uid = 0
 
 /**
@@ -32,8 +34,8 @@ export default class Watcher {
   active: boolean;
   deps: Array<Dep>;
   newDeps: Array<Dep>;
-  depIds: Set;
-  newDepIds: Set;
+  depIds: ISet;
+  newDepIds: ISet;
   getter: Function;
   value: any;
 
@@ -242,7 +244,7 @@ function traverse (val: any) {
   _traverse(val, seenObjects)
 }
 
-function _traverse (val: any, seen: Set) {
+function _traverse (val: any, seen: ISet) {
   let i, keys
   const isA = Array.isArray(val)
   if ((!isA && !isObject(val)) || !Object.isExtensible(val)) {

--- a/src/core/util/debug.js
+++ b/src/core/util/debug.js
@@ -1,9 +1,11 @@
+/* @flow */
+
 import config from '../config'
 import { noop } from 'shared/util'
 
 export let warn = noop
 export let tip = noop
-export let formatComponentName
+export let formatComponentName: Function = (null: any) // work around flow check
 
 if (process.env.NODE_ENV !== 'production') {
   const hasConsole = typeof console !== 'undefined'

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -153,7 +153,7 @@ if (typeof Set !== 'undefined' && isNative(Set)) {
   _Set = Set
 } else {
   // a non-standard Set polyfill that only works with primitive keys.
-  _Set = class Set {
+  _Set = class Set implements ISet {
     set: Object;
     constructor () {
       this.set = Object.create(null)
@@ -170,4 +170,11 @@ if (typeof Set !== 'undefined' && isNative(Set)) {
   }
 }
 
+interface ISet {
+  has(key: string| number): boolean;
+  add(key: string| number): mixed;
+  clear(): void;
+}
+
 export { _Set }
+export type { ISet }

--- a/src/core/util/error.js
+++ b/src/core/util/error.js
@@ -1,8 +1,10 @@
+/* @flow */
+
 import config from '../config'
 import { warn } from './debug'
 import { inBrowser } from './env'
 
-export function handleError (err, vm, info) {
+export function handleError (err: Error, vm: any, info: string) {
   if (config.errorHandler) {
     config.errorHandler.call(null, err, vm, info)
   } else {

--- a/src/core/util/index.js
+++ b/src/core/util/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 export * from 'shared/util'
 export * from './lang'
 export * from './env'

--- a/src/core/vdom/create-functional-component.js
+++ b/src/core/vdom/create-functional-component.js
@@ -22,7 +22,7 @@ export function createFunctionalComponent (
   const propOptions = Ctor.options.props
   if (isDef(propOptions)) {
     for (const key in propOptions) {
-      props[key] = validateProp(key, propOptions, propsData)
+      props[key] = validateProp(key, propOptions, propsData || {})
     }
   } else {
     if (isDef(data.attrs)) mergeProps(props, data.attrs)

--- a/src/core/vdom/create-functional-component.js
+++ b/src/core/vdom/create-functional-component.js
@@ -21,8 +21,9 @@ export function createFunctionalComponent (
   const props = {}
   const propOptions = Ctor.options.props
   if (isDef(propOptions)) {
+    propsData = propsData || {}
     for (const key in propOptions) {
-      props[key] = validateProp(key, propOptions, propsData || {})
+      props[key] = validateProp(key, propOptions, propsData)
     }
   } else {
     if (isDef(data.attrs)) mergeProps(props, data.attrs)

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -103,7 +103,7 @@ export function remove (arr: Array<any>, item: any): Array<any> | void {
  * Check whether the object has the property.
  */
 const hasOwnProperty = Object.prototype.hasOwnProperty
-export function hasOwn (obj: Object, key: string): boolean {
+export function hasOwn (obj: Object | Array<*>, key: string): boolean {
   return hasOwnProperty.call(obj, key)
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -6,7 +6,7 @@ export function isUndef (v: any): boolean {
   return v === undefined || v === null
 }
 
-export function isDef (v: any): boolean {
+export function isDef (v: any) /* : %checks */ {
   return v !== undefined && v !== null
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [x] Other, please describe:
  improve flow type coverage to make `isDef` narrow nullable value to no-null value.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included: no new test needed.

**Other information:**

Currently `isDef` cannot narrow nullable value, as tracked in https://github.com/facebook/flow/issues/34. Howerver, we can use a special `%checks` comment to instruct flow inline the function. 

To make this happen, we need first to type check `utl/index.js`. So some type definition changes are required. I have tried my best to keep changes constrained to type level. But still some changes influence runtime.