### PR TITLE
refactor: use an `inProduction` constant

### DIFF
--- a/src/compiler/codegen/events.js
+++ b/src/compiler/codegen/events.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { inProduction } from 'core/util/index'
+
 const fnExpRE = /^\s*([\w$_]+|\([^)]*?\))\s*=>|^function\s*\(/
 const simplePathRE = /^\s*[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\['.*?']|\[".*?"]|\[\d+]|\[[A-Za-z_$][\w$]*])*\s*$/
 
@@ -43,7 +45,7 @@ export function genHandlers (
   for (const name in events) {
     const handler = events[name]
     // #5330: warn click.right, since right clicks do not actually fire click events.
-    if (process.env.NODE_ENV !== 'production' &&
+    if (!inProduction &&
       name === 'click' &&
       handler && handler.modifiers && handler.modifiers.right
     ) {

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -2,7 +2,7 @@
 
 import { genHandlers } from './events'
 import baseDirectives from '../directives/index'
-import { camelize, no, extend } from 'shared/util'
+import { camelize, extend, no, inProduction } from 'shared/util'
 import { baseWarn, pluckModuleFunction } from '../helpers'
 
 type TransformFunction = (el: ASTElement, code: string) => string;
@@ -108,7 +108,7 @@ function genOnce (el: ASTElement, state: CodegenState): string {
       parent = parent.parent
     }
     if (!key) {
-      process.env.NODE_ENV !== 'production' && state.warn(
+      !inProduction && state.warn(
         `v-once can only be used inside v-for that is keyed. `
       )
       return genElement(el, state)
@@ -171,7 +171,7 @@ export function genFor (
   const iterator1 = el.iterator1 ? `,${el.iterator1}` : ''
   const iterator2 = el.iterator2 ? `,${el.iterator2}` : ''
 
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!inProduction &&
     state.maybeComponent(el) &&
     el.tag !== 'slot' &&
     el.tag !== 'template' &&
@@ -308,9 +308,7 @@ function genDirectives (el: ASTElement, state: CodegenState): string | void {
 
 function genInlineTemplate (el: ASTElement, state: CodegenState): ?string {
   const ast = el.children[0]
-  if (process.env.NODE_ENV !== 'production' && (
-    el.children.length > 1 || ast.type !== 1
-  )) {
+  if (!inProduction && (el.children.length > 1 || ast.type !== 1)) {
     state.warn('Inline-template components must have exactly one child element.')
   }
   if (ast.type === 1) {

--- a/src/compiler/create-compiler.js
+++ b/src/compiler/create-compiler.js
@@ -3,6 +3,7 @@
 import { extend } from 'shared/util'
 import { detectErrors } from './error-detector'
 import { createCompileToFunctionFn } from './to-function'
+import { inProduction } from 'core/util/index'
 
 export function createCompilerCreator (baseCompile: Function): Function {
   return function createCompiler (baseOptions: CompilerOptions) {
@@ -39,7 +40,7 @@ export function createCompilerCreator (baseCompile: Function): Function {
       }
 
       const compiled = baseCompile(template, finalOptions)
-      if (process.env.NODE_ENV !== 'production') {
+      if (!inProduction) {
         errors.push.apply(errors, detectErrors(compiled.ast))
       }
       compiled.errors = errors

--- a/src/compiler/directives/on.js
+++ b/src/compiler/directives/on.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import { warn } from 'core/util/index'
+import { inProduction, warn } from 'core/util/index'
 
 export default function on (el: ASTElement, dir: ASTDirective) {
-  if (process.env.NODE_ENV !== 'production' && dir.modifiers) {
+  if (!inProduction && dir.modifiers) {
     warn(`v-on without argument does not support modifiers.`)
   }
   el.wrapListeners = (code: string) => `_g(${code},${dir.value})`

--- a/src/compiler/helpers.js
+++ b/src/compiler/helpers.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { parseFilters } from './parser/filter-parser'
+import { inProduction } from 'core/util/index'
 
 export function baseWarn (msg: string) {
   console.error(`[Vue compiler]: ${msg}`)
@@ -44,10 +45,7 @@ export function addHandler (
 ) {
   // warn prevent and passive modifier
   /* istanbul ignore if */
-  if (
-    process.env.NODE_ENV !== 'production' && warn &&
-    modifiers && modifiers.prevent && modifiers.passive
-  ) {
+  if (!inProduction && warn && modifiers && modifiers.prevent && modifiers.passive) {
     warn(
       'passive and prevent can\'t be used together. ' +
       'Passive handler can\'t prevent default event.'

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -9,7 +9,7 @@
  * http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
  */
 
-import { makeMap, no } from 'shared/util'
+import { inProduction, makeMap, no } from 'shared/util'
 import { isNonPhrasingTag } from 'web/compiler/util'
 
 // Regular Expressions for parsing tags and attributes
@@ -169,7 +169,7 @@ export function parseHTML (html, options) {
 
     if (html === last) {
       options.chars && options.chars(html)
-      if (process.env.NODE_ENV !== 'production' && !stack.length && options.warn) {
+      if (!inProduction && !stack.length && options.warn) {
         options.warn(`Mal-formatted tag at end of template: "${html}"`)
       }
       break
@@ -276,10 +276,7 @@ export function parseHTML (html, options) {
     if (pos >= 0) {
       // Close all the open elements, up the stack
       for (let i = stack.length - 1; i >= pos; i--) {
-        if (process.env.NODE_ENV !== 'production' &&
-          (i > pos || !tagName) &&
-          options.warn
-        ) {
+        if (!inProduction && (i > pos || !tagName) && options.warn) {
           options.warn(
             `tag <${stack[i].tag}> has no matching end tag.`
           )

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -4,7 +4,7 @@ import he from 'he'
 import { parseHTML } from './html-parser'
 import { parseText } from './text-parser'
 import { parseFilters } from './filter-parser'
-import { cached, no, camelize } from 'shared/util'
+import { cached, camelize, inProduction, no } from 'shared/util'
 import { genAssignmentCode } from '../directives/model'
 import { isIE, isEdge, isServerRendering } from 'core/util/env'
 
@@ -116,7 +116,7 @@ export function parse (
 
       if (isForbiddenTag(element) && !isServerRendering()) {
         element.forbidden = true
-        process.env.NODE_ENV !== 'production' && warn(
+        !inProduction && warn(
           'Templates should only be responsible for mapping the state to the ' +
           'UI. Avoid placing tags with side-effects in your templates, such as ' +
           `<${tag}>` + ', as they will not be parsed.'
@@ -159,7 +159,7 @@ export function parse (
       }
 
       function checkRootConstraints (el) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!inProduction) {
           if (el.tag === 'slot' || el.tag === 'template') {
             warnOnce(
               `Cannot use <${el.tag}> as component root element because it may ` +
@@ -187,7 +187,7 @@ export function parse (
             exp: element.elseif,
             block: element
           })
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!inProduction) {
           warnOnce(
             `Component template should contain exactly one root element. ` +
             `If you are using v-if on multiple elements, ` +
@@ -234,7 +234,7 @@ export function parse (
 
     chars (text: string) {
       if (!currentParent) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!inProduction) {
           if (text === template) {
             warnOnce(
               'Component template requires a root element, rather than just text.'
@@ -312,7 +312,7 @@ function processRawAttrs (el) {
 function processKey (el) {
   const exp = getBindingAttr(el, 'key')
   if (exp) {
-    if (process.env.NODE_ENV !== 'production' && el.tag === 'template') {
+    if (!inProduction && el.tag === 'template') {
       warn(`<template> cannot be keyed. Place the key on real elements instead.`)
     }
     el.key = exp
@@ -332,7 +332,7 @@ function processFor (el) {
   if ((exp = getAndRemoveAttr(el, 'v-for'))) {
     const inMatch = exp.match(forAliasRE)
     if (!inMatch) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         `Invalid v-for expression: ${exp}`
       )
       return
@@ -378,7 +378,7 @@ function processIfConditions (el, parent) {
       exp: el.elseif,
       block: el
     })
-  } else if (process.env.NODE_ENV !== 'production') {
+  } else if (!inProduction) {
     warn(
       `v-${el.elseif ? ('else-if="' + el.elseif + '"') : 'else'} ` +
       `used on element <${el.tag}> without corresponding v-if.`
@@ -392,7 +392,7 @@ function findPrevElement (children: Array<any>): ASTElement | void {
     if (children[i].type === 1) {
       return children[i]
     } else {
-      if (process.env.NODE_ENV !== 'production' && children[i].text !== ' ') {
+      if (!inProduction && children[i].text !== ' ') {
         warn(
           `text "${children[i].text.trim()}" between v-if and v-else(-if) ` +
           `will be ignored.`
@@ -420,7 +420,7 @@ function processOnce (el) {
 function processSlot (el) {
   if (el.tag === 'slot') {
     el.slotName = getBindingAttr(el, 'name')
-    if (process.env.NODE_ENV !== 'production' && el.key) {
+    if (!inProduction && el.key) {
       warn(
         `\`key\` does not work on <slot> because slots are abstract outlets ` +
         `and can possibly expand into multiple elements. ` +
@@ -504,13 +504,13 @@ function processAttrs (el) {
           name = name.slice(0, -(arg.length + 1))
         }
         addDirective(el, name, rawName, value, arg, modifiers)
-        if (process.env.NODE_ENV !== 'production' && name === 'model') {
+        if (!inProduction && name === 'model') {
           checkForAliasModel(el, value)
         }
       }
     } else {
       // literal attribute
-      if (process.env.NODE_ENV !== 'production') {
+      if (!inProduction) {
         const expression = parseText(value, delimiters)
         if (expression) {
           warn(
@@ -550,7 +550,7 @@ function makeAttrsMap (attrs: Array<Object>): Object {
   const map = {}
   for (let i = 0, l = attrs.length; i < l; i++) {
     if (
-      process.env.NODE_ENV !== 'production' &&
+      !inProduction &&
       map[attrs[i].name] && !isIE && !isEdge
     ) {
       warn('duplicate attribute: ' + attrs[i].name)

--- a/src/compiler/to-function.js
+++ b/src/compiler/to-function.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { noop } from 'shared/util'
+import { inProduction, noop } from 'shared/util'
 import { warn, tip } from 'core/util/debug'
 
 type CompiledFunctionResult = {
@@ -30,7 +30,7 @@ export function createCompileToFunctionFn (compile: Function): Function {
     options = options || {}
 
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       // detect possible CSP restriction
       try {
         new Function('return 1')
@@ -59,7 +59,7 @@ export function createCompileToFunctionFn (compile: Function): Function {
     const compiled = compile(template, options)
 
     // check compilation errors/tips
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if (compiled.errors && compiled.errors.length) {
         warn(
           `Error compiling template:\n\n${template}\n\n` +
@@ -84,7 +84,7 @@ export function createCompileToFunctionFn (compile: Function): Function {
     // this should only happen if there is a bug in the compiler itself.
     // mostly for codegen development use
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if ((!compiled.errors || !compiled.errors.length) && fnGenErrors.length) {
         warn(
           `Failed to generate render function:\n\n` +

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -3,7 +3,8 @@
 import {
   no,
   noop,
-  identity
+  identity,
+  inProduction
 } from 'shared/util'
 
 import { LIFECYCLE_HOOKS } from 'shared/constants'
@@ -46,12 +47,12 @@ export default ({
   /**
    * Show production mode tip message on boot?
    */
-  productionTip: process.env.NODE_ENV !== 'production',
+  productionTip: inProduction,
 
   /**
    * Whether to enable devtools
    */
-  devtools: process.env.NODE_ENV !== 'production',
+  devtools: inProduction,
 
   /**
    * Whether to record perf

--- a/src/core/global-api/assets.js
+++ b/src/core/global-api/assets.js
@@ -2,7 +2,7 @@
 
 import config from '../config'
 import { ASSET_TYPES } from 'shared/constants'
-import { warn, isPlainObject } from '../util/index'
+import { inProduction, isPlainObject, warn } from '../util/index'
 
 export function initAssetRegisters (Vue: GlobalAPI) {
   /**
@@ -17,7 +17,7 @@ export function initAssetRegisters (Vue: GlobalAPI) {
         return this.options[type + 's'][id]
       } else {
         /* istanbul ignore if */
-        if (process.env.NODE_ENV !== 'production') {
+        if (!inProduction) {
           if (type === 'component' && config.isReservedTag(id)) {
             warn(
               'Do not use built-in or reserved HTML elements as component ' +

--- a/src/core/global-api/extend.js
+++ b/src/core/global-api/extend.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { ASSET_TYPES } from 'shared/constants'
-import { warn, extend, mergeOptions } from '../util/index'
+import { warn, extend, mergeOptions, inProduction } from '../util/index'
 import { defineComputed, proxy } from '../instance/state'
 
 export function initExtend (Vue: GlobalAPI) {
@@ -26,7 +26,7 @@ export function initExtend (Vue: GlobalAPI) {
     }
 
     const name = extendOptions.name || Super.options.name
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if (!/^[a-zA-Z][\w-]*$/.test(name)) {
         warn(
           'Invalid component name: "' + name + '". Component names ' +

--- a/src/core/global-api/index.js
+++ b/src/core/global-api/index.js
@@ -13,6 +13,7 @@ import {
   warn,
   extend,
   nextTick,
+  inProduction,
   mergeOptions,
   defineReactive
 } from '../util/index'
@@ -21,7 +22,7 @@ export function initGlobalAPI (Vue: GlobalAPI) {
   // config
   const configDef = {}
   configDef.get = () => config
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     configDef.set = () => {
       warn(
         'Do not replace the Vue.config object, set individual fields instead.'

--- a/src/core/instance/events.js
+++ b/src/core/instance/events.js
@@ -5,6 +5,7 @@ import {
   toArray,
   hyphenate,
   handleError,
+  inProduction,
   formatComponentName
 } from '../util/index'
 import { updateListeners } from '../vdom/helpers/index'
@@ -112,7 +113,7 @@ export function eventsMixin (Vue: Class<Component>) {
 
   Vue.prototype.$emit = function (event: string): Component {
     const vm: Component = this
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       const lowerCaseEvent = event.toLowerCase()
       if (lowerCaseEvent !== event && vm._events[lowerCaseEvent]) {
         tip(

--- a/src/core/instance/index.js
+++ b/src/core/instance/index.js
@@ -3,12 +3,10 @@ import { stateMixin } from './state'
 import { renderMixin } from './render'
 import { eventsMixin } from './events'
 import { lifecycleMixin } from './lifecycle'
-import { warn } from '../util/index'
+import { inProduction, warn } from '../util/index'
 
 function Vue (options) {
-  if (process.env.NODE_ENV !== 'production' &&
-    !(this instanceof Vue)
-  ) {
+  if (!inProduction && !(this instanceof Vue)) {
     warn('Vue is a constructor and should be called with the `new` keyword')
   }
   this._init(options)

--- a/src/core/instance/init.js
+++ b/src/core/instance/init.js
@@ -8,7 +8,12 @@ import { initEvents } from './events'
 import { mark, measure } from '../util/perf'
 import { initLifecycle, callHook } from './lifecycle'
 import { initProvide, initInjections } from './inject'
-import { extend, mergeOptions, formatComponentName } from '../util/index'
+import {
+  extend,
+  mergeOptions,
+  inProduction,
+  formatComponentName
+} from '../util/index'
 
 let uid = 0
 
@@ -20,7 +25,7 @@ export function initMixin (Vue: Class<Component>) {
 
     let startTag, endTag
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+    if (!inProduction && config.performance && mark) {
       startTag = `vue-perf-init:${vm._uid}`
       endTag = `vue-perf-end:${vm._uid}`
       mark(startTag)
@@ -42,7 +47,7 @@ export function initMixin (Vue: Class<Component>) {
       )
     }
     /* istanbul ignore else */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       initProxy(vm)
     } else {
       vm._renderProxy = vm
@@ -59,7 +64,7 @@ export function initMixin (Vue: Class<Component>) {
     callHook(vm, 'created')
 
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+    if (!inProduction && config.performance && mark) {
       vm._name = formatComponentName(vm, false)
       mark(endTag)
       measure(`${vm._name} init`, startTag, endTag)

--- a/src/core/instance/inject.js
+++ b/src/core/instance/inject.js
@@ -1,7 +1,6 @@
 /* @flow */
 
-import { warn } from '../util/index'
-import { hasSymbol } from 'core/util/env'
+import { hasSymbol, inProduction, warn } from '../util/index'
 import { defineReactive, observerState } from '../observer/index'
 
 export function initProvide (vm: Component) {
@@ -19,7 +18,7 @@ export function initInjections (vm: Component) {
     observerState.shouldConvert = false
     Object.keys(result).forEach(key => {
       /* istanbul ignore else */
-      if (process.env.NODE_ENV !== 'production') {
+      if (!inProduction) {
         defineReactive(vm, key, result[key], () => {
           warn(
             `Avoid mutating an injected value directly since the changes will be ` +
@@ -58,7 +57,7 @@ export function resolveInject (inject: any, vm: Component): ?Object {
         }
         source = source.$parent
       }
-      if (process.env.NODE_ENV !== 'production' && !source) {
+      if (!inProduction && !source) {
         warn(`Injection "${key}" not found`, vm)
       }
     }

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -14,6 +14,7 @@ import {
   remove,
   handleError,
   emptyObject,
+  inProduction,
   validateProp
 } from '../util/index'
 
@@ -144,7 +145,7 @@ export function mountComponent (
   vm.$el = el
   if (!vm.$options.render) {
     vm.$options.render = createEmptyVNode
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       /* istanbul ignore if */
       if ((vm.$options.template && vm.$options.template.charAt(0) !== '#') ||
         vm.$options.el || el) {
@@ -166,7 +167,7 @@ export function mountComponent (
 
   let updateComponent
   /* istanbul ignore if */
-  if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+  if (!inProduction && config.performance && mark) {
     updateComponent = () => {
       const name = vm._name
       const id = vm._uid
@@ -208,7 +209,7 @@ export function updateChildComponent (
   parentVnode: VNode,
   renderChildren: ?Array<VNode>
 ) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     isUpdatingChildComponent = true
   }
 
@@ -261,7 +262,7 @@ export function updateChildComponent (
     vm.$forceUpdate()
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     isUpdatingChildComponent = false
   }
 }

--- a/src/core/instance/proxy.js
+++ b/src/core/instance/proxy.js
@@ -1,11 +1,11 @@
 /* not type checking this file because flow doesn't play well with Proxy */
 
 import config from 'core/config'
-import { warn, makeMap } from '../util/index'
+import { inProduction, makeMap, warn } from '../util/index'
 
 let initProxy
 
-if (process.env.NODE_ENV !== 'production') {
+if (!inProduction) {
   const allowedGlobals = makeMap(
     'Infinity,undefined,NaN,isFinite,isNaN,' +
     'parseFloat,parseInt,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,' +

--- a/src/core/instance/render-helpers/bind-object-listeners.js
+++ b/src/core/instance/render-helpers/bind-object-listeners.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import { warn, extend, isPlainObject } from 'core/util/index'
+import { extend, inProduction, isPlainObject, warn } from 'core/util/index'
 
 export function bindObjectListeners (data: any, value: any): VNodeData {
   if (value) {
     if (!isPlainObject(value)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         'v-on without argument expects an Object value',
         this
       )

--- a/src/core/instance/render-helpers/bind-object-props.js
+++ b/src/core/instance/render-helpers/bind-object-props.js
@@ -6,6 +6,7 @@ import {
   warn,
   isObject,
   toObject,
+  inProduction,
   isReservedAttribute
 } from 'core/util/index'
 
@@ -21,7 +22,7 @@ export function bindObjectProps (
 ): VNodeData {
   if (value) {
     if (!isObject(value)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         'v-bind without argument expects an Object or Array value',
         this
       )

--- a/src/core/instance/render-helpers/render-slot.js
+++ b/src/core/instance/render-helpers/render-slot.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { extend, warn } from 'core/util/index'
+import { extend, warn, inProduction } from 'core/util/index'
 
 /**
  * Runtime helper for rendering <slot>
@@ -21,7 +21,7 @@ export function renderSlot (
   } else {
     const slotNodes = this.$slots[name]
     // warn duplicate slot usage
-    if (slotNodes && process.env.NODE_ENV !== 'production') {
+    if (slotNodes && !inProduction) {
       slotNodes._rendered && warn(
         `Duplicate presence of slot "${name}" found in the same render tree ` +
         `- this will likely cause render errors.`,

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -9,6 +9,7 @@ import {
   emptyObject,
   handleError,
   looseIndexOf,
+  inProduction,
   defineReactive
 } from '../util/index'
 
@@ -51,7 +52,7 @@ export function initRender (vm: Component) {
   const parentData = parentVnode && parentVnode.data
 
   /* istanbul ignore else */
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     defineReactive(vm, '$attrs', parentData && parentData.attrs || emptyObject, () => {
       !isUpdatingChildComponent && warn(`$attrs is readonly.`, vm)
     }, true)
@@ -105,7 +106,7 @@ export function renderMixin (Vue: Class<Component>) {
       // return error render result,
       // or previous vnode to prevent render error causing blank component
       /* istanbul ignore else */
-      if (process.env.NODE_ENV !== 'production') {
+      if (!inProduction) {
         vnode = vm.$options.renderError
           ? vm.$options.renderError.call(vm._renderProxy, vm.$createElement, e)
           : vm._vnode
@@ -115,7 +116,7 @@ export function renderMixin (Vue: Class<Component>) {
     }
     // return empty vnode in case the render function errored out
     if (!(vnode instanceof VNode)) {
-      if (process.env.NODE_ENV !== 'production' && Array.isArray(vnode)) {
+      if (!inProduction && Array.isArray(vnode)) {
         warn(
           'Multiple root nodes returned from render function. Render function ' +
           'should return a single root node.',

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -21,6 +21,7 @@ import {
   isReserved,
   handleError,
   nativeWatch,
+  inProduction,
   validateProp,
   isPlainObject,
   isServerRendering,
@@ -83,7 +84,7 @@ function initProps (vm: Component, propsOptions: Object) {
     keys.push(key)
     const value = validateProp(key, propsOptions, propsData, vm)
     /* istanbul ignore else */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if (isReservedAttribute(key) || config.isReservedAttr(key)) {
         warn(
           `"${key}" is a reserved attribute and cannot be used as component prop.`,
@@ -121,7 +122,7 @@ function initData (vm: Component) {
     : data || {}
   if (!isPlainObject(data)) {
     data = {}
-    process.env.NODE_ENV !== 'production' && warn(
+    !inProduction && warn(
       'data functions should return an object:\n' +
       'https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
       vm
@@ -134,7 +135,7 @@ function initData (vm: Component) {
   let i = keys.length
   while (i--) {
     const key = keys[i]
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if (methods && hasOwn(methods, key)) {
         warn(
           `Method "${key}" has already been defined as a data property.`,
@@ -143,7 +144,7 @@ function initData (vm: Component) {
       }
     }
     if (props && hasOwn(props, key)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         `The data property "${key}" is already declared as a prop. ` +
         `Use prop default value instead.`,
         vm
@@ -168,7 +169,7 @@ function getData (data: Function, vm: Component): any {
 const computedWatcherOptions = { lazy: true }
 
 function initComputed (vm: Component, computed: Object) {
-  process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'computed')
+  !inProduction && checkOptionType(vm, 'computed')
   const watchers = vm._computedWatchers = Object.create(null)
   // computed properties are just getters during SSR
   const isSSR = isServerRendering()
@@ -176,7 +177,7 @@ function initComputed (vm: Component, computed: Object) {
   for (const key in computed) {
     const userDef = computed[key]
     const getter = typeof userDef === 'function' ? userDef : userDef.get
-    if (process.env.NODE_ENV !== 'production' && getter == null) {
+    if (!inProduction && getter == null) {
       warn(
         `Getter is missing for computed property "${key}".`,
         vm
@@ -198,7 +199,7 @@ function initComputed (vm: Component, computed: Object) {
     // at instantiation here.
     if (!(key in vm)) {
       defineComputed(vm, key, userDef)
-    } else if (process.env.NODE_ENV !== 'production') {
+    } else if (!inProduction) {
       if (key in vm.$data) {
         warn(`The computed property "${key}" is already defined in data.`, vm)
       } else if (vm.$options.props && key in vm.$options.props) {
@@ -229,7 +230,7 @@ export function defineComputed (
       ? userDef.set
       : noop
   }
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!inProduction &&
       sharedPropertyDefinition.set === noop) {
     sharedPropertyDefinition.set = function () {
       warn(
@@ -257,10 +258,10 @@ function createComputedGetter (key) {
 }
 
 function initMethods (vm: Component, methods: Object) {
-  process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'methods')
+  !inProduction && checkOptionType(vm, 'methods')
   const props = vm.$options.props
   for (const key in methods) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if (methods[key] == null) {
         warn(
           `Method "${key}" has an undefined value in the component definition. ` +
@@ -286,7 +287,7 @@ function initMethods (vm: Component, methods: Object) {
 }
 
 function initWatch (vm: Component, watch: Object) {
-  process.env.NODE_ENV !== 'production' && checkOptionType(vm, 'watch')
+  !inProduction && checkOptionType(vm, 'watch')
   for (const key in watch) {
     const handler = watch[key]
     if (Array.isArray(handler)) {
@@ -323,7 +324,7 @@ export function stateMixin (Vue: Class<Component>) {
   dataDef.get = function () { return this._data }
   const propsDef = {}
   propsDef.get = function () { return this._props }
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     dataDef.set = function (newData: Object) {
       warn(
         'Avoid replacing instance root $data. ' +

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -9,6 +9,7 @@ import {
   hasOwn,
   hasProto,
   isObject,
+  inProduction,
   isPlainObject,
   isValidArrayIndex,
   isServerRendering
@@ -171,7 +172,7 @@ export function defineReactive (
         return
       }
       /* eslint-enable no-self-compare */
-      if (process.env.NODE_ENV !== 'production' && customSetter) {
+      if (!inProduction && customSetter) {
         customSetter()
       }
       if (setter) {
@@ -202,7 +203,7 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
   }
   const ob = (target: any).__ob__
   if (target._isVue || (ob && ob.vmCount)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !inProduction && warn(
       'Avoid adding reactive properties to a Vue instance or its root $data ' +
       'at runtime - declare it upfront in the data option.'
     )
@@ -227,7 +228,7 @@ export function del (target: Array<any> | Object, key: any) {
   }
   const ob = (target: any).__ob__
   if (target._isVue || (ob && ob.vmCount)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !inProduction && warn(
       'Avoid deleting properties on a Vue instance or its root $data ' +
       '- just set it to null.'
     )

--- a/src/core/observer/scheduler.js
+++ b/src/core/observer/scheduler.js
@@ -7,7 +7,8 @@ import { callHook, activateChildComponent } from '../instance/lifecycle'
 import {
   warn,
   nextTick,
-  devtools
+  devtools,
+  inProduction
 } from '../util/index'
 
 export const MAX_UPDATE_COUNT = 100
@@ -26,7 +27,7 @@ let index = 0
 function resetSchedulerState () {
   index = queue.length = activatedChildren.length = 0
   has = {}
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     circular = {}
   }
   waiting = flushing = false
@@ -57,7 +58,7 @@ function flushSchedulerQueue () {
     has[id] = null
     watcher.run()
     // in dev build, check and stop circular updates.
-    if (process.env.NODE_ENV !== 'production' && has[id] != null) {
+    if (!inProduction && has[id] != null) {
       circular[id] = (circular[id] || 0) + 1
       if (circular[id] > MAX_UPDATE_COUNT) {
         warn(

--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -9,7 +9,8 @@ import {
   isObject,
   parsePath,
   _Set as Set,
-  handleError
+  handleError,
+  inProduction
 } from '../util/index'
 
 import type { ISet } from '../util/index'
@@ -64,7 +65,7 @@ export default class Watcher {
     this.newDeps = []
     this.depIds = new Set()
     this.newDepIds = new Set()
-    this.expression = process.env.NODE_ENV !== 'production'
+    this.expression = !inProduction
       ? expOrFn.toString()
       : ''
     // parse expression for getter
@@ -74,7 +75,7 @@ export default class Watcher {
       this.getter = parsePath(expOrFn)
       if (!this.getter) {
         this.getter = function () {}
-        process.env.NODE_ENV !== 'production' && warn(
+        !inProduction && warn(
           `Failed watching path: "${expOrFn}" ` +
           'Watcher only accepts simple dot-delimited paths. ' +
           'For full control, use a function instead.',

--- a/src/core/util/debug.js
+++ b/src/core/util/debug.js
@@ -1,13 +1,13 @@
 /* @flow */
 
 import config from '../config'
-import { noop } from 'shared/util'
+import { inProduction, noop } from 'shared/util'
 
 export let warn = noop
 export let tip = noop
 export let formatComponentName: Function = (null: any) // work around flow check
 
-if (process.env.NODE_ENV !== 'production') {
+if (!inProduction) {
   const hasConsole = typeof console !== 'undefined'
   const classifyRE = /(?:^|[-_])(\w)/g
   const classify = str => str

--- a/src/core/util/error.js
+++ b/src/core/util/error.js
@@ -3,14 +3,14 @@
 import config from '../config'
 import { warn } from './debug'
 import { inBrowser } from './env'
+import { inProduction } from 'core/util/index'
 
 export function handleError (err: Error, vm: any, info: string) {
   if (config.errorHandler) {
     config.errorHandler.call(null, err, vm, info)
   } else {
-    if (process.env.NODE_ENV !== 'production') {
-      warn(`Error in ${info}: "${err.toString()}"`, vm)
-    }
+    !inProduction && warn(`Error in ${info}: "${err.toString()}"`, vm)
+
     /* istanbul ignore else */
     if (inBrowser && typeof console !== 'undefined') {
       console.error(err)

--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -15,6 +15,7 @@ import {
   hasOwn,
   camelize,
   capitalize,
+  inProduction,
   isBuiltInTag,
   isPlainObject
 } from 'shared/util'
@@ -29,7 +30,7 @@ const strats = config.optionMergeStrategies
 /**
  * Options with restrictions
  */
-if (process.env.NODE_ENV !== 'production') {
+if (!inProduction) {
   strats.el = strats.propsData = function (parent, child, vm, key) {
     if (!vm) {
       warn(
@@ -113,7 +114,7 @@ strats.data = function (
 ): ?Function {
   if (!vm) {
     if (childVal && typeof childVal !== 'function') {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         'The "data" option should be a function ' +
         'that returns a per-instance value in component ' +
         'definitions.',
@@ -249,7 +250,7 @@ function normalizeProps (options: Object) {
       if (typeof val === 'string') {
         name = camelize(val)
         res[name] = { type: null }
-      } else if (process.env.NODE_ENV !== 'production') {
+      } else if (!inProduction) {
         warn('props must be strings when using array syntax.')
       }
     }
@@ -302,7 +303,7 @@ export function mergeOptions (
   child: Object,
   vm?: Component
 ): Object {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     checkComponents(child)
   }
 
@@ -363,7 +364,7 @@ export function resolveAsset (
   if (hasOwn(assets, PascalCaseId)) return assets[PascalCaseId]
   // fallback to prototype chain
   const res = assets[id] || assets[camelizedId] || assets[PascalCaseId]
-  if (process.env.NODE_ENV !== 'production' && warnMissing && !res) {
+  if (!inProduction && warnMissing && !res) {
     warn(
       'Failed to resolve ' + type.slice(0, -1) + ': ' + id,
       options

--- a/src/core/util/perf.js
+++ b/src/core/util/perf.js
@@ -1,9 +1,10 @@
 import { inBrowser } from './env'
+import { inProduction } from 'core/util/index'
 
 export let mark
 export let measure
 
-if (process.env.NODE_ENV !== 'production') {
+if (!inProduction) {
   const perf = inBrowser && window.performance
   /* istanbul ignore if */
   if (

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -7,6 +7,7 @@ import {
   isObject,
   hyphenate,
   capitalize,
+  inProduction,
   isPlainObject
 } from 'shared/util'
 
@@ -44,7 +45,7 @@ export function validateProp (
     observe(value)
     observerState.shouldConvert = prevShouldConvert
   }
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     assertProp(prop, key, value, vm, absent)
   }
   return value
@@ -60,7 +61,7 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
   }
   const def = prop.default
   // warn against non-factory defaults for Object & Array
-  if (process.env.NODE_ENV !== 'production' && isObject(def)) {
+  if (!inProduction && isObject(def)) {
     warn(
       'Invalid default value for prop "' + key + '": ' +
       'Props with type Object/Array must use a factory function ' +

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -10,7 +10,8 @@ import {
   isDef,
   isUndef,
   isTrue,
-  isObject
+  isObject,
+  inProduction
 } from '../util/index'
 
 import {
@@ -117,7 +118,7 @@ export function createComponent (
   // if at this stage it's not a constructor or an async component factory,
   // reject.
   if (typeof Ctor !== 'function') {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       warn(`Invalid Component definition: ${String(Ctor)}`, context)
     }
     return

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -10,6 +10,7 @@ import {
   isUndef,
   isTrue,
   isPrimitive,
+  inProduction,
   resolveAsset
 } from '../util/index'
 
@@ -50,7 +51,7 @@ export function _createElement (
   normalizationType?: number
 ): VNode {
   if (isDef(data) && isDef((data: any).__ob__)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !inProduction && warn(
       `Avoid using observed data object as vnode data: ${JSON.stringify(data)}\n` +
       'Always create fresh vnode data objects in each render!',
       context
@@ -66,7 +67,7 @@ export function _createElement (
     return createEmptyVNode()
   }
   // warn against non-primitive key
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!inProduction &&
     isDef(data) && isDef(data.key) && !isPrimitive(data.key)
   ) {
     warn(

--- a/src/core/vdom/helpers/extract-props.js
+++ b/src/core/vdom/helpers/extract-props.js
@@ -6,6 +6,7 @@ import {
   isDef,
   isUndef,
   hyphenate,
+  inProduction,
   formatComponentName
 } from 'core/util/index'
 
@@ -26,7 +27,7 @@ export function extractPropsFromVNodeData (
   if (isDef(attrs) || isDef(props)) {
     for (const key in propOptions) {
       const altKey = hyphenate(key)
-      if (process.env.NODE_ENV !== 'production') {
+      if (!inProduction) {
         const keyInLowerCase = key.toLowerCase()
         if (
           key !== keyInLowerCase &&

--- a/src/core/vdom/helpers/resolve-async-component.js
+++ b/src/core/vdom/helpers/resolve-async-component.js
@@ -6,7 +6,8 @@ import {
   isDef,
   isUndef,
   isTrue,
-  isObject
+  isObject,
+  inProduction
 } from 'core/util/index'
 
 import { createEmptyVNode } from 'core/vdom/vnode'
@@ -74,7 +75,7 @@ export function resolveAsyncComponent (
     })
 
     const reject = once(reason => {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         `Failed to resolve async component: ${String(factory)}` +
         (reason ? `\nReason: ${reason}` : '')
       )
@@ -117,7 +118,7 @@ export function resolveAsyncComponent (
           setTimeout(() => {
             if (isUndef(factory.resolved)) {
               reject(
-                process.env.NODE_ENV !== 'production'
+                !inProduction
                   ? `timeout (${res.timeout}ms)`
                   : null
               )

--- a/src/core/vdom/helpers/update-listeners.js
+++ b/src/core/vdom/helpers/update-listeners.js
@@ -1,7 +1,6 @@
 /* @flow */
 
-import { warn } from 'core/util/index'
-import { cached, isUndef } from 'shared/util'
+import { cached, inProduction, isUndef, warn } from 'core/util/index'
 
 const normalizeEvent = cached((name: string): {
   name: string,
@@ -65,7 +64,7 @@ export function updateListeners (
     event = normalizeEvent(name)
     if (!event.plain) hasModifier = true
     if (isUndef(cur)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !inProduction && warn(
         `Invalid handler for event "${event.name}": got ` + String(cur),
         vm
       )

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -23,7 +23,8 @@ import {
   isUndef,
   isTrue,
   makeMap,
-  isPrimitive
+  isPrimitive,
+  inProduction
 } from '../util/index'
 
 export const emptyNode = new VNode('', {}, [])
@@ -113,7 +114,7 @@ export function createPatchFunction (backend) {
     const children = vnode.children
     const tag = vnode.tag
     if (isDef(tag)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (!inProduction) {
         if (data && data.pre) {
           inPre++
         }
@@ -163,7 +164,7 @@ export function createPatchFunction (backend) {
         insert(parentElm, vnode.elm, refElm)
       }
 
-      if (process.env.NODE_ENV !== 'production' && data && data.pre) {
+      if (!inProduction && data && data.pre) {
         inPre--
       }
     } else if (isTrue(vnode.isComment)) {
@@ -409,7 +410,7 @@ export function createPatchFunction (backend) {
         } else {
           elmToMove = oldCh[idxInOld]
           /* istanbul ignore if */
-          if (process.env.NODE_ENV !== 'production' && !elmToMove) {
+          if (!inProduction && !elmToMove) {
             warn(
               'It seems there are duplicate keys that is causing an update error. ' +
               'Make sure each v-for item has a unique key.'
@@ -526,7 +527,7 @@ export function createPatchFunction (backend) {
       vnode.isAsyncPlaceholder = true
       return true
     }
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       if (!assertNodeMatch(elm, vnode)) {
         return false
       }
@@ -551,10 +552,7 @@ export function createPatchFunction (backend) {
           if (isDef(i = data) && isDef(i = i.domProps) && isDef(i = i.innerHTML)) {
             if (i !== elm.innerHTML) {
               /* istanbul ignore if */
-              if (process.env.NODE_ENV !== 'production' &&
-                typeof console !== 'undefined' &&
-                !bailed
-              ) {
+              if (!inProduction && typeof console !== 'undefined' && !bailed) {
                 bailed = true
                 console.warn('Parent: ', elm)
                 console.warn('server innerHTML: ', i)
@@ -577,10 +575,7 @@ export function createPatchFunction (backend) {
             // longer than the virtual children list.
             if (!childrenMatch || childNode) {
               /* istanbul ignore if */
-              if (process.env.NODE_ENV !== 'production' &&
-                typeof console !== 'undefined' &&
-                !bailed
-              ) {
+              if (!inProduction && typeof console !== 'undefined' && !bailed) {
                 bailed = true
                 console.warn('Parent: ', elm)
                 console.warn('Mismatching childNodes vs. VNodes: ', elm.childNodes, children)
@@ -646,7 +641,7 @@ export function createPatchFunction (backend) {
             if (hydrate(oldVnode, vnode, insertedVnodeQueue)) {
               invokeInsertHook(vnode, insertedVnodeQueue, true)
               return oldVnode
-            } else if (process.env.NODE_ENV !== 'production') {
+            } else if (!inProduction) {
               warn(
                 'The client-side rendered virtual DOM tree is not matching ' +
                 'server-rendered content. This is likely caused by incorrect ' +

--- a/src/platforms/web/compiler/directives/model.js
+++ b/src/platforms/web/compiler/directives/model.js
@@ -3,6 +3,7 @@
 import config from 'core/config'
 import { addHandler, addProp, getBindingAttr } from 'compiler/helpers'
 import { genComponentModel, genAssignmentCode } from 'compiler/directives/model'
+import { inProduction } from 'core/util/index'
 
 let warn
 
@@ -22,7 +23,7 @@ export default function model (
   const tag = el.tag
   const type = el.attrsMap.type
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (!inProduction) {
     const dynamicType = el.attrsMap['v-bind:type'] || el.attrsMap[':type']
     if (tag === 'input' && dynamicType) {
       warn(
@@ -56,7 +57,7 @@ export default function model (
     genComponentModel(el, value, modifiers)
     // component v-model doesn't need extra runtime
     return false
-  } else if (process.env.NODE_ENV !== 'production') {
+  } else if (!inProduction) {
     warn(
       `<${el.tag} v-model="${value}">: ` +
       `v-model is not supported on this element type. ` +

--- a/src/platforms/web/compiler/modules/class.js
+++ b/src/platforms/web/compiler/modules/class.js
@@ -6,11 +6,12 @@ import {
   getBindingAttr,
   baseWarn
 } from 'compiler/helpers'
+import { inProduction } from 'core/util/index'
 
 function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticClass = getAndRemoveAttr(el, 'class')
-  if (process.env.NODE_ENV !== 'production' && staticClass) {
+  if (!inProduction && staticClass) {
     const expression = parseText(staticClass, options.delimiters)
     if (expression) {
       warn(

--- a/src/platforms/web/compiler/modules/style.js
+++ b/src/platforms/web/compiler/modules/style.js
@@ -7,13 +7,14 @@ import {
   getBindingAttr,
   baseWarn
 } from 'compiler/helpers'
+import { inProduction } from 'core/util/index'
 
 function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticStyle = getAndRemoveAttr(el, 'style')
   if (staticStyle) {
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!inProduction) {
       const expression = parseText(staticStyle, options.delimiters)
       if (expression) {
         warn(

--- a/src/platforms/web/entry-runtime-with-compiler.js
+++ b/src/platforms/web/entry-runtime-with-compiler.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import config from 'core/config'
-import { warn, cached } from 'core/util/index'
+import { cached, inProduction, warn } from 'core/util/index'
 import { mark, measure } from 'core/util/perf'
 
 import Vue from './runtime/index'
@@ -23,7 +23,7 @@ Vue.prototype.$mount = function (
 
   /* istanbul ignore if */
   if (el === document.body || el === document.documentElement) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !inProduction && warn(
       `Do not mount Vue to <html> or <body> - mount to normal elements instead.`
     )
     return this
@@ -38,7 +38,7 @@ Vue.prototype.$mount = function (
         if (template.charAt(0) === '#') {
           template = idToTemplate(template)
           /* istanbul ignore if */
-          if (process.env.NODE_ENV !== 'production' && !template) {
+          if (!inProduction && !template) {
             warn(
               `Template element not found or is empty: ${options.template}`,
               this
@@ -48,7 +48,7 @@ Vue.prototype.$mount = function (
       } else if (template.nodeType) {
         template = template.innerHTML
       } else {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!inProduction) {
           warn('invalid template option:' + template, this)
         }
         return this
@@ -58,7 +58,7 @@ Vue.prototype.$mount = function (
     }
     if (template) {
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+      if (!inProduction && config.performance && mark) {
         mark('compile')
       }
 
@@ -71,7 +71,7 @@ Vue.prototype.$mount = function (
       options.staticRenderFns = staticRenderFns
 
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+      if (!inProduction && config.performance && mark) {
         mark('compile end')
         measure(`${this._name} compile`, 'compile', 'compile end')
       }

--- a/src/platforms/web/runtime/components/transition-group.js
+++ b/src/platforms/web/runtime/components/transition-group.js
@@ -11,7 +11,7 @@
 // into the final desired state. This way in the second pass removed
 // nodes will remain where they should be.
 
-import { warn, extend } from 'core/util/index'
+import { extend, inProduction, warn } from 'core/util/index'
 import { addClass, removeClass } from '../class-util'
 import { transitionProps, extractTransitionData } from './transition'
 
@@ -48,7 +48,7 @@ export default {
           children.push(c)
           map[c.key] = c
           ;(c.data || (c.data = {})).transition = transitionData
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!inProduction) {
           const opts: ?VNodeComponentOptions = c.componentOptions
           const name: string = opts ? (opts.Ctor.options.name || opts.tag || '') : c.tag
           warn(`<transition-group> children must be keyed: <${name}>`)

--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -3,8 +3,7 @@
 // Provides transition support for a single element/component.
 // supports transition mode (out-in / in-out)
 
-import { warn } from 'core/util/index'
-import { camelize, extend, isPrimitive } from 'shared/util'
+import { camelize, extend, inProduction, isPrimitive, warn } from 'core/util/index'
 import {
   mergeVNodeHook,
   isAsyncPlaceholder,
@@ -95,7 +94,7 @@ export default {
     }
 
     // warn multiple elements
-    if (process.env.NODE_ENV !== 'production' && children.length > 1) {
+    if (!inProduction && children.length > 1) {
       warn(
         '<transition> can only be used on a single element. Use ' +
         '<transition-group> for lists.',
@@ -106,9 +105,7 @@ export default {
     const mode: string = this.mode
 
     // warn invalid mode
-    if (process.env.NODE_ENV !== 'production' &&
-      mode && mode !== 'in-out' && mode !== 'out-in'
-    ) {
+    if (!inProduction && mode && mode !== 'in-out' && mode !== 'out-in') {
       warn(
         'invalid <transition> mode: ' + mode,
         this.$parent

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -5,7 +5,7 @@
 
 import { isTextInputType } from 'web/util/element'
 import { looseEqual, looseIndexOf } from 'shared/util'
-import { warn, isAndroid, isIE9, isIE, isEdge } from 'core/util/index'
+import { inProduction, isAndroid, isIE9, isIE, isEdge, warn } from 'core/util/index'
 
 /* istanbul ignore if */
 if (isIE9) {
@@ -79,7 +79,7 @@ function actuallySetSelected (el, binding, vm) {
   const value = binding.value
   const isMultiple = el.multiple
   if (isMultiple && !Array.isArray(value)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !inProduction && warn(
       `<select multiple v-model="${binding.expression}"> ` +
       `expects an Array value for its binding, but got ${
         Object.prototype.toString.call(value).slice(8, -1)

--- a/src/platforms/web/runtime/index.js
+++ b/src/platforms/web/runtime/index.js
@@ -4,7 +4,7 @@ import Vue from 'core/index'
 import config from 'core/config'
 import { extend, noop } from 'shared/util'
 import { mountComponent } from 'core/instance/lifecycle'
-import { devtools, inBrowser, isChrome } from 'core/util/index'
+import { devtools, inBrowser, inProduction, isChrome } from 'core/util/index'
 
 import {
   query,
@@ -48,14 +48,14 @@ setTimeout(() => {
   if (config.devtools) {
     if (devtools) {
       devtools.emit('init', Vue)
-    } else if (process.env.NODE_ENV !== 'production' && isChrome) {
+    } else if (!inProduction && isChrome) {
       console[console.info ? 'info' : 'log'](
         'Download the Vue Devtools extension for a better development experience:\n' +
         'https://github.com/vuejs/vue-devtools'
       )
     }
   }
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!inProduction &&
     config.productionTip !== false &&
     inBrowser && typeof console !== 'undefined'
   ) {

--- a/src/platforms/web/runtime/modules/transition.js
+++ b/src/platforms/web/runtime/modules/transition.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { inBrowser, isIE9, warn } from 'core/util/index'
+import { inBrowser, inProduction, isIE9, warn } from 'core/util/index'
 import { mergeVNodeHook } from 'core/vdom/helpers/index'
 import { activeInstance } from 'core/instance/lifecycle'
 
@@ -105,7 +105,7 @@ export function enter (vnode: VNodeWithData, toggleDisplay: ?() => void) {
       : duration
   )
 
-  if (process.env.NODE_ENV !== 'production' && explicitEnterDuration != null) {
+  if (!inProduction && explicitEnterDuration != null) {
     checkDuration(explicitEnterDuration, 'enter', vnode)
   }
 
@@ -213,7 +213,7 @@ export function leave (vnode: VNodeWithData, rm: Function) {
       : duration
   )
 
-  if (process.env.NODE_ENV !== 'production' && isDef(explicitLeaveDuration)) {
+  if (!inProduction && isDef(explicitLeaveDuration)) {
     checkDuration(explicitLeaveDuration, 'leave', vnode)
   }
 

--- a/src/platforms/web/util/index.js
+++ b/src/platforms/web/util/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { warn } from 'core/util/index'
+import { inProduction, warn } from 'core/util/index'
 
 export * from './attrs'
 export * from './class'
@@ -13,9 +13,7 @@ export function query (el: string | Element): Element {
   if (typeof el === 'string') {
     const selected = document.querySelector(el)
     if (!selected) {
-      process.env.NODE_ENV !== 'production' && warn(
-        'Cannot find element: ' + el
-      )
+      !inProduction && warn('Cannot find element: ' + el)
       return document.createElement('div')
     }
     return selected

--- a/src/platforms/weex/compiler/modules/class.js
+++ b/src/platforms/weex/compiler/modules/class.js
@@ -6,6 +6,7 @@ import {
   getBindingAttr,
   baseWarn
 } from 'compiler/helpers'
+import { inProduction } from 'core/util/index'
 
 type StaticClassResult = {
   dynamic: boolean,
@@ -16,7 +17,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticClass = getAndRemoveAttr(el, 'class')
   const { dynamic, classResult } = parseStaticClass(staticClass, options)
-  if (process.env.NODE_ENV !== 'production' && dynamic && staticClass) {
+  if (!inProduction && dynamic && staticClass) {
     warn(
       `class="${staticClass}": ` +
       'Interpolation inside attributes has been deprecated. ' +

--- a/src/platforms/weex/compiler/modules/style.js
+++ b/src/platforms/weex/compiler/modules/style.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { cached, camelize } from 'shared/util'
+import { cached, camelize, inProduction } from 'shared/util'
 import { parseText } from 'compiler/parser/text-parser'
 import {
   getAndRemoveAttr,
@@ -19,7 +19,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticStyle = getAndRemoveAttr(el, 'style')
   const { dynamic, styleResult } = parseStaticStyle(staticStyle, options)
-  if (process.env.NODE_ENV !== 'production' && dynamic) {
+  if (!inProduction && dynamic) {
     warn(
       `style="${String(staticStyle)}": ` +
       'Interpolation inside attributes has been deprecated. ' +

--- a/src/platforms/weex/runtime/components/transition-group.js
+++ b/src/platforms/weex/runtime/components/transition-group.js
@@ -1,4 +1,4 @@
-import { warn, extend } from 'core/util/index'
+import { extend, warn, inProduction } from 'core/util/index'
 import { transitionProps, extractTransitionData } from './transition'
 
 const props = extend({
@@ -44,7 +44,7 @@ export default {
           children.push(c)
           map[c.key] = c
           ;(c.data || (c.data = {})).transition = transitionData
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!inProduction) {
           const opts = c.componentOptions
           const name = opts
             ? (opts.Ctor.options.name || opts.tag)

--- a/src/platforms/weex/runtime/modules/transition.js
+++ b/src/platforms/weex/runtime/modules/transition.js
@@ -1,5 +1,5 @@
 import { warn } from 'core/util/debug'
-import { extend, once, noop } from 'shared/util'
+import { extend, noop, once, inProduction } from 'shared/util'
 import { activeInstance } from 'core/instance/lifecycle'
 import { resolveTransition } from 'web/runtime/transition-util'
 
@@ -235,7 +235,7 @@ function getEnterTargetState (el, stylesheet, startClass, endClass, activeClass,
     for (const key in startState) {
       targetState[key] = el.style[key]
       if (
-        process.env.NODE_ENV !== 'production' &&
+        !inProduction &&
         targetState[key] == null &&
         (!activeState || activeState[key] == null) &&
         (!endState || endState[key] == null)

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -297,3 +297,8 @@ export function once (fn: Function): Function {
     }
   }
 }
+
+/**
+ * Check if we're in the production environment.
+ */
+export const inProduction = process.env.NODE_ENV === 'production'


### PR DESCRIPTION
Currently the comparison `process.env.NODE_ENV !== 'production'` is seen all over the place. This commit turns it into an exported constant for a bit of DRY.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
