### PR TITLE
fix: add `inject` option in functional component options type

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -47,7 +47,7 @@ export interface ComponentOptions<V extends Vue> {
   filters?: { [key: string]: Function };
 
   provide?: Object | (() => Object);
-  inject?: { [key: string]: string | symbol } | Array<string>;
+  inject?: { [key: string]: string | symbol } | string[];
 
   model?: {
     prop?: string;
@@ -66,6 +66,7 @@ export interface ComponentOptions<V extends Vue> {
 export interface FunctionalComponentOptions {
   name?: string;
   props?: string[] | { [key: string]: PropOptions | Constructor | Constructor[] };
+  inject?: { [key: string]: string | symbol } | string[];
   functional: boolean;
   render(this: never, createElement: CreateElement, context: RenderContext): VNode | void;
 }

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -196,6 +196,7 @@ Vue.component('component-with-scoped-slot', {
 Vue.component('functional-component', {
   props: ['prop'],
   functional: true,
+  inject: ['foo'],
   render(createElement, context) {
     context.props;
     context.children;
@@ -205,6 +206,14 @@ Vue.component('functional-component', {
     return createElement("div", {}, context.children);
   }
 } as FunctionalComponentOptions);
+
+Vue.component('functional-component-object-inject', {
+  functional: true,
+  inject: {
+    foo: 'bar',
+    baz: Symbol()
+  }
+})
 
 Vue.component("async-component", ((resolve, reject) => {
   setTimeout(() => {

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -2,10 +2,8 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
-      "es5",
       "dom",
-      "es2015.promise",
-      "es2015.core"
+      "es2015"
     ],
     "module": "commonjs",
     "noImplicitAny": true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Other, please describe: Add missing typings

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Looks like current functional component can have `inject` option but the typings do not have it. https://vuejs.org/v2/guide/render-function.html#Functional-Components