### PR TITLE
Move link to docs under it's own heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ Vue.js is a library for building interactive web interfaces. It provides data-re
 - [Flexible transition effect system](https://vuejs.org/guide/transitions.html)
 - Fast without the need for complex optimization
 
-Note that Vue.js only supports [ES5-compliant browsers](http://kangax.github.io/compat-table/es5/) (IE8 and below are not supported). To check out live examples and docs, visit [vuejs.org](https://vuejs.org).
+Note that Vue.js only supports [ES5-compliant browsers](http://kangax.github.io/compat-table/es5/) (IE8 and below are not supported).
+
+## Documentation
+
+To check out live examples and docs, visit [vuejs.org](https://vuejs.org).
 
 ## Questions
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: **_Update to documentation._**

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR moves the link to the documentation site under it's own heading in the repo's README.

The reason I submitted this PR is that I often have trouble finding the Vue docs.
When googling I click the Vue github repo link by default. 
When landing on the github repo I am confused as to where the docs are.
Currently there **is** a link to the documentation site, however it is not very noticeable.
In order to make it **more** noticeable and easier for other developers to find, I have moved the link to the documentation under it's own heading.

This will make it easier for developers to quickly find a link to the Vue documentation from the github repo.
