### PR TITLE
refactor: remove always falsy condition on perf

### DIFF
--- a/benchmarks/dbmon/lib/memory-stats.js
+++ b/benchmarks/dbmon/lib/memory-stats.js
@@ -46,10 +46,7 @@ var MemoryStats = function (){
 
 	var perf = window.performance || {};
 	// polyfill usedJSHeapSize
-	if (!perf && !perf.memory){
-		perf.memory = { usedJSHeapSize : 0 };
-	}
-	if (perf && !perf.memory){
+	if (!perf.memory){
 		perf.memory = { usedJSHeapSize : 0 };
 	}
 
@@ -57,7 +54,7 @@ var MemoryStats = function (){
 	if( perf.memory.totalJSHeapSize === 0 ){
 		console.warn('totalJSHeapSize === 0... performance.memory is only available in Chrome .')
 	}
-	
+
 	// TODO, add a sanity check to see if values are bucketed.
 	// If so, remind user to adopt the --enable-precise-memory-info flag.
 	// open -a "/Applications/Google Chrome.app" --args --enable-precise-memory-info
@@ -76,16 +73,16 @@ var MemoryStats = function (){
 			var delta	= perf.memory.usedJSHeapSize - lastUsedHeap;
 			lastUsedHeap	= perf.memory.usedJSHeapSize;
 			var color	= delta < 0 ? '#830' : '#131';
-			
+
 			var ms	= perf.memory.usedJSHeapSize;
 			msMin	= Math.min( msMin, ms );
 			msMax	= Math.max( msMax, ms );
 			msText.textContent = "Mem: " + bytesToSize(ms, 2);
-			
+
 			var normValue	= ms / (30*1024*1024);
 			var height	= Math.min( 30, 30 - normValue * 30 );
 			updateGraph( msGraph, height, color);
-			
+
 			function bytesToSize( bytes, nFractDigit ){
 				var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
 				if (bytes == 0) return 'n/a';
@@ -97,5 +94,5 @@ var MemoryStats = function (){
 		}
 
 	}
-	
+
 };


### PR DESCRIPTION
Signed-off-by: Clark Du <clark.duxin@gmail.com>

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
1. `perf` will never be `null` or `undefined` due to previous definition, so remove the block
2. even if `perf` is `null` or `undefined`, the block will throw and `Cannot read property` error