### PR TITLE
fix: prefetch should not have `as` attribute

### DIFF
--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -181,7 +181,7 @@ export default class TemplateRenderer {
       }
       return this.prefetchFiles.map(file => {
         if (!alreadyRendered(file)) {
-          return `<link rel="prefetch" href="${this.publicPath}/${file}" as="script">`
+          return `<link rel="prefetch" href="${this.publicPath}/${file}">`
         } else {
           return ''
         }

--- a/test/ssr/ssr-template.spec.js
+++ b/test/ssr/ssr-template.spec.js
@@ -230,7 +230,7 @@ describe('SSR: template option', () => {
       (options.preloadOtherAssets ? `<link rel="preload" href="/test.png" as="image">` : ``) +
       (options.preloadOtherAssets ? `<link rel="preload" href="/test.woff2" as="font" type="font/woff2" crossorigin>` : ``) +
       // unused chunks should have prefetch
-      `<link rel="prefetch" href="/1.js" as="script">` +
+      `<link rel="prefetch" href="/1.js">` +
       // css assets should be loaded
       `<link rel="stylesheet" href="/test.css">` +
     `</head><body>` +


### PR DESCRIPTION

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Actually, `vue-server-renderer` does not generate valid HTML because of the `as` attribute on `rel="prefetch"`, this PR fix this issue.

![screenshot_2017-05-16_17-36-56](https://cloud.githubusercontent.com/assets/904724/26116449/7c701838-3a63-11e7-9c17-ed64b5b5cbd3.png)
