### PR TITLE
Fix use mixin  API feat continuous operation

### DIFF
--- a/src/core/global-api/mixin.js
+++ b/src/core/global-api/mixin.js
@@ -5,5 +5,6 @@ import { mergeOptions } from '../util/index'
 export function initMixin (Vue: GlobalAPI) {
   Vue.mixin = function (mixin: Object) {
     this.options = mergeOptions(this.options, mixin)
+    return this
   }
 }

--- a/src/core/global-api/use.js
+++ b/src/core/global-api/use.js
@@ -6,7 +6,7 @@ export function initUse (Vue: GlobalAPI) {
   Vue.use = function (plugin: Function | Object) {
     /* istanbul ignore if */
     if (plugin.installed) {
-      return
+      return this
     }
     // additional parameters
     const args = toArray(arguments, 1)


### PR DESCRIPTION
### Example
```javascript
import Vue from 'vue'
Vue
  .use(...)
  .use(...)
  .use(...)
  .mixin(...)
  .mixin(...)
  .mixin(...)
```