### PR TITLE
Properly set inherited setters

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -199,14 +199,6 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
     target[key] = val
     return val
   }
-  if (!Array.isArray(target)) {
-    const propertyDescriptor = getInheritedPropertyDescriptor(target, key)
-    if (propertyDescriptor && propertyDescriptor.set) {
-      propertyDescriptor.set.call(target, val)
-      return val
-    }
-  }
-
   const ob = (target: any).__ob__
   if (target._isVue || (ob && ob.vmCount)) {
     process.env.NODE_ENV !== 'production' && warn(
@@ -219,6 +211,13 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
     target[key] = val
     return val
   }
+
+  const propertyDescriptor = getInheritedPropertyDescriptor(ob.value, key)
+  if (propertyDescriptor && propertyDescriptor.set) {
+    propertyDescriptor.set.call(target, val)
+    return val
+  }
+
   defineReactive(ob.value, key, val)
   ob.dep.notify()
   return val
@@ -281,7 +280,7 @@ function getInheritedPropertyDescriptor (obj: Object, key: string) {
     if (property) {
       return property
     }
-  } while (obj)
+  } while (obj && obj.constructor !== Object)
 
   return null
 }

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -142,7 +142,6 @@ export function defineReactive (
   if (property && property.configurable === false) {
     return
   }
-
   // cater for pre-defined getter/setters
   const getter = property && property.get
   const setter = property && property.set
@@ -200,6 +199,14 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
     target[key] = val
     return val
   }
+  if (!Array.isArray(target)) {
+    const propertyDescriptor = getInheritedPropertyDescriptor(target, key)
+    if (propertyDescriptor && propertyDescriptor.set) {
+      propertyDescriptor.set.call(target, val)
+      return val
+    }
+  }
+
   const ob = (target: any).__ob__
   if (target._isVue || (ob && ob.vmCount)) {
     process.env.NODE_ENV !== 'production' && warn(
@@ -255,4 +262,26 @@ function dependArray (value: Array<any>) {
       dependArray(e)
     }
   }
+}
+
+/**
+ * Searches an object's prototype chain for the specified property descriptor
+ * Does not check the object itself because this function is only used
+ * when hasOwnProperty has already been confirmed false.
+ */
+function getInheritedPropertyDescriptor (obj: Object, key: string) {
+  // no point in traversing the entire chain for a property that does not exist
+  if (!(key in obj)) {
+    return null
+  }
+
+  do {
+    obj = obj.constructor && obj.constructor.prototype
+    const property = Object.getOwnPropertyDescriptor(obj, key)
+    if (property) {
+      return property
+    }
+  } while (obj)
+
+  return null
 }

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -336,6 +336,28 @@ describe('Observer', () => {
     }).then(done)
   })
 
+  it('calls setters when found in the prototype chain of observed object', () => {
+    class Seq {
+      constructor () {
+        this.number = 1
+      }
+      get nextNumber () {
+        return this.number + 1
+      }
+      set nextNumber (v) {
+        this.number = v - 1
+      }
+    }
+    const seq = new Seq()
+    observe(seq)
+    expect(seq.hasOwnProperty('nextNumber')).toBe(false)
+    expect(seq.number).toBe(1)
+    expect(seq.nextNumber).toBe(2)
+    Vue.set(seq, 'nextNumber', 5)
+    expect(seq.number).toBe(4)
+    expect(seq.nextNumber).toBe(5)
+  })
+
   it('observing array mutation', () => {
     const arr = []
     const ob = observe(arr)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
Encountered an issue where v-model would not try to call a setter on an instance of a class.
A basic example:

```
    <div>
        <input v-model="person.fullName">
        <table>
            <tr>
                <td>First Name</td>
                <td>{{ person.firstName }}</td>
            </tr>
            <tr>
                <td>Last Name</td>
                <td>{{ person.lastName }}</td>
            </tr>
            <tr>
                <td>Full Name</td>
                <td>{{ person.fullName }}</td>
            </tr>
        </table>
    </div>
```
```
export class Person {
    constructor() {
        this.firstName = 'First'
        this.lastName = 'Last'
    }

    get fullName() {
        if (!this.lastName) {
            return this.firstName;
        }
        return this.firstName + ' ' + this.lastName
    }

    set fullName(v) {
        const split = v.split(' ', 2)
        this.firstName = split[0]
        this.lastName = split.length === 2 ? split[1] : ''
    }
}
```


In the above example the firstName and lastName don't change when the value of the input changes because the fullName setter is never called.

This PR fixes this by checking if we're trying to set a property that is defined as a setter in an object's prototype chain.
Because this explicitly checks for the presence of a .set on the property descriptor it will not try to set normal properties, to keep it more in line with how set has worked so far.

I'm guessing simply doing a (key in obj) check followed by a obj[key] = value would be more performant, but this being my first time looking at the Vue source code I'm not sure what this might break.