### PR TITLE
work around the buggy behavior of textNode in old chrome. fix #6601

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -97,7 +97,7 @@ export function createPatchFunction (backend) {
   function removeNode (el) {
     const parent = nodeOps.parentNode(el)
     // element may have already been removed due to v-html / v-text
-    if (isDef(parent)) {
+    if (isDef(parent) && !parent._isContentReset) {
       nodeOps.removeChild(parent, el)
     }
   }

--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -28,6 +28,16 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
     if (key === 'textContent' || key === 'innerHTML') {
       if (vnode.children) vnode.children.length = 0
       if (cur === oldProps[key]) continue
+
+      // in old version of chrome, textNode will always in the dom tree
+      // which causes the wrong behavior when patching
+      // see #6601
+      if (oldVnode.children &&
+        oldVnode.children.length === 1 &&
+        isDef(oldVnode.children[0].text)
+      ) {
+        elm._isContentReset = true
+      }
     }
 
     if (key === 'value') {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

fix #6601

There are currently many browsers based on the outdated chrome in China which could not got autoupdated.
This PR tries to work around the textNode wrong behavior in old version of Chrome.

As for the proper test case, I haven't added the proper test case as it's a problem of outdated browser version. Let me know if it is necessary to add it.

