### PR TITLE
fix: pass errors encountered within nextTick to Vue.config.errorHandler

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -89,7 +89,7 @@ export const nextTick = (function () {
   /* istanbul ignore if */ // $flow-disable-line
   if (typeof Promise !== 'undefined' && isNative(Promise)) {
     var p = Promise.resolve()
-    var logError = err => { console.error(err) }
+    var logError = err => { handleError(err, null, 'nextTick') }
     timerFunc = () => {
       p.then(nextTickHandler).catch(logError)
       // in problematic UIWebViews, Promise.then doesn't completely break, but


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I've found it easier to debug my application if I use:

Vue.config.errorHandler = function(err, vm, info) {throw err};

Unfortunately, I found that my error handler wasn't being called if the error was encountered as a result of updating a reactive element.  Tracing back, I found that this was due to nextTick calling console.error directly instead of handleError.  I made this change locally and found that it fixed my problem, and didn't cause any failures with 'npm test'.
