### PR TITLE
test(weex): support to test the virtual dom generated form *.vue file

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "typescript": "^2.5.2",
     "uglify-js": "^3.0.15",
     "webpack": "^2.6.1",
-    "weex-js-runtime": "^0.23.0"
+    "weex-js-runtime": "^0.23.0",
+    "weex-styler": "^0.3.0"
   },
   "config": {
     "commitizen": {

--- a/test/weex/cases/cases.spec.js
+++ b/test/weex/cases/cases.spec.js
@@ -1,0 +1,72 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  compileVue,
+  createInstance,
+  getRoot,
+  getEvents,
+  fireEvent
+} from '../helpers'
+
+function readFile (filename) {
+  return fs.readFileSync(path.resolve(__dirname, filename), 'utf8')
+}
+
+function readObject (filename) {
+  return (new Function(`return ${readFile(filename)}`))()
+}
+
+// Create one-off render test case
+function createRenderTestCase (name) {
+  const source = readFile(`${name}.vue`)
+  const target = readObject(`${name}.vdom.js`)
+  return done => {
+    compileVue(source).then(code => {
+      const id = String(Date.now() * Math.random())
+      const instance = createInstance(id, code)
+      setTimeout(() => {
+        expect(getRoot(instance)).toEqual(target)
+        done()
+      }, 50)
+    }).catch(err => {
+      expect(err).toBe(null)
+      done()
+    })
+  }
+}
+
+// Create event test case, will trigger the first bind event
+function createEventTestCase (name) {
+  const source = readFile(`${name}.vue`)
+  const before = readObject(`${name}.before.vdom.js`)
+  const after = readObject(`${name}.after.vdom.js`)
+  return done => {
+    compileVue(source).then(code => {
+      const id = String(Date.now() * Math.random())
+      const instance = createInstance(id, code)
+      setTimeout(() => {
+        expect(getRoot(instance)).toEqual(before)
+        const event = getEvents(instance)[0]
+        fireEvent(instance, event.ref, event.type, {})
+        setTimeout(() => {
+          expect(getRoot(instance)).toEqual(after)
+          done()
+        }, 50)
+      }, 50)
+    }).catch(err => {
+      expect(err).toBe(null)
+      done()
+    })
+  }
+}
+
+describe('Usage', () => {
+  describe('render', () => {
+    it('sample', createRenderTestCase('render/sample'))
+  })
+
+  describe('event', () => {
+    it('click', createEventTestCase('event/click'))
+  })
+})
+

--- a/test/weex/cases/event/click.after.vdom.js
+++ b/test/weex/cases/event/click.after.vdom.js
@@ -1,0 +1,10 @@
+({
+  type: 'div',
+  event: ['click'],
+  children: [{
+    type: 'text',
+    attr: {
+      value: '43'
+    }
+  }]
+})

--- a/test/weex/cases/event/click.before.vdom.js
+++ b/test/weex/cases/event/click.before.vdom.js
@@ -1,0 +1,10 @@
+({
+  type: 'div',
+  event: ['click'],
+  children: [{
+    type: 'text',
+    attr: {
+      value: '42'
+    }
+  }]
+})

--- a/test/weex/cases/event/click.vue
+++ b/test/weex/cases/event/click.vue
@@ -1,0 +1,20 @@
+<template>
+  <div @click="inc">
+    <text>{{count}}</text>
+  </div>
+</template>
+
+<script>
+  module.exports = {
+    data () {
+      return {
+        count: 42
+      }
+    },
+    methods: {
+      inc () {
+        this.count++
+      }
+    }
+  }
+</script>

--- a/test/weex/cases/render/sample.vdom.js
+++ b/test/weex/cases/render/sample.vdom.js
@@ -1,0 +1,17 @@
+({
+  type: 'div',
+  style: {
+    justifyContent: 'center'
+  },
+  children: [{
+    type: 'text',
+    attr: {
+      value: 'Yo'
+    },
+    style: {
+      color: '#41B883',
+      fontSize: '233px',
+      textAlign: 'center'
+    }
+  }]
+})

--- a/test/weex/cases/render/sample.vue
+++ b/test/weex/cases/render/sample.vue
@@ -1,0 +1,23 @@
+<template>
+  <div style="justify-content:center">
+    <text class="freestyle">{{string}}</text>
+  </div>
+</template>
+
+<style scoped>
+  .freestyle {
+    color: #41B883;
+    font-size: 233px;
+    text-align: center;
+  }
+</style>
+
+<script>
+  module.exports = {
+    data () {
+      return {
+        string: 'Yo'
+      }
+    }
+  }
+</script>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add new tests.

**Does this PR introduce a breaking change?**

- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Compile the `*.vue` file into js code, then run it in Weex context and compare the render result with the expected virtual dom tree.

It’s black-box testing for `weex-template-compiler`, `weex-vue-framework`, `weex-styler` and `weex-js-runtime`. The source code of the first two packages is in the current repo.

The test files are put in the `test/weex/cases`:

+ `render/`:  One-off render test cases.
  + `[name].vue`: Source code.
  + `[name].vdom.js`: Expected virtual dom tree.
+ `event/`:  Test cases which contain event bindings.
  + `[name].vue`: Source code.
  + `[name].before.vdom.js`: The first rendered virtual dom.
  + `[name].after.vdom.js`: The updated virtual dom after the event dispatch.



