### PR TITLE
fix(keep-alive): higher priority for exclude than include

### DIFF
--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -87,8 +87,8 @@ export default {
       // check pattern
       const name: ?string = getComponentName(componentOptions)
       if (name && (
-        (this.include && !matches(this.include, name)) ||
-        (this.exclude && matches(this.exclude, name))
+        (this.exclude && matches(this.exclude, name)) ||
+        (this.include && !matches(this.include, name))
       )) {
         return vnode
       }


### PR DESCRIPTION
Here's my problem in some cases : 

my routes list:  redIndex yellowIndex blueIndex   indexBottom  page1 page2 page3...
just want to cache all the index page except indexBottom page , but include  & exclude can not work together .

 i change the match order , so i can write component like this 
<keepalive include ='/index/ ' exclude='indexBottom >...</keep-alive>

 i think it would be more convenient in most scnario