### PR TITLE
fix #6093, inject should not be merged with Object.create

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -195,11 +195,16 @@ strats.watch = function (parentVal: ?Object, childVal: ?Object): ?Object {
  */
 strats.props =
 strats.methods =
-strats.inject =
 strats.computed = function (parentVal: ?Object, childVal: ?Object): ?Object {
   if (!childVal) return Object.create(parentVal || null)
   if (!parentVal) return childVal
   const ret = Object.create(null)
+  extend(ret, parentVal)
+  extend(ret, childVal)
+  return ret
+}
+strats.inject = function (parentVal: ?Object, childVal: ?Object): ?Object {
+  const ret = {}
   extend(ret, parentVal)
   extend(ret, childVal)
   return ret

--- a/test/unit/features/options/inject.spec.js
+++ b/test/unit/features/options/inject.spec.js
@@ -442,4 +442,25 @@ describe('Options provide/inject', () => {
     expect(isObserver(child.bar)).toBe(false)
     expect(isObserver(child.baz)).toBe(false)
   })
+
+  // #6093
+  it('should merge inject from mixins properly', () => {
+    const mixinA = { inject: ['foo'] }
+    const mixinB = { inject: ['bar'] }
+    const child = {
+      template: `<span/>`,
+      mixins: [mixinA, mixinB],
+      created () {
+        injected = [this.foo, this.bar]
+      }
+    }
+    new Vue({
+      provide: { foo: 'foo', bar: 'bar' },
+      render (h) {
+        return h(child)
+      }
+    }).$mount()
+
+    expect(injected).toEqual(['foo', 'bar'])
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ x When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
fix [https://github.com/vuejs/vue/issues/6093](https://github.com/vuejs/vue/issues/6093)

`Object.create` is not adding 'own property' to the object, which caused injections not injected properly.😭