### PR TITLE
Improve DevTools perfromance user timing measurement name

### DIFF
--- a/src/core/instance/init.js
+++ b/src/core/instance/init.js
@@ -21,7 +21,7 @@ export function initMixin (Vue: Class<Component>) {
     let startTag, endTag
     /* istanbul ignore if */
     if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
-      startTag = `vue-perf-init:${vm._uid}`
+      startTag = `vue-perf-start:${vm._uid}`
       endTag = `vue-perf-end:${vm._uid}`
       mark(startTag)
     }
@@ -62,7 +62,7 @@ export function initMixin (Vue: Class<Component>) {
     if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
       vm._name = formatComponentName(vm, false)
       mark(endTag)
-      measure(`${vm._name} init`, startTag, endTag)
+      measure(`vue ${vm._name} init`, startTag, endTag)
     }
 
     if (vm.$options.el) {

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -176,12 +176,12 @@ export function mountComponent (
       mark(startTag)
       const vnode = vm._render()
       mark(endTag)
-      measure(`${name} render`, startTag, endTag)
+      measure(`vue ${name} render`, startTag, endTag)
 
       mark(startTag)
       vm._update(vnode, hydrating)
       mark(endTag)
-      measure(`${name} patch`, startTag, endTag)
+      measure(`vue ${name} patch`, startTag, endTag)
     }
   } else {
     updateComponent = () => {

--- a/src/platforms/web/entry-runtime-with-compiler.js
+++ b/src/platforms/web/entry-runtime-with-compiler.js
@@ -73,7 +73,7 @@ Vue.prototype.$mount = function (
       /* istanbul ignore if */
       if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
         mark('compile end')
-        measure(`${this._name} compile`, 'compile', 'compile end')
+        measure(`vue ${this._name} compile`, 'compile', 'compile end')
       }
     }
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Vue core is marked with performance.measure too vague. (e.g. `<Root> render`)
I think it's difficult to understand intuitively in devtools performance timeline.

the following devtools performance timeline capturing image:
<img width="635" alt="performance-timeline" src="https://user-images.githubusercontent.com/72989/30515516-38bce92e-9b64-11e7-82cf-88d81ab02f57.png">

And also vue performance measurement with headless browser API (e.g. puppeteer) is hard to parse from profile data.

the following profile data capturing image:

<img width="1006" alt="hard-to-parsing" src="https://user-images.githubusercontent.com/72989/30515500-d4c4ec3c-9b63-11e7-8b4f-1631633fdce1.png">

I hope improvement.