### PR TITLE
fix: the first LF following pre and textarea tag should be ignored, fix #5992

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -61,7 +61,7 @@ const encodedAttrWithNewLines = /&(?:lt|gt|quot|amp|#10);/g
 
 // #5992
 const ignoreFirstLFTagList = makeMap('pre,textarea', true)
-const isIgnoreFirstLf = (tag, html) => tag && ignoreFirstLFTagList(tag.toLowerCase()) && html[0] === '\n'
+const isIgnoreFirstLf = (tag, html) => tag && ignoreFirstLFTagList(tag) && html[0] === '\n'
 
 function decodeAttr (value, shouldDecodeNewlines) {
   const re = shouldDecodeNewlines ? encodedAttrWithNewLines : encodedAttr

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -59,6 +59,7 @@ const decodingMap = {
 const encodedAttr = /&(?:lt|gt|quot|amp);/g
 const encodedAttrWithNewLines = /&(?:lt|gt|quot|amp|#10);/g
 
+// #5992
 const ignoreFirstLFTagList = makeMap('pre,textarea', true)
 const isIgnoreFirstLf = (tag, html) => tag && ignoreFirstLFTagList(tag.toLowerCase()) && html[0] === '\n'
 
@@ -78,7 +79,6 @@ export function parseHTML (html, options) {
     last = html
     // Make sure we're not in a plaintext content element like script/style
     if (!lastTag || !isPlainTextElement(lastTag)) {
-      // #5992
       if (isIgnoreFirstLf(lastTag, html)) {
         advance(1)
       }

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -59,6 +59,9 @@ const decodingMap = {
 const encodedAttr = /&(?:lt|gt|quot|amp);/g
 const encodedAttrWithNewLines = /&(?:lt|gt|quot|amp|#10);/g
 
+const ignoreFirstLFTagList = makeMap('pre,textarea', true)
+const isIgnoreFirstLf = (tag, html) => tag && ignoreFirstLFTagList(tag.toLowerCase()) && html[0] === '\n'
+
 function decodeAttr (value, shouldDecodeNewlines) {
   const re = shouldDecodeNewlines ? encodedAttrWithNewLines : encodedAttr
   return value.replace(re, match => decodingMap[match])
@@ -75,6 +78,10 @@ export function parseHTML (html, options) {
     last = html
     // Make sure we're not in a plaintext content element like script/style
     if (!lastTag || !isPlainTextElement(lastTag)) {
+      // #5992
+      if (isIgnoreFirstLf(lastTag, html)) {
+        advance(1)
+      }
       let textEnd = html.indexOf('<')
       if (textEnd === 0) {
         // Comment:
@@ -152,15 +159,18 @@ export function parseHTML (html, options) {
         options.chars(text)
       }
     } else {
-      var stackedTag = lastTag.toLowerCase()
-      var reStackedTag = reCache[stackedTag] || (reCache[stackedTag] = new RegExp('([\\s\\S]*?)(</' + stackedTag + '[^>]*>)', 'i'))
-      var endTagLength = 0
-      var rest = html.replace(reStackedTag, function (all, text, endTag) {
+      let endTagLength = 0
+      const stackedTag = lastTag.toLowerCase()
+      const reStackedTag = reCache[stackedTag] || (reCache[stackedTag] = new RegExp('([\\s\\S]*?)(</' + stackedTag + '[^>]*>)', 'i'))
+      const rest = html.replace(reStackedTag, function (all, text, endTag) {
         endTagLength = endTag.length
         if (!isPlainTextElement(stackedTag) && stackedTag !== 'noscript') {
           text = text
             .replace(/<!--([\s\S]*?)-->/g, '$1')
             .replace(/<!\[CDATA\[([\s\S]*?)]]>/g, '$1')
+        }
+        if (isIgnoreFirstLf(stackedTag, text)) {
+          text = text.substring(1)
         }
         if (options.chars) {
           options.chars(text)

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -60,8 +60,8 @@ const encodedAttr = /&(?:lt|gt|quot|amp);/g
 const encodedAttrWithNewLines = /&(?:lt|gt|quot|amp|#10);/g
 
 // #5992
-const ignoreFirstLFTagList = makeMap('pre,textarea', true)
-const isIgnoreFirstLf = (tag, html) => tag && ignoreFirstLFTagList(tag) && html[0] === '\n'
+const isIgnoreNewlineTag = makeMap('pre,textarea', true)
+const shouldIgnoreFirstNewline = (tag, html) => tag && isIgnoreNewlineTag(tag) && html[0] === '\n'
 
 function decodeAttr (value, shouldDecodeNewlines) {
   const re = shouldDecodeNewlines ? encodedAttrWithNewLines : encodedAttr
@@ -79,7 +79,7 @@ export function parseHTML (html, options) {
     last = html
     // Make sure we're not in a plaintext content element like script/style
     if (!lastTag || !isPlainTextElement(lastTag)) {
-      if (isIgnoreFirstLf(lastTag, html)) {
+      if (shouldIgnoreFirstNewline(lastTag, html)) {
         advance(1)
       }
       let textEnd = html.indexOf('<')
@@ -169,8 +169,8 @@ export function parseHTML (html, options) {
             .replace(/<!--([\s\S]*?)-->/g, '$1')
             .replace(/<!\[CDATA\[([\s\S]*?)]]>/g, '$1')
         }
-        if (isIgnoreFirstLf(stackedTag, text)) {
-          text = text.substring(1)
+        if (shouldIgnoreFirstNewline(stackedTag, text)) {
+          text = text.slice(1)
         }
         if (options.chars) {
           options.chars(text)

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -495,6 +495,21 @@ describe('parser', () => {
     expect(span.children[0].text).toBe(' ')
   })
 
+  // #5992
+  it('ignore the first LF in <pre> tag', function () {
+    const options = extend({}, baseOptions)
+    const ast = parse('<div><pre>\nabc</pre>\ndef<pre>\n\nabc</pre></div>', options)
+    const pre = ast.children[0]
+    expect(pre.children[0].type).toBe(3)
+    expect(pre.children[0].text).toBe('abc')
+    const text = ast.children[1]
+    expect(text.type).toBe(3)
+    expect(text.text).toBe('\ndef')
+    const pre2 = ast.children[2]
+    expect(pre2.children[0].type).toBe(3)
+    expect(pre2.children[0].text).toBe('\nabc')
+  })
+
   it('forgivingly handle < in plain text', () => {
     const options = extend({}, baseOptions)
     const ast = parse('<p>1 < 2 < 3</p>', options)

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -530,8 +530,7 @@ describe('parser', () => {
     expect(whitespace.children.length).toBe(1)
     expect(whitespace.children[0].type).toBe(3)
     // textarea is whitespace sensitive
-    expect(whitespace.children[0].text).toBe(`
-        <p>Test 1</p>
+    expect(whitespace.children[0].text).toBe(`        <p>Test 1</p>
         test2
       `)
 

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -496,7 +496,7 @@ describe('parser', () => {
   })
 
   // #5992
-  it('ignore the first LF in <pre> tag', function () {
+  it('ignore the first newline in <pre> tag', function () {
     const options = extend({}, baseOptions)
     const ast = parse('<div><pre>\nabc</pre>\ndef<pre>\n\nabc</pre></div>', options)
     const pre = ast.children[0]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [X] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
fix #5992 