### PR TITLE
perf: remove src directory from npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "unpkg": "dist/vue.js",
   "typings": "types/index.d.ts",
   "files": [
-    "src",
     "dist/*.js",
     "types/*.d.ts"
   ],


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

Breaking change is only for users, who uses undocumented requires/imports from `vue/src`. After this PR all scripts from `src` folder are not included in npm-package

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**


`src` directory is not used by node package. Removing this directory reduces size of `.tgz` package by 112kb and saves 840kb in each node project, where vue.js is installed
