### PR TITLE
fix: ensure cleanup in watcher.get

### DIFF
--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -94,22 +94,23 @@ export default class Watcher {
     pushTarget(this)
     let value
     const vm = this.vm
-    if (this.user) {
-      try {
-        value = this.getter.call(vm, vm)
-      } catch (e) {
-        handleError(e, vm, `getter for watcher "${this.expression}"`)
-      }
-    } else {
+    try {
       value = this.getter.call(vm, vm)
+    } catch (e) {
+      if (this.user) {
+        handleError(e, vm, `getter for watcher "${this.expression}"`)
+      } else {
+        throw e
+      }
+    } finally {
+      // "touch" every property so they are all tracked as
+      // dependencies for deep watching
+      if (this.deep) {
+        traverse(value)
+      }
+      popTarget()
+      this.cleanupDeps()
     }
-    // "touch" every property so they are all tracked as
-    // dependencies for deep watching
-    if (this.deep) {
-      traverse(value)
-    }
-    popTarget()
-    this.cleanupDeps()
     return value
   }
 

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -193,4 +193,15 @@ describe('Options computed', () => {
     })
     expect(`computed property "a" is already defined as a prop`).toHaveBeenWarned()
   })
+
+  it('rethrow computed error', () => {
+    const vm = new Vue({
+      computed: {
+        a: () => {
+          throw new Error('rethrow')
+        }
+      }
+    })
+    expect(() => vm.a).toThrowError('rethrow')
+  })
 })


### PR DESCRIPTION
watcher.get should always clean up observee stack in order to prevent memory leak. Also, non-user
defined watch should rethrow error.

#5975 