### PR TITLE
fix #6193, change event should not be triggered if each value still matches an option

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -60,7 +60,14 @@ export default {
       const prevOptions = el._vOptions
       const curOptions = el._vOptions = [].map.call(el.options, getValue)
       if (curOptions.some((o, i) => !looseEqual(o, prevOptions[i]))) {
-        trigger(el, 'change')
+        // trigger change event if
+        // no matching option found for at least one value
+        const needReset = el.multiple
+          ? binding.value.some(v => hasNoMatchingOption(v, el.options))
+          : binding.value !== binding.oldValue && hasNoMatchingOption(binding.value, el.options)
+        if (needReset) {
+          trigger(el, 'change')
+        }
       }
     }
   }
@@ -99,6 +106,15 @@ function setSelected (el, binding, vm) {
   if (!isMultiple) {
     el.selectedIndex = -1
   }
+}
+
+function hasNoMatchingOption (value, options) {
+  for (let i = 0, l = options.length; i < l; i++) {
+    if (looseEqual(getValue(options[i]), value)) {
+      return false
+    }
+  }
+  return true
 }
 
 function getValue (option) {

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -63,8 +63,8 @@ export default {
         // trigger change event if
         // no matching option found for at least one value
         const needReset = el.multiple
-          ? binding.value.some(v => hasNoMatchingOption(v, el.options))
-          : binding.value !== binding.oldValue && hasNoMatchingOption(binding.value, el.options)
+          ? binding.value.some(v => hasNoMatchingOption(v, curOptions))
+          : binding.value !== binding.oldValue && hasNoMatchingOption(binding.value, curOptions)
         if (needReset) {
           trigger(el, 'change')
         }
@@ -109,12 +109,7 @@ function setSelected (el, binding, vm) {
 }
 
 function hasNoMatchingOption (value, options) {
-  for (let i = 0, l = options.length; i < l; i++) {
-    if (looseEqual(getValue(options[i]), value)) {
-      return false
-    }
-  }
-  return true
+  return options.every(o => !looseEqual(o, value))
 }
 
 function getValue (option) {

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -519,7 +519,7 @@ describe('Directive v-model select', () => {
   })
 
   // #6193
-  it('should not trigger change event when match option can be found for each value', done => {
+  it('should not trigger change event when matching option can be found for each value', done => {
     const spy = jasmine.createSpy()
     const vm = new Vue({
       data: {

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -517,4 +517,33 @@ describe('Directive v-model select', () => {
       expect(vm.test).toBe('2')
     }).then(done)
   })
+
+  // #6193
+  it('should not trigger change event when match option can be found for each value', done => {
+    const spy = jasmine.createSpy()
+    const vm = new Vue({
+      data: {
+        options: ['1']
+      },
+      computed: {
+        test: {
+          get () {
+            return '1'
+          },
+          set () {
+            spy()
+          }
+        }
+      },
+      template:
+        '<select v-model="test">' +
+          '<option :key="opt" v-for="opt in options" :value="opt">{{ opt }}</option>' +
+        '</select>'
+    }).$mount()
+
+    vm.options = ['1', '2']
+    waitForUpdate(() => {
+      expect(spy).not.toHaveBeenCalled()
+    }).then(done)
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
[https://github.com/vuejs/vue/issues/6193](https://github.com/vuejs/vue/issues/6193)

---
It seems we still need the value matching check, only detect options change is not enough.