### PR TITLE
build: install dependency for vue-server-renderer in setup script

### DIFF
--- a/build/install-hooks.js
+++ b/build/install-hooks.js
@@ -1,8 +1,0 @@
-const { test, ln, chmod } = require('shelljs')
-
-if (test('-e', '.git/hooks')) {
-  ln('-sf', '../../build/git-hooks/pre-commit', '.git/hooks/pre-commit')
-  chmod('+x', '.git/hooks/pre-commit')
-  ln('-sf', '../../build/git-hooks/commit-msg', '.git/hooks/commit-msg')
-  chmod('+x', '.git/hooks/commit-msg')
-}

--- a/build/setup.js
+++ b/build/setup.js
@@ -1,0 +1,26 @@
+const { test, ln, chmod, cd, exec } = require('shelljs')
+const path = require('path')
+
+const baseUrl = path.resolve()
+
+function installHooks () {
+  if (test('-e', '.git/hooks')) {
+    ln('-sf', '../../build/git-hooks/pre-commit', '.git/hooks/pre-commit')
+    chmod('+x', '.git/hooks/pre-commit')
+    ln('-sf', '../../build/git-hooks/commit-msg', '.git/hooks/commit-msg')
+    chmod('+x', '.git/hooks/commit-msg')
+  }
+}
+
+function setupSSR () {
+  const ssrBase = path.resolve('packages/vue-server-renderer')
+  if (!test('-e', path.join(ssrBase, 'node_modules'))) {
+    cd(ssrBase)
+    exec('npm install')
+    cd(baseUrl)
+  }
+}
+
+installHooks()
+setupSSR()
+

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "bash build/release.sh",
     "release:weex": "bash build/release-weex.sh",
     "release:note": "node build/gen-release-note.js",
-    "setup": "node build/install-hooks.js",
+    "setup": "node build/setup.js",
     "commit": "git-cz"
   },
   "repository": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Currently when running `npm test`, an error occurs: 
```
packages/vue-server-renderer/types/index.d.ts(1,44): error TS2307: Cannot find module 'vue'.
```

It's because that `vue-server-renderer` dependencies are missing, simply run `npm install` under `packages/vue-server-renderer` could solve that.

This PR is trying to improve setup script so that new contributor can run `npm test` successfully. 