### PR TITLE
fix reactive objects which are sealed

### DIFF
--- a/src/core/observer/traverse.js
+++ b/src/core/observer/traverse.js
@@ -18,7 +18,7 @@ export function traverse (val: any) {
 function _traverse (val: any, seen: SimpleSet) {
   let i, keys
   const isA = Array.isArray(val)
-  if ((!isA && !isObject(val)) || !Object.isExtensible(val)) {
+  if ((!isA && !isObject(val)) || Object.isFrozen(val)) {
     return
   }
   if (val.__ob__) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

I am using this helper method to seal my objects before passing them to Vue:

```
function makeReactiveAndSeal(obj) {
  if (!obj.__ob__) {
    Object.keys(obj).forEach((key) => {
      Vue.util.defineReactive(obj, key, obj[key]);
    });
  }
  Object.seal(obj);
}
```

This turns silent errors into nice verbose errors, for example when there is a mistake in a Vue template. The function changed by this PR is currently preventing this from working correctly.