### PR TITLE
feat: ignored elements wildcard

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -120,13 +120,13 @@ export function createPatchFunction (backend) {
         if (
           !inPre &&
           !vnode.ns &&
-          !(config.ignoredElements.length &&
-            (config.ignoredElements.indexOf(tag) > -1 ||
-            config.ignoredElements.filter(
-              el => el.length > 1 &&
-              el[el.length - 1] === '*' &&
-              tag.indexOf(el.slice(0, -1)) === 0).length
-            )
+          !(
+            config.ignoredElements.length &&
+            config.ignoredElements.some(ignore => {
+              return ignore instanceof RegExp
+                ? ignore.test(tag)
+                : ignore === tag
+            })
           ) &&
           config.isUnknownElement(tag)
         ) {

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -120,7 +120,14 @@ export function createPatchFunction (backend) {
         if (
           !inPre &&
           !vnode.ns &&
-          !(config.ignoredElements.length && config.ignoredElements.indexOf(tag) > -1) &&
+          !(config.ignoredElements.length &&
+            (config.ignoredElements.indexOf(tag) > -1 ||
+            config.ignoredElements.filter(
+              el => el.length > 1 &&
+              el[el.length - 1] === '*' &&
+              tag.indexOf(el.slice(0, -1)) === 0).length
+            )
+          ) &&
           config.isUnknownElement(tag)
         ) {
           warn(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Did not make an issue for this, but would be nice to have this implemented.
To avoid warnings when integrating web components within Vue (e.g. polymer, ionic 4 / stenciljs), we currently need to add them to [ignoredElements](https://vuejs.org/v2/api/#ignoredElements).
I think it would be a nice addition if we would be able to use a wildcard there, for example:

`Vue.config.ignoredElements = ['ion*']`

instead of 

`Vue.config.ignoredElements = ['ion-app', 'ion-header', 'ion-page', 'ion-toolbar', etc....]`


All tests pass: 
```
86 specs, 0 failures
Finished in 0.698 seconds

```
If there are better ways to implement this functionality (e.g. regex), let me know.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
