### PR TITLE
feat: add browser ESM build

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -58,11 +58,21 @@ const builds = {
     format: 'es',
     banner
   },
-  // Runtime+compiler CommonJS build (ES Modules)
+  // Runtime+compiler ES modules build (for bundlers)
   'web-full-esm': {
     entry: resolve('web/entry-runtime-with-compiler.js'),
     dest: resolve('dist/vue.esm.js'),
     format: 'es',
+    alias: { he: './entity-decoder' },
+    banner
+  },
+  // Runtime+compiler ES modules build (for direct import in browser)
+  'web-full-esm-browser': {
+    entry: resolve('web/entry-runtime-with-compiler.js'),
+    dest: resolve('dist/vue.esm.browser.js'),
+    format: 'es',
+    transpile: false,
+    env: 'development',
     alias: { he: './entity-decoder' },
     banner
   },
@@ -180,7 +190,6 @@ function genConfig (name) {
         __VERSION__: version
       }),
       flow(),
-      buble(),
       alias(Object.assign({}, aliases, opts.alias))
     ].concat(opts.plugins || []),
     output: {
@@ -195,6 +204,10 @@ function genConfig (name) {
     config.plugins.push(replace({
       'process.env.NODE_ENV': JSON.stringify(opts.env)
     }))
+  }
+
+  if (opts.transpile !== false) {
+    config.plugins.push(buble())
   }
 
   Object.defineProperty(config, '_name', {


### PR DESCRIPTION
Adding a new dist file `vue.esm.browser.js` which enables direct import in ESM-enabled browsers:

``` html
<script type="module">
import Vue from 'https://unpkg.com/vue/dist/vue.esm.browser.js'

new Vue({
  el: '#app',
  data: {
    msg: 'hello!'
  }
})
</script>
```