### PR TITLE
revert(weex): remove the "receiveTasks" api and support component hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "typescript": "^2.5.2",
     "uglify-js": "^3.0.15",
     "webpack": "^2.6.1",
-    "weex-js-runtime": "^0.23.0",
+    "weex-js-runtime": "^0.23.1",
     "weex-styler": "^0.3.0"
   },
   "config": {

--- a/src/platforms/weex/entry-framework.js
+++ b/src/platforms/weex/entry-framework.js
@@ -117,53 +117,6 @@ export function getRoot (instanceId) {
   return instance.app.$el.toJSON()
 }
 
-const jsHandlers = {
-  fireEvent: (id, ...args) => {
-    return fireEvent(instances[id], ...args)
-  },
-  callback: (id, ...args) => {
-    return callback(instances[id], ...args)
-  }
-}
-
-function fireEvent (instance, nodeId, type, e, domChanges, params) {
-  const el = instance.document.getRef(nodeId)
-  if (el) {
-    return instance.document.fireEvent(el, type, e, domChanges, params)
-  }
-  return new Error(`invalid element reference "${nodeId}"`)
-}
-
-function callback (instance, callbackId, data, ifKeepAlive) {
-  const result = instance.document.taskCenter.callback(callbackId, data, ifKeepAlive)
-  instance.document.taskCenter.send('dom', { action: 'updateFinish' }, [])
-  return result
-}
-
-/**
- * Accept calls from native (event or callback).
- *
- * @param  {string} id
- * @param  {array} tasks list with `method` and `args`
- */
-export function receiveTasks (id, tasks) {
-  const instance = instances[id]
-  if (instance && Array.isArray(tasks)) {
-    const results = []
-    tasks.forEach((task) => {
-      const handler = jsHandlers[task.method]
-      const args = [...task.args]
-      /* istanbul ignore else */
-      if (typeof handler === 'function') {
-        args.unshift(id)
-        results.push(handler(...args))
-      }
-    })
-    return results
-  }
-  return new Error(`invalid instance id "${id}" or tasks`)
-}
-
 /**
  * Create a fresh instance of Vue for each Weex instance.
  */

--- a/src/platforms/weex/util/index.js
+++ b/src/platforms/weex/util/index.js
@@ -1,6 +1,7 @@
 /* globals document */
 
 import { makeMap } from 'shared/util'
+import { warn } from 'core/util/index'
 
 export const isReservedTag = makeMap(
   'template,script,style,element,content,slot,link,meta,svg,view,' +
@@ -20,7 +21,7 @@ export const canBeLeftOpenTag = makeMap(
 )
 
 export const isRuntimeComponent = makeMap(
-  'richtext,trisition,trisition-group',
+  'richtext,transition,transition-group',
   true
 )
 
@@ -39,4 +40,15 @@ export function query (el, document) {
   placeholder.hasAttribute = placeholder.removeAttribute = function () {} // hack for patch
   document.documentElement.appendChild(placeholder)
   return placeholder
+}
+
+export function registerHook (cid, type, hook, fn) {
+  if (!document || !document.taskCenter) {
+    warn(`Can't find available "document" or "taskCenter".`)
+    return
+  }
+  if (typeof document.taskCenter.registerHook === 'function') {
+    return document.taskCenter.registerHook(cid, type, hook, fn)
+  }
+  warn(`Not support to register component hook "${type}@${hook}#${cid}".`)
 }

--- a/test/weex/runtime/framework.spec.js
+++ b/test/weex/runtime/framework.spec.js
@@ -152,57 +152,6 @@ describe('framework APIs', () => {
     expect(root).toMatch(/not found/)
   })
 
-  // TODO: deprecated, move to weex-js-runtime
-  it('receiveTasks: fireEvent', (done) => {
-    const id = String(Date.now() * Math.random())
-    const instance = createInstance(id, `
-      new Vue({
-        data: {
-          x: 'Hello'
-        },
-        methods: {
-          update: function (e) {
-            this.x = 'World'
-          }
-        },
-        render: function (createElement) {
-          return createElement('div', {}, [
-            createElement('text', { attrs: { value: this.x }, on: { click: this.update }}, [])
-          ])
-        },
-        el: "body"
-      })
-    `)
-    expect(getRoot(instance)).toEqual({
-      type: 'div',
-      children: [{
-        type: 'text',
-        attr: { value: 'Hello' },
-        event: ['click']
-      }]
-    })
-    const textRef = framework.getRoot(id).children[0].ref
-    framework.receiveTasks(id, [
-      { method: 'fireEvent', args: [textRef, 'click'] }
-    ])
-    setTimeout(() => {
-      expect(getRoot(instance)).toEqual({
-        type: 'div',
-        children: [{
-          type: 'text',
-          attr: { value: 'World' },
-          event: ['click']
-        }]
-      })
-      framework.destroyInstance(id)
-      const result = framework.receiveTasks(id, [
-        { method: 'fireEvent', args: [textRef, 'click'] }
-      ])
-      expect(result instanceof Error).toBe(true)
-      done()
-    })
-  })
-
   it('vm.$getConfig', () => {
     const id = String(Date.now() * Math.random())
     global.WXEnvironment = {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Feature
- [x] Refactor

**Does this PR introduce a breaking change?**

- [x] Yes

This feature only compatible with `0.23.1` or higher versions of `weex-js-runtime`.

**Other information:**

The `receiveTasks` API is moved to `weex-js-runtime` in order to maintain the consistency of communication behavior between Weex and native.

Also, expose the `registerHook` API in utils and fix spelling mistakes about the "transition".
