### PR TITLE
doc: spelling and formatting

### DIFF
--- a/benchmarks/ssr/README.md
+++ b/benchmarks/ssr/README.md
@@ -2,9 +2,9 @@
 
 This benchmark renders a table of 1000 rows with 10 columns (10k components), with around 30k normal elements on the page. Note this is not something likely to be seen in a typical app. This benchmark is mostly for stress/regression testing and comparing between `renderToString` and `renderToStream`.
 
-To view the results follow the run section. Note that the overall completion time for the results are variable, this is due to other system related variants at run time (available memory, processing ect). In ideal circumstances both should finish within similar results.
+To view the results follow the run section. Note that the overall completion time for the results are variable, this is due to other system related variants at run time (available memory, processing power, etc). In ideal circumstances both should finish within similar results.
 
-`renderToStream` pipes the content through a stream which provides considerable performance benefits (faster time-to-first-byte and non-event-loop-blocking) over renderToString. This can be observed through the benchmark.
+`renderToStream` pipes the content through a stream which provides considerable performance benefits (faster time-to-first-byte and non-event-loop-blocking) over `renderToString`. This can be observed through the benchmark.
 
 ### run
 

--- a/packages/vue-template-compiler/README.md
+++ b/packages/vue-template-compiler/README.md
@@ -2,7 +2,7 @@
 
 > This package is auto-generated. For pull requests please see [src/platforms/web/entry-compiler.js](https://github.com/vuejs/vue/tree/dev/src/platforms/web/entry-compiler.js).
 
-This package can be used to pre-compile Vue 2.0 templates into render functions to avoid runtime-compilation overhead and CSP restrictions. You will only need it if you are writing build tools with very specific needs. In most cases you should be using [vue-loader](https://github.com/vuejs/vue-loader) or [vueify](https://github.com/vuejs/vueify) instead, both of which use this package internally.
+This package can be used to pre-compile Vue 2.0 templates into render functions to avoid runtime-compilation overhead and CSP restrictions. You will only need it if you are writing build tools with very specific needs. In most cases you should be using [`vue-loader`](https://github.com/vuejs/vue-loader) or [`vueify`](https://github.com/vuejs/vueify) instead, both of which use this package internally.
 
 ## Installation
 
@@ -61,7 +61,7 @@ The optional `options` object can contain the following:
 
 - `preserveWhitespace`
 
-  Defaults to `true`. This means the compiled render function respects all the whitespaces between HTML tags. If set to `false`, all whitespaces between tags will be ignored. This can result in slightly better performance but may affect layout for inline elements.
+  Defaults to `true`. This means the compiled render function preserves all whitespace characters between HTML tags. If set to `false`, whitespace between tags will be ignored. This can result in slightly better performance but may affect layout for inline elements.
 
 ---
 
@@ -86,7 +86,7 @@ This is only useful at runtime with pre-configured builds, so it doesn't accept 
 
 Same as `compiler.compile` but generates SSR-specific render function code by optimizing parts of the template into string concatenation in order to improve SSR performance.
 
-This is used by default in `vue-loader@>=12` and can be disabled using the [optimizeSSR](https://vue-loader.vuejs.org/en/options.html#optimizessr) option.
+This is used by default in `vue-loader@>=12` and can be disabled using the [`optimizeSSR`](https://vue-loader.vuejs.org/en/options.html#optimizessr) option.
 
 ---
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup

**Other information:**

When mentioning certain library names like `vueify` and `vue-loader`, the documentation uses backticks in some places but not in others.  Of the cases I noticed, most were in links.  GitHub permits backticks within links and they are rendered with the fixed-width fontQ

The main README.md omits them for vue-loader.  To show the difference, I took the specific line from the table and included both forms:

| Project | Status | Description |
|---------|--------|-------------|
| [vue-loader]          | [![vue-loader-status]][vue-loader-package] | Single File Component (`*.vue` file) loader for webpack |
| [`vue-loader`]        | [![vue-loader-status]][vue-loader-package] | Single File Component (`*.vue` file) loader for webpack |

[vue-loader]: https://github.com/vuejs/vue-loader
[`vue-loader`]: https://github.com/vuejs/vue-loader
[vue-loader-status]: https://img.shields.io/npm/v/vue-loader.svg
[vue-loader-package]: https://npmjs.com/package/vue-loader

This PR does not include the aforementioned change, but if that is desirable I can add it in.