### PR TITLE
feat(ssr): auto-remove initial state script if prod [#6761]

### DIFF
--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -191,10 +191,13 @@ export default class TemplateRenderer {
       contextKey = 'state',
       windowKey = '__INITIAL_STATE__'
     } = options || {}
+    const autoRemove = process.env.NODE_ENV === 'production'
+      ? 'var s;(s=document.currentScript||document.scripts[document.scripts.length-1]).parentNode.removeChild(s);'
+      : ''
     return context[contextKey]
       ? `<script>window.${windowKey}=${
           serialize(context[contextKey], { isJSON: true })
-        }</script>`
+        }${autoRemove}</script>`
       : ''
   }
 

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -192,7 +192,7 @@ export default class TemplateRenderer {
       windowKey = '__INITIAL_STATE__'
     } = options || {}
     const autoRemove = process.env.NODE_ENV === 'production'
-      ? 'var s;(s=document.currentScript||document.scripts[document.scripts.length-1]).parentNode.removeChild(s);'
+      ? '(function(){var s;(s=document.currentScript||document.scripts[document.scripts.length-1]).parentNode.removeChild(s);}());'
       : ''
     return context[contextKey]
       ? `<script>window.${windowKey}=${


### PR DESCRIPTION
Enable intial state script to automatically remove itself from the DOM if server environment is
prod. (https://github.com/vuejs/vue/issues/6761)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)