### PR TITLE
Provide an option called plugins to process ast in vue-template-compiler, fix #5703

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -21,6 +21,8 @@ declare type CompilerOptions = {
 
   // runtime user-configurable
   delimiters?: [string, string]; // template delimiters
+
+  plugins?: Array<Function>; // customizing plugins to process ast
 };
 
 declare type CompiledResult = {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -14,6 +14,9 @@ export const createCompiler = createCompilerCreator(function baseCompile (
 ): CompiledResult {
   const ast = parse(template.trim(), options)
   optimize(ast, options)
+  if (options.plugins) {
+    options.plugins.forEach(plugin => plugin(ast, options))
+  }
   const code = generate(ast, options)
   return {
     ast,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Plugins to process AST like ones in postcss.