### PR TITLE
fix:#6938 <keep-alive> should not cache anonymous components

### DIFF
--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -85,7 +85,7 @@ export default {
     const componentOptions: ?VNodeComponentOptions = vnode && vnode.componentOptions
     if (componentOptions) {
       // check pattern
-      const name: ?string = componentOptions && componentOptions.Ctor.options.name
+      const name: ?string = componentOptions.Ctor.options.name
       if (!name || (
         (this.exclude && matches(this.exclude, name)) ||
         (this.include && !matches(this.include, name))

--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -85,8 +85,8 @@ export default {
     const componentOptions: ?VNodeComponentOptions = vnode && vnode.componentOptions
     if (componentOptions) {
       // check pattern
-      const name: ?string = getComponentName(componentOptions)
-      if (name && (
+      const name: ?string = componentOptions && componentOptions.Ctor.options.name
+      if (!name || (
         (this.exclude && matches(this.exclude, name)) ||
         (this.include && !matches(this.include, name))
       )) {

--- a/test/unit/features/component/component-keep-alive.spec.js
+++ b/test/unit/features/component/component-keep-alive.spec.js
@@ -488,7 +488,7 @@ describe('Component keep-alive', () => {
           random: Math.random(0, 10)
         }
       },
-      template: `<div class="child">{{ random }}</div>`
+      template: `<div>{{ random }}</div>`
     }
     const two = {
       data () {
@@ -496,7 +496,7 @@ describe('Component keep-alive', () => {
           random: Math.random(0, 10)
         }
       },
-      template: `<div class="child">{{ random }}</div>`
+      template: `<div>{{ random }}</div>`
     }
     const vm = new Vue({
       data: { view: 'one' },
@@ -516,7 +516,6 @@ describe('Component keep-alive', () => {
       vm.view = 'two'
     }).then(() => {
       noCacheText = vm.$el.textContent
-      expect(noCacheText).not.toBe(cacheText)
       vm.view = 'one'
     }).then(() => {
       expect(vm.$el.textContent).toBe(cacheText)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included


**Other information:**
anonymous components aslo have tag , so func getComponentName can not be used anymore.