### PR TITLE
[bugfix] ignore comment type in array children.

### DIFF
--- a/src/core/vdom/helpers/normalize-children.js
+++ b/src/core/vdom/helpers/normalize-children.js
@@ -53,7 +53,7 @@ function normalizeArrayChildren (children: any, nestedIndex?: string): Array<VNo
         // convert primitive to vnode
         res.push(createTextVNode(c))
       }
-    } else {
+    } else if (!c.isComment) {
       if (isDef(c.text) && isDef(last) && isDef(last.text)) {
         res[res.length - 1] = createTextVNode(last.text + c.text)
       } else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Here is a part of the template which will be rendered both in client-side and server-side:
```
<div v-for="i in 3" v-if="0===i" :is="tabs[i].type" v-bind="tabs[i].data"></div>
```
In Vue 2.3.0, it was rendered to two VNodes: `[component, text]`, while the server-side only rendered the first node. 

The case will lead to this error: `The client-side rendered virtual DOM tree is not matching server-rendered content.`

The problem is, by method `normalizeArrayChildren`, `[component, comment, comment]` will be processed into ` [component] -> [component, comment] ->  [component, text]`.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
