### PR TITLE
fix(v-html): added warning when v-html used with child content present

### DIFF
--- a/src/platforms/web/compiler/directives/html.js
+++ b/src/platforms/web/compiler/directives/html.js
@@ -2,7 +2,14 @@
 
 import { addProp } from 'compiler/helpers'
 
-export default function html (el: ASTElement, dir: ASTDirective) {
+export default function html (el: ASTElement, dir: ASTDirective, warn: Function) {
+  if (el.children.length) {
+    warn(
+      `<${el.tag} v-html="${dir.value}">:\n` +
+      'Element content should be empty with v-html, because it will be overwritten.'
+    )
+  }
+
   if (dir.value) {
     addProp(el, 'innerHTML', `_s(${dir.value})`)
   }

--- a/src/platforms/web/compiler/directives/text.js
+++ b/src/platforms/web/compiler/directives/text.js
@@ -2,7 +2,14 @@
 
 import { addProp } from 'compiler/helpers'
 
-export default function text (el: ASTElement, dir: ASTDirective) {
+export default function text (el: ASTElement, dir: ASTDirective, warn: Function) {
+  if (el.children.length) {
+    warn(
+      `<${el.tag} v-text="${dir.value}">:\n` +
+      'Element content should be empty with v-text, because it will be overwritten.'
+    )
+  }
+
   if (dir.value) {
     addProp(el, 'textContent', `_s(${dir.value})`)
   }

--- a/test/unit/features/directives/html.spec.js
+++ b/test/unit/features/directives/html.spec.js
@@ -64,4 +64,18 @@ describe('Directive v-html', () => {
       expect(vm.$el.innerHTML).toBe('')
     }).then(done)
   })
+
+  it('should warn when element has children', done => {
+    new Vue({
+      template: '<div v-html="a">test</div>',
+      data: { a: 'hello' }
+    }).$mount()
+
+    setTimeout(() => {
+      expect(`<div v-html="a">:
+Element content should be empty with v-html, because it will be overwritten.`)
+        .toHaveBeenWarned()
+      done()
+    }, 0)
+  })
 })

--- a/test/unit/features/directives/text.spec.js
+++ b/test/unit/features/directives/text.spec.js
@@ -50,4 +50,18 @@ describe('Directive v-text', () => {
       expect(vm.$el.innerHTML).toBe('')
     }).then(done)
   })
+
+  it('should warn when element has children', done => {
+    new Vue({
+      template: '<div v-text="a">test</div>',
+      data: { a: 'hello' }
+    }).$mount()
+
+    setTimeout(() => {
+      expect(`<div v-text="a">:
+Element content should be empty with v-text, because it will be overwritten.`)
+        .toHaveBeenWarned()
+      done()
+    }, 0)
+  })
 })


### PR DESCRIPTION
v-html and v-text both overwrote the content of the element if anything
was present: this change checks if there's content and throws an warning
if there is.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Improvement.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
