### PR TITLE
Extend config keyCodes property type to accept an array of numbers

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -80,7 +80,7 @@ export declare class Vue {
     errorHandler(err: Error, vm: Vue, info: string): void;
     warnHandler(msg: string, vm: Vue, trace: string): void;
     ignoredElements: string[];
-    keyCodes: { [key: string]: number };
+    keyCodes: { [key: string]: number | number[] };
   }
 
   static extend(options: ComponentOptions<Vue> | FunctionalComponentOptions): typeof Vue;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Modification of Vue's static `config` property type definition.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

![image](https://user-images.githubusercontent.com/10469676/31264038-0a7df5e0-aa2c-11e7-9ef9-441ca9e91dd4.png)

[Per the documentation of the Vue config's `keyCodes` object](https://vuejs.org/v2/api/#keyCodes), the value of a `keyCodes` property may be either a number or an array of numbers. The current `keyCodes` type definition only accepts a single, non-array number. This PR corrects the type definition to reflect both types of acceptable values.


