### PR TITLE
fix #6154: use prop when prop modifier was explicitly declared

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -483,8 +483,8 @@ function processAttrs (el) {
             )
           }
         }
-        if (!el.component && (
-          isProp || platformMustUseProp(el.tag, el.attrsMap.type, name)
+        if (isProp || (
+          !el.component && platformMustUseProp(el.tag, el.attrsMap.type, name)
         )) {
           addProp(el, name, value)
         } else {

--- a/test/unit/features/component/component.spec.js
+++ b/test/unit/features/component/component.spec.js
@@ -187,6 +187,25 @@ describe('Component', () => {
     }).then(done)
   })
 
+  it('dynamic elements with domProps', done => {
+    const vm = new Vue({
+      template: '<component :is="view" :value.prop="val"></component>',
+      data: {
+        view: 'input',
+        val: 'hello'
+      }
+    }).$mount()
+    expect(vm.$el.tagName).toBe('INPUT')
+    expect(vm.$el.value).toBe('hello')
+    vm.view = 'textarea'
+    vm.val += ' world'
+    waitForUpdate(() => {
+      expect(vm.$el.tagName).toBe('TEXTAREA')
+      expect(vm.$el.value).toBe('hello world')
+      vm.view = ''
+    }).then(done)
+  })
+
   it('should compile parent template directives & content in parent scope', done => {
     const vm = new Vue({
       data: {

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -463,6 +463,14 @@ describe('parser', () => {
     expect(ast.props).toBeUndefined()
   })
 
+  it('use prop when prop modifier was explicitly declared', () => {
+    const ast = parse('<component is="textarea" :value.prop="val" />', baseOptions)
+    expect(ast.attrs).toBeUndefined()
+    expect(ast.props.length).toBe(1)
+    expect(ast.props[0].name).toBe('value')
+    expect(ast.props[0].value).toBe('val')
+  })
+
   it('pre/post transforms', () => {
     const options = extend({}, baseOptions)
     const spy1 = jasmine.createSpy('preTransform')


### PR DESCRIPTION
fix #6154 .
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
