### PR TITLE
README update to include Vue Land as questions resource and chat badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To check out live examples and docs, visit [vuejs.org](https://vuejs.org).
 
 ## Questions
 
-For questions and support please use the [Discord chat room](https://discord.gg/eKWPvZ9), [Gitter chat room](https://gitter.im/vuejs/vue), or [the official forum](http://forum.vuejs.org). The issue list of this repo is **exclusively** for bug reports and feature requests.
+For questions and support please use the [Discord chat room](https://vue-land.js.org/), [Gitter chat room](https://gitter.im/vuejs/vue), or [the official forum](http://forum.vuejs.org). The issue list of this repo is **exclusively** for bug reports and feature requests.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/dm/vue.svg" alt="Downloads"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/v/vue.svg" alt="Version"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/l/vue.svg" alt="License"></a>
+  <a href="https://gitter.im/vuejs/vue"><img src="https://img.shields.io/gitter/room/nwjs/nw.js.svg" alt="Gitter">
+  <a href="https://discordapp.com/invite/eKWPvZ9"><img src="https://img.shields.io/badge/chat-on%20discord-7289da.svg" alt="Discord">
   <br>
   <a href="https://saucelabs.com/u/vuejs"><img src="https://saucelabs.com/browser-matrix/vuejs.svg" alt="Sauce Test Status"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To check out live examples and docs, visit [vuejs.org](https://vuejs.org).
 
 ## Questions
 
-For questions and support please use the [Gitter chat room](https://gitter.im/vuejs/vue) or [the official forum](http://forum.vuejs.org). The issue list of this repo is **exclusively** for bug reports and feature requests.
+For questions and support please use the [Discord chat room](https://discord.gg/eKWPvZ9), [Gitter chat room](https://gitter.im/vuejs/vue), or [the official forum](http://forum.vuejs.org). The issue list of this repo is **exclusively** for bug reports and feature requests.
 
 ## Issues
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR is an update to the README file to include the Vue Land chat hosted by Discord. 😄  Although @egoist has mentioned the chat on Twitter I thought it'd be a good idea to include it in the README so new and old Vue developers know about the resource. Also, I added badges for both the Discord and Gitter chats.

_Since this PR made no changes to Vue's codebase I neglected to run any test._