### PR TITLE
feat(v-model): warn for undefined binding values (#5932)

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -41,6 +41,10 @@ export default {
         }
       }
     }
+
+    if (process.env.NODE_ENV !== 'production' && 'warn' in binding) {
+      warn(binding.warn)
+    }
   },
   componentUpdated (el, binding, vnode) {
     if (vnode.tag === 'select') {

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -354,5 +354,19 @@ describe('Directive v-model text', () => {
         done()
       }, 16)
     })
+
+    it('warn binding v-model to non-existant data property', () => {
+      new Vue({
+        data: {
+          testData: {}
+        },
+        template: `
+          <div>
+            <input v-model="testData.missingKey">
+          </div>
+        `
+      }).$mount()
+      expect('You are binding v-model to a key that does not exist, expression: testData.missingKey').toHaveBeenWarned()
+    })
   }
 })


### PR DESCRIPTION
Warn when the v-model binding value is undefined so users are aware that the binding may not be
reactive.

Fixes #5932

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I'm not sure if checking if the value is undefined is the right thing to do. I was hoping to do some kind of `hasOwnProperty`-like check to see if the key in the object exists, but I couldn't figure out how to do that. If that's what makes more sense a pointer in the right direction would be awesome.