### PR TITLE
fix(warn): do not warn when destructuring in v-for

### DIFF
--- a/src/compiler/error-detector.js
+++ b/src/compiler/error-detector.js
@@ -80,7 +80,11 @@ function checkIdentifier (
 ) {
   if (typeof ident === 'string') {
     try {
-      new Function(`var ${ident}`)
+      // #7096 use an array because it makes it possible to destructure
+      // arrays and objects:
+      // var { foo } = [] works
+      // var [ foo ] = [] works
+      new Function(`var ${ident} = []`)
     } catch (e) {
       errors.push(`invalid ${type} "${ident}" in expression: ${text.trim()}`)
     }

--- a/test/unit/features/options/template.spec.js
+++ b/test/unit/features/options/template.spec.js
@@ -78,6 +78,25 @@ describe('Options template', () => {
     expect('Raw expression: v-for="(1, 2) in a----"').toHaveBeenWarned()
   })
 
+  // #7096
+  it('should not warn with object destructuring in v-for', () => {
+    new Vue({
+      data: { items: [] },
+      template: '<div><div v-for="{ foo } in items"></div></div>'
+    }).$mount()
+    expect('Error compiling template').not.toHaveBeenWarned()
+    expect('invalid v-for alias ').not.toHaveBeenWarned()
+  })
+
+  it('should not warn with array destructuring in v-for', () => {
+    new Vue({
+      data: { items: [] },
+      template: '<div><div v-for="[ foo ] in items"></div></div>'
+    }).$mount()
+    expect('Error compiling template').not.toHaveBeenWarned()
+    expect('invalid v-for alias ').not.toHaveBeenWarned()
+  })
+
   it('warn error in generated function (v-on)', () => {
     new Vue({
       template: `<div @click="delete('Delete')"></div>`,

--- a/test/unit/features/options/template.spec.js
+++ b/test/unit/features/options/template.spec.js
@@ -79,7 +79,8 @@ describe('Options template', () => {
   })
 
   // #7096
-  it('should not warn with object destructuring in v-for', () => {
+  // TODO activate once we use something newer than PhantomJS
+  xit('should not warn with object destructuring in v-for', () => {
     new Vue({
       data: { items: [] },
       template: '<div><div v-for="{ foo } in items"></div></div>'
@@ -88,7 +89,7 @@ describe('Options template', () => {
     expect('invalid v-for alias ').not.toHaveBeenWarned()
   })
 
-  it('should not warn with array destructuring in v-for', () => {
+  xit('should not warn with array destructuring in v-for', () => {
     new Vue({
       data: { items: [] },
       template: '<div><div v-for="[ foo ] in items"></div></div>'


### PR DESCRIPTION
Fixes #7096 
Right now tests do not pass because PhantomJS do not support destructuring syntax. I'm taking a look to replace it by something better

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
