### PR TITLE
perf(vdom): don't move plain elements containing components (#6659)

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -55,6 +55,16 @@ function sameInputType (a, b) {
   return typeA === typeB || isTextInputType(typeA) && isTextInputType(typeB)
 }
 
+function plainNodeWithComponent (a) {
+  let i
+  const { children } = a
+  if (isDef(a.componentInstance) || !isDef(children)) return false
+  for (i = 0; i < children.length; i++) {
+    if (isDef(children[i].componentInstance)) return true
+  }
+  return false
+}
+
 function createKeyToOldIdx (children, beginIdx, endIdx) {
   let i, key
   const map = {}
@@ -438,7 +448,7 @@ export function createPatchFunction (backend) {
   function findIdxInOld (node, oldCh, start, end) {
     for (let i = start; i < end; i++) {
       const c = oldCh[i]
-      if (isDef(c) && sameVnode(node, c)) return i
+      if (isDef(c) && sameVnode(node, c) && (c === node || !plainNodeWithComponent(c))) return i
     }
   }
 


### PR DESCRIPTION
Do not move a plain element during patch if it contains any
components. This will prevent re-creating the component in a
new element after it's previous parent is moved.

#6659

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is my naive attempt at improving the logic in the diff process to prevent moving a plain element that contains components. I'm definitely open to better options and feedback, I'm not sure this is the right direction to go in. Thanks! 