### PR TITLE
add hasCrashed function to determin whether the code has minified or not

### DIFF
--- a/src/platforms/web/runtime/index.js
+++ b/src/platforms/web/runtime/index.js
@@ -42,6 +42,12 @@ Vue.prototype.$mount = function (
   return mountComponent(this, el, hydrating)
 }
 
+/*
+  determin wheather the code has minified
+  if the code has minified, then `hasCrashed.name !== 'hasCrashed'`
+*/
+function hasCrashed () {}
+
 // devtools global hook
 /* istanbul ignore next */
 setTimeout(() => {
@@ -57,6 +63,8 @@ setTimeout(() => {
   }
   if (process.env.NODE_ENV !== 'production' &&
     config.productionTip !== false &&
+    typeof hasCrashed.name === 'string' &&
+    hasCrashed.name === 'hasCrashed' &&
     inBrowser && typeof console !== 'undefined'
   ) {
     console[console.info ? 'info' : 'log'](


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Sometimes I minified the code without `NODE_ENV=production`, It still warned me `You are running Vue in development mode.`, I don't think it's rigorous enough.

To determine whether the code runs in the development mode or in production mode, I think it should be judged from the behavior of the code, not just from the `NODE_ENV` flag when building.

So I add `function hasCrashed () {}`, when someone minified the code without flag. But the code here will know, "Oh, You are No Longer Development!"

Also, I find the [doc](https://vuejs.org/v2/guide/deployment.html) of VUE are still using the vue.js uncompressed version. 

(ง •̀_•́)ง