### PR TITLE
chore #7070: warn properties that starts with $ or _

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -142,12 +142,14 @@ function initData (vm: Component) {
         vm
       )
     } else if (isReserved(key)) {
-      warn(
-        `Property "${key}" will not be proxied on the instance because it ` +
-        `may conflict with Vue's internal properties. You will have to access it as ` +
-        `"vm.$data.${key}". Avoid defining component properties that start with _ or $.`,
-        vm
-      )
+      if (process.env.NODE_ENV !== 'production') {
+        warn(
+          `Property "${key}" will not be proxied on the instance because it ` +
+          `may conflict with Vue's internal properties. You will have to access it as ` +
+          `"vm.$data.${key}". Avoid defining component properties that start with _ or $.`,
+          vm
+        )
+      }
     } else {
       proxy(vm, `_data`, key)
     }

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -141,7 +141,14 @@ function initData (vm: Component) {
         `Use prop default value instead.`,
         vm
       )
-    } else if (!isReserved(key)) {
+    } else if (isReserved(key)) {
+      warn(
+        `Property "${key}" will not be proxied on the instance because it ` +
+        `may conflict with Vue's internal properties. You will have to access it as ` +
+        `"vm.$data.${key}". Avoid defining component properties that start with _ or $.`,
+        vm
+      )
+    } else {
       proxy(vm, `_data`, key)
     }
   }

--- a/test/unit/features/instance/properties.spec.js
+++ b/test/unit/features/instance/properties.spec.js
@@ -200,4 +200,13 @@ describe('Instance properties', () => {
     vm.$listeners = {}
     expect(`$listeners is readonly`).toHaveBeenWarned()
   })
+
+  it('warn data properties that start with _ or $', () => {
+    new Vue({
+      data: { $a: 'a', _b: 'b' },
+      template: '<div></div>'
+    }).$mount()
+    expect(`Property "$a" will not be proxied on the instance`).toHaveBeenWarned()
+    expect(`Property "_b" will not be proxied on the instance`).toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
close #7070

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
As the docs says:

> Properties that start with _ or $ will not be proxied on the Vue instance because they may conflict with Vue’s internal properties and API methods. You will have to access them as vm.$data._property.`

But, this is a little bit hidden during development. It would be better if a warn could be raised to show developer that the data property will not be proxied on the Vue instance.