### PR TITLE
fix(typing): relax $options type for TS2.6+

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -22,7 +22,7 @@ export interface CreateElement {
 
 export interface Vue {
   readonly $el: HTMLElement;
-  readonly $options: ComponentOptions<this>;
+  readonly $options: ComponentOptions<Vue>;
   readonly $parent: Vue;
   readonly $root: Vue;
   readonly $children: Vue[];


### PR DESCRIPTION
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

TS2.6 introduces strict function variance. `$options`'s type breaks variance check. Relaxing the signature solves this. (We need TS2.6RC to break existing code, this fix is tested locally)