### PR TITLE
Warn when component option should be an object, but is not (#5605)

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -60,16 +60,14 @@ const isReservedProp = {
   slot: 1
 }
 
-function parseObjectOption (vm: Component, name: string) {
+function checkOptionType (vm: Component, name: string) {
   const option = vm.$options[name]
   if (!isPlainObject(option)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    warn(
       `${name} should be an object.`,
       vm
     )
-    return {}
   }
-  return option
 }
 
 function initProps (vm: Component, propsOptions: Object) {
@@ -160,7 +158,7 @@ function getData (data: Function, vm: Component): any {
 const computedWatcherOptions = { lazy: true }
 
 function initComputed (vm: Component, computed: Object) {
-  computed = parseObjectOption(vm, 'computed')
+  process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'computed')
   const watchers = vm._computedWatchers = Object.create(null)
   for (const key in computed) {
     const userDef = computed[key]
@@ -225,7 +223,7 @@ function createComputedGetter (key) {
 }
 
 function initMethods (vm: Component, methods: Object) {
-  methods = parseObjectOption(vm, 'methods')
+  process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'methods')
   const props = vm.$options.props
   for (const key in methods) {
     vm[key] = methods[key] == null ? noop : bind(methods[key], vm)
@@ -248,7 +246,7 @@ function initMethods (vm: Component, methods: Object) {
 }
 
 function initWatch (vm: Component, watch: Object) {
-  watch = parseObjectOption(vm, 'watch')
+  process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'watch')
   for (const key in watch) {
     const handler = watch[key]
     if (Array.isArray(handler)) {

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -148,8 +148,14 @@ function getData (data: Function, vm: Component): any {
 const computedWatcherOptions = { lazy: true }
 
 function initComputed (vm: Component, computed: Object) {
+  if (!isPlainObject(computed)) {
+    computed = {}
+    process.env.NODE_ENV !== 'production' && warn(
+      'computed should be an object.',
+      vm
+    )
+  }
   const watchers = vm._computedWatchers = Object.create(null)
-
   for (const key in computed) {
     const userDef = computed[key]
     let getter = typeof userDef === 'function' ? userDef : userDef.get
@@ -213,6 +219,13 @@ function createComputedGetter (key) {
 }
 
 function initMethods (vm: Component, methods: Object) {
+  if (!isPlainObject(methods)) {
+    methods = {}
+    process.env.NODE_ENV !== 'production' && warn(
+      'methods should be an object.',
+      vm
+    )
+  }
   const props = vm.$options.props
   for (const key in methods) {
     vm[key] = methods[key] == null ? noop : bind(methods[key], vm)
@@ -235,6 +248,13 @@ function initMethods (vm: Component, methods: Object) {
 }
 
 function initWatch (vm: Component, watch: Object) {
+  if (!isPlainObject(watch)) {
+    watch = {}
+    process.env.NODE_ENV !== 'production' && warn(
+      'watch should be an object.',
+      vm
+    )
+  }
   for (const key in watch) {
     const handler = watch[key]
     if (Array.isArray(handler)) {

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -60,6 +60,17 @@ const isReservedProp = {
   slot: 1
 }
 
+function parseObjectOption (vm: Component, option: Object, name: string) {
+  if (!isPlainObject(option)) {
+    process.env.NODE_ENV !== 'production' && warn(
+      `${name} should be an object.`,
+      vm
+    )
+    return {}
+  }
+  return option
+}
+
 function initProps (vm: Component, propsOptions: Object) {
   const propsData = vm.$options.propsData || {}
   const props = vm._props = {}
@@ -148,13 +159,7 @@ function getData (data: Function, vm: Component): any {
 const computedWatcherOptions = { lazy: true }
 
 function initComputed (vm: Component, computed: Object) {
-  if (!isPlainObject(computed)) {
-    computed = {}
-    process.env.NODE_ENV !== 'production' && warn(
-      'computed should be an object.',
-      vm
-    )
-  }
+  computed = parseObjectOption(vm, computed, 'computed')
   const watchers = vm._computedWatchers = Object.create(null)
   for (const key in computed) {
     const userDef = computed[key]
@@ -219,13 +224,7 @@ function createComputedGetter (key) {
 }
 
 function initMethods (vm: Component, methods: Object) {
-  if (!isPlainObject(methods)) {
-    methods = {}
-    process.env.NODE_ENV !== 'production' && warn(
-      'methods should be an object.',
-      vm
-    )
-  }
+  methods = parseObjectOption(vm, methods, 'methods')
   const props = vm.$options.props
   for (const key in methods) {
     vm[key] = methods[key] == null ? noop : bind(methods[key], vm)
@@ -248,13 +247,7 @@ function initMethods (vm: Component, methods: Object) {
 }
 
 function initWatch (vm: Component, watch: Object) {
-  if (!isPlainObject(watch)) {
-    watch = {}
-    process.env.NODE_ENV !== 'production' && warn(
-      'watch should be an object.',
-      vm
-    )
-  }
+  watch = parseObjectOption(vm, watch, 'watch')
   for (const key in watch) {
     const handler = watch[key]
     if (Array.isArray(handler)) {

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -64,7 +64,7 @@ function checkOptionType (vm: Component, name: string) {
   const option = vm.$options[name]
   if (!isPlainObject(option)) {
     warn(
-      `${name} should be an object.`,
+      `component option "${name}" should be an object.`,
       vm
     )
   }

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -60,7 +60,8 @@ const isReservedProp = {
   slot: 1
 }
 
-function parseObjectOption (vm: Component, option: Object, name: string) {
+function parseObjectOption (vm: Component, name: string) {
+  const option = vm.$options[name]
   if (!isPlainObject(option)) {
     process.env.NODE_ENV !== 'production' && warn(
       `${name} should be an object.`,
@@ -159,7 +160,7 @@ function getData (data: Function, vm: Component): any {
 const computedWatcherOptions = { lazy: true }
 
 function initComputed (vm: Component, computed: Object) {
-  computed = parseObjectOption(vm, computed, 'computed')
+  computed = parseObjectOption(vm, 'computed')
   const watchers = vm._computedWatchers = Object.create(null)
   for (const key in computed) {
     const userDef = computed[key]
@@ -224,7 +225,7 @@ function createComputedGetter (key) {
 }
 
 function initMethods (vm: Component, methods: Object) {
-  methods = parseObjectOption(vm, methods, 'methods')
+  methods = parseObjectOption(vm, 'methods')
   const props = vm.$options.props
   for (const key in methods) {
     vm[key] = methods[key] == null ? noop : bind(methods[key], vm)
@@ -247,7 +248,7 @@ function initMethods (vm: Component, methods: Object) {
 }
 
 function initWatch (vm: Component, watch: Object) {
-  watch = parseObjectOption(vm, watch, 'watch')
+  watch = parseObjectOption(vm, 'watch')
   for (const key in watch) {
     const handler = watch[key]
     if (Array.isArray(handler)) {

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -160,6 +160,7 @@ const computedWatcherOptions = { lazy: true }
 function initComputed (vm: Component, computed: Object) {
   process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'computed')
   const watchers = vm._computedWatchers = Object.create(null)
+
   for (const key in computed) {
     const userDef = computed[key]
     let getter = typeof userDef === 'function' ? userDef : userDef.get

--- a/test/helpers/test-object-option.js
+++ b/test/helpers/test-object-option.js
@@ -3,7 +3,7 @@ import Vue from 'vue'
 export default function testObjectOption (name: string) {
   it('should warn non object', () => {
     const options = {}
-    options[name] = 'wrong'
+    options[name] = () => {}
     new Vue(options)
     expect(`${name} should be an object`).toHaveBeenWarned()
   })

--- a/test/helpers/test-object-option.js
+++ b/test/helpers/test-object-option.js
@@ -5,13 +5,13 @@ export default function testObjectOption (name: string) {
     const options = {}
     options[name] = () => {}
     new Vue(options)
-    expect(`${name} should be an object`).toHaveBeenWarned()
+    expect(`component option "${name}" should be an object`).toHaveBeenWarned()
   })
 
   it('don\'t warn when is an object', () => {
     const options = {}
     options[name] = {}
     new Vue(options)
-    expect(`${name} should be an object`).not.toHaveBeenWarned()
+    expect(`component option "${name}" should be an object`).not.toHaveBeenWarned()
   })
 }

--- a/test/helpers/test-object-option.js
+++ b/test/helpers/test-object-option.js
@@ -1,0 +1,17 @@
+import Vue from 'vue'
+
+export default function testObjectOption (name: string) {
+  it('should warn non object', () => {
+    const options = {}
+    options[name] = 'wrong'
+    new Vue(options)
+    expect(`${name} should be an object`).toHaveBeenWarned()
+  })
+
+  it('don\'t warn when is an object', () => {
+    const options = {}
+    options[name] = {}
+    new Vue(options)
+    expect(`${name} should be an object`).not.toHaveBeenWarned()
+  })
+}

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -48,6 +48,13 @@ describe('Options computed', () => {
     }).then(done)
   })
 
+  it('warn non object', () => {
+    new Vue({
+      computed: 'wrong'
+    })
+    expect('computed should be an object').toHaveBeenWarned()
+  })
+
   it('warn with setter and no getter', () => {
     const vm = new Vue({
       template: `

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -55,6 +55,13 @@ describe('Options computed', () => {
     expect('computed should be an object').toHaveBeenWarned()
   })
 
+  it('don\'t warn when is an object', () => {
+    new Vue({
+      computed: {}
+    })
+    expect('computed should be an object').not.toHaveBeenWarned()
+  })
+
   it('warn with setter and no getter', () => {
     const vm = new Vue({
       template: `

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import testObjectOption from '../../../helpers/test-object-option'
 
 describe('Options computed', () => {
   it('basic usage', done => {
@@ -48,19 +49,7 @@ describe('Options computed', () => {
     }).then(done)
   })
 
-  it('warn non object', () => {
-    new Vue({
-      computed: 'wrong'
-    })
-    expect('computed should be an object').toHaveBeenWarned()
-  })
-
-  it('don\'t warn when is an object', () => {
-    new Vue({
-      computed: {}
-    })
-    expect('computed should be an object').not.toHaveBeenWarned()
-  })
+  testObjectOption('computed')
 
   it('warn with setter and no getter', () => {
     const vm = new Vue({

--- a/test/unit/features/options/methods.spec.js
+++ b/test/unit/features/options/methods.spec.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import testObjectOption from '../../../helpers/test-object-option'
 
 describe('Options methods', () => {
   it('should have correct context', () => {
@@ -16,6 +17,8 @@ describe('Options methods', () => {
     expect(vm.a).toBe(2)
   })
 
+  testObjectOption('methods')
+
   it('should warn undefined methods', () => {
     new Vue({
       methods: {
@@ -23,19 +26,5 @@ describe('Options methods', () => {
       }
     })
     expect(`method "hello" has an undefined value in the component definition`).toHaveBeenWarned()
-  })
-
-  it('should warn non object', () => {
-    new Vue({
-      methods: 'wrong'
-    })
-    expect('methods should be an object').toHaveBeenWarned()
-  })
-
-  it('don\'t warn when is an object', () => {
-    new Vue({
-      methods: {}
-    })
-    expect('computed should be an object').not.toHaveBeenWarned()
   })
 })

--- a/test/unit/features/options/methods.spec.js
+++ b/test/unit/features/options/methods.spec.js
@@ -31,4 +31,11 @@ describe('Options methods', () => {
     })
     expect('methods should be an object').toHaveBeenWarned()
   })
+
+  it('don\'t warn when is an object', () => {
+    new Vue({
+      methods: {}
+    })
+    expect('computed should be an object').not.toHaveBeenWarned()
+  })
 })

--- a/test/unit/features/options/methods.spec.js
+++ b/test/unit/features/options/methods.spec.js
@@ -24,4 +24,11 @@ describe('Options methods', () => {
     })
     expect(`method "hello" has an undefined value in the component definition`).toHaveBeenWarned()
   })
+
+  it('should warn non object', () => {
+    new Vue({
+      methods: 'wrong'
+    })
+    expect('methods should be an object').toHaveBeenWarned()
+  })
 })

--- a/test/unit/features/options/watch.spec.js
+++ b/test/unit/features/options/watch.spec.js
@@ -23,6 +23,13 @@ describe('Options watch', () => {
     }).then(done)
   })
 
+  it('warn non object', () => {
+    new Vue({
+      watch: 'wrong'
+    })
+    expect('watch should be an object').toHaveBeenWarned()
+  })
+
   it('string method name', done => {
     const vm = new Vue({
       data: {

--- a/test/unit/features/options/watch.spec.js
+++ b/test/unit/features/options/watch.spec.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import testObjectOption from '../../../helpers/test-object-option'
 
 describe('Options watch', () => {
   let spy
@@ -23,19 +24,7 @@ describe('Options watch', () => {
     }).then(done)
   })
 
-  it('warn non object', () => {
-    new Vue({
-      watch: 'wrong'
-    })
-    expect('watch should be an object').toHaveBeenWarned()
-  })
-
-  it('don\'t warn when is an object', () => {
-    new Vue({
-      watch: {}
-    })
-    expect('computed should be an object').not.toHaveBeenWarned()
-  })
+  testObjectOption('watch')
 
   it('string method name', done => {
     const vm = new Vue({

--- a/test/unit/features/options/watch.spec.js
+++ b/test/unit/features/options/watch.spec.js
@@ -30,6 +30,13 @@ describe('Options watch', () => {
     expect('watch should be an object').toHaveBeenWarned()
   })
 
+  it('don\'t warn when is an object', () => {
+    new Vue({
+      watch: {}
+    })
+    expect('computed should be an object').not.toHaveBeenWarned()
+  })
+
   it('string method name', done => {
     const vm = new Vue({
       data: {


### PR DESCRIPTION
https://github.com/vuejs/vue/issues/5605

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
