### PR TITLE
chore: correct the contributor link that goes 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Please make sure to read the [Contributing Guide](https://github.com/vuejs/vue/b
 
 Thank you to all the people who already contributed to Vue!
 
-<a href="graphs/contributors"><img src="https://opencollective.com/vuejs/contributors.svg?width=890" /></a>
+<a href="https://github.com/vuejs/vue/graphs/contributors"><img src="https://opencollective.com/vuejs/contributors.svg?width=890" /></a>
 
 ## Changelog
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**Summary**

Now the clickable `contributor` part in __README__ will go to 404:

![image](https://user-images.githubusercontent.com/23133919/30286880-bb8bf984-9755-11e7-8f38-1e58d5add851.png)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: correct the contributor link, now it will redirect to __404__

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
