### PR TITLE
Allow white space when v-binding to an array or object (fix #4881)

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -21,7 +21,7 @@ const singleAttrValues = [
   // attr value, single quotes
   /'([^']*)'+/.source,
   // attr value, no quotes
-  /([^\s"'=<>`]+)/.source
+  /([^"'=<>`]+)/.source
 ]
 const attribute = new RegExp(
   '^\\s*' + singleAttrIdentifier.source +

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -123,7 +123,7 @@ describe('parser', () => {
   it('not warn 3 root elements with v-if, v-else-if and v-else', () => {
     parse('<div v-if="1"></div><div v-else-if="2"></div><div v-else></div>', baseOptions)
     expect('Component template should contain exactly one root element')
-        .not.toHaveBeenWarned()
+      .not.toHaveBeenWarned()
   })
 
   it('not warn 2 root elements with v-if and v-else on separate lines', () => {
@@ -142,7 +142,7 @@ describe('parser', () => {
       <div v-else></div>
     `, baseOptions)
     expect('Component template should contain exactly one root element')
-        .not.toHaveBeenWarned()
+      .not.toHaveBeenWarned()
 
     parse(`
       <div v-if="1"></div>
@@ -152,7 +152,7 @@ describe('parser', () => {
       <div v-else></div>
     `, baseOptions)
     expect('Component template should contain exactly one root element')
-        .not.toHaveBeenWarned()
+      .not.toHaveBeenWarned()
   })
 
   it('generate correct ast for 2 root elements with v-if and v-else on separate lines', () => {
@@ -219,7 +219,7 @@ describe('parser', () => {
   it('warn 2 root elements with v-if and v-else-if with v-for on 2nd', () => {
     parse('<div v-if="1"></div><div v-else-if="2" v-for="i in [1]"></div>', baseOptions)
     expect('Cannot use v-for on stateful component root element because it renders multiple elements')
-        .toHaveBeenWarned()
+      .toHaveBeenWarned()
   })
 
   it('warn <template> as root element', () => {
@@ -547,5 +547,23 @@ describe('parser', () => {
     const options = extend({}, baseOptions)
     const ast = parse(`<script type="x/template">&gt;<foo>&lt;</script>`, options)
     expect(ast.children[0].text).toBe(`&gt;<foo>&lt;`)
+  })
+
+  // #4881
+  it('should not break array class match on white space', () => {
+    const ast = parse(`<p :class=[color, decoration]>{{message}}</p>`, baseOptions)
+    expect(ast.tag).toBe('p')
+    expect(ast.plain).toBe(false)
+    expect(ast.classBinding).toBe('[color, decoration]')
+    expect(ast.attrsMap[':class']).toBe('[color, decoration]')
+  })
+
+  // #4881
+  it('should not break object class match on white space', () => {
+    const ast = parse(`<p :class={enabled: isEnabled, error: hasError}>{{message}}</p>`, baseOptions)
+    expect(ast.tag).toBe('p')
+    expect(ast.plain).toBe(false)
+    expect(ast.classBinding).toBe('{enabled: isEnabled, error: hasError}')
+    expect(ast.attrsMap[':class']).toBe('{enabled: isEnabled, error: hasError}')
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Not really a _bug_ but prevents a compilation error when you have white space in array or object bindings which is a common way to write them.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When binding a value using array or object syntax, it is much more human readable and human writable to allow white space within it. This PR makes a change to the 5th capture group of the HTML parser regex to not break the match when a white space appears, thus allowing you to have spaces in your array/object syntax.

For example, if you have a template like one of these:
```js
template: `<p :class=[color, decoration]>{{message}}</p>`,
//or
template: `<p :class={enabled: isEnabled, error: hasError}>{{message}}</p>`
```
The current parser will throw a template compilation error `- invalid expression: :class="[color,"`. [Here is a simple jsfiddle showing the issue](https://jsfiddle.net/jimrottinger/50wL7mdz/40869/). The changes in this PR correctly grabs the entire array or object, white spaces included.