### PR TITLE
added Object key sort prior to JSON.stringify comparison (fix #5908)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -23,7 +23,7 @@ export function isFalse (v: any): boolean %checks {
  * by succinct key order. Guaranteed to at least return an
  * empty object.
  */
-export function keySort (obj: Object): Object {
+export function keySort (obj: any): Object {
   if (isObject(obj) === false) {
     return {}
   }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -17,6 +17,23 @@ export function isTrue (v: any): boolean %checks {
 export function isFalse (v: any): boolean %checks {
   return v === false
 }
+
+/**
+ * Sorts an object by key to ensure seraialized equality
+ * by succinct key order. Guaranteed to at least return an
+ * empty object.
+ */
+export function keySort (obj: Object): Object {
+  if (isObject(obj) === false) {
+    return {}
+  }
+  const sorted = {}
+  Object.keys(obj).sort().forEach(key => {
+    sorted[key] = obj[key]
+  })
+  return sorted
+}
+
 /**
  * Check if value is primitive
  */
@@ -240,7 +257,7 @@ export function looseEqual (a: mixed, b: mixed): boolean {
   const isObjectB = isObject(b)
   if (isObjectA && isObjectB) {
     try {
-      return JSON.stringify(a) === JSON.stringify(b)
+      return JSON.stringify(keySort(a)) === JSON.stringify(keySort(b))
     } catch (e) {
       // possible circular reference
       return a === b

--- a/test/unit/modules/shared/key-sort.spec.js
+++ b/test/unit/modules/shared/key-sort.spec.js
@@ -1,0 +1,55 @@
+import { keySort, looseEqual } from 'shared/util'
+
+describe('keySort', () => {
+  const chars = '0123456789abcdefghijklmnopqrstuvwxyz!@#$%^&*()_+./'
+  const randomWord = () => {
+    const letters = []
+    for (let cnt = 0; cnt < 10; cnt++) {
+      letters.push(chars.charAt(Math.floor(Math.random() * chars.length)))
+    }
+    return letters.join('')
+  }
+  const unsortedObject = () => {
+    const unsorted = {}
+    chars.split('').map(c => {
+      unsorted[c + '' + randomWord()] = randomWord()
+    })
+    return unsorted
+  }
+
+  it('returns Object for empty Object argument', () => {
+    expect(looseEqual(keySort({}), {})).toBe(true)
+  })
+
+  it('returns Object for Array argument', () => {
+    expect(looseEqual(keySort([]), {})).toBe(true)
+  })
+
+  it('returns Object for String argument', () => {
+    expect(looseEqual(keySort('Test String'), {})).toBe(true)
+  })
+
+  it('returns Object for Number argument', () => {
+    expect(looseEqual(keySort(Number.MAX_SAFE_INTEGER), {})).toBe(true)
+  })
+
+  it('returns Object for Undefined argument', () => {
+    expect(looseEqual(keySort(undefined), {})).toBe(true)
+  })
+
+  it('returns Object for Null argument', () => {
+    expect(looseEqual(keySort(null), {})).toBe(true)
+  })
+
+  it('Sorts an unsorted Object, which are equal', () => {
+    const unsortedTestObj = unsortedObject()
+    const sortedObject = keySort(unsortedTestObj)
+    expect(looseEqual(sortedObject, sortedObject)).toBe(true)
+  })
+
+  it('does not unsort a sorted object', () => {
+    const sortedObject = keySort(unsortedObject())
+    const sortedObjectCompare = keySort(sortedObject)
+    expect(looseEqual(sortedObject, sortedObjectCompare)).toBe(true)
+  })
+})

--- a/test/unit/modules/shared/key-sort.spec.js
+++ b/test/unit/modules/shared/key-sort.spec.js
@@ -44,7 +44,7 @@ describe('keySort', () => {
   it('Sorts an unsorted Object, which are equal', () => {
     const unsortedTestObj = unsortedObject()
     const sortedObject = keySort(unsortedTestObj)
-    expect(looseEqual(sortedObject, sortedObject)).toBe(true)
+    expect(looseEqual(sortedObject, unsortedTestObj)).toBe(true)
   })
 
   it('does not unsort a sorted object', () => {


### PR DESCRIPTION
#5908

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe: Improvement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
