### PR TITLE
fix #6687 out-in transition getting stuck with v-if

### DIFF
--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -160,7 +160,7 @@ export default {
     if (
       oldChild &&
       oldChild.data &&
-      oldChild.elm.nodeType !== Node.COMMENT_NODE &&
+      oldChild.elm.nodeType !== 8 && // Node.COMMENT_NODE
       !isSameChild(child, oldChild) &&
       !isAsyncPlaceholder(oldChild)
     ) {

--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -160,6 +160,7 @@ export default {
     if (
       oldChild &&
       oldChild.data &&
+      oldChild.elm.nodeType !== Node.COMMENT_NODE &&
       !isSameChild(child, oldChild) &&
       !isAsyncPlaceholder(oldChild)
     ) {

--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -160,10 +160,10 @@ export default {
     if (
       oldChild &&
       oldChild.data &&
-      oldChild.elm &&
-      oldChild.elm.nodeType !== 8 && // Node.COMMENT_NODE
       !isSameChild(child, oldChild) &&
-      !isAsyncPlaceholder(oldChild)
+      !isAsyncPlaceholder(oldChild) &&
+      // #6687 component root is a comment node
+      !(oldChild.componentInstance && oldChild.componentInstance._vnode.isComment)
     ) {
       // replace old child transition data with fresh one
       // important for dynamic transitions!

--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -160,6 +160,7 @@ export default {
     if (
       oldChild &&
       oldChild.data &&
+      oldChild.elm &&
       oldChild.elm.nodeType !== 8 && // Node.COMMENT_NODE
       !isSameChild(child, oldChild) &&
       !isAsyncPlaceholder(oldChild)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

An out-in transition could get stuck if the child with v-if was not yet shown and then replaced with a different child. In this case, "afterLeave" would never get fired, thus "_leaving" stayed true indefinitely. This was likely to happen with vue-router and asynchronous data loading before the new page is shown.

Fixes #6687.
