### PR TITLE
fix(weex): donot rethrow the captured error on weex platform

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -1,16 +1,19 @@
 /* @flow */
+declare var WXEnvironment: any;
 
 // can we use __proto__?
 export const hasProto = '__proto__' in {}
 
 // Browser environment sniffing
 export const inBrowser = typeof window !== 'undefined'
+export const inWeex = typeof WXEnvironment !== 'undefined' && !!WXEnvironment.platform
+export const weexPlatform = inWeex && WXEnvironment.platform.toLowerCase()
 export const UA = inBrowser && window.navigator.userAgent.toLowerCase()
 export const isIE = UA && /msie|trident/.test(UA)
 export const isIE9 = UA && UA.indexOf('msie 9.0') > 0
 export const isEdge = UA && UA.indexOf('edge/') > 0
-export const isAndroid = UA && UA.indexOf('android') > 0
-export const isIOS = UA && /iphone|ipad|ipod|ios/.test(UA)
+export const isAndroid = (UA && UA.indexOf('android') > 0) || (weexPlatform === 'android')
+export const isIOS = (UA && /iphone|ipad|ipod|ios/.test(UA)) || (weexPlatform === 'ios')
 export const isChrome = UA && /chrome\/\d+/.test(UA) && !isEdge
 
 // Firefox has a "watch" function on Object.prototype...

--- a/src/core/util/error.js
+++ b/src/core/util/error.js
@@ -2,7 +2,7 @@
 
 import config from '../config'
 import { warn } from './debug'
-import { inBrowser } from './env'
+import { inBrowser, inWeex } from './env'
 
 export function handleError (err: Error, vm: any, info: string) {
   if (vm) {
@@ -40,7 +40,7 @@ function logError (err, vm, info) {
     warn(`Error in ${info}: "${err.toString()}"`, vm)
   }
   /* istanbul ignore else */
-  if (inBrowser && typeof console !== 'undefined') {
+  if ((inBrowser || inWeex) && typeof console !== 'undefined') {
     console.error(err)
   } else {
     throw err


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**Other information:**

If the `Vue.config.errorHandler` is not specified, captured errors will be rethrown on the Weex platform. Add more reliable env check in the `logError` could fix it.

Besides, I also add an `inWeex` flag and make the `isAndroid` and `isIOS` flag more reliable.
