### PR TITLE
fix(types): fix ThisType of component options with no props option

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -32,6 +32,15 @@ export type Accessors<T> = {
 }
 
 /**
+ * This type should be used when a component has no props
+ */
+export type ThisTypedComponentOptionsWithNoProps<V extends Vue, Data, Methods, Computed, EmptyProps extends undefined> =
+  object &
+  ComponentOptions<V, Data | ((this: {} & V) => Data), Methods, Computed, EmptyProps> &
+  ThisType<CombinedVueInstance<V, Data, Methods, Computed, {}>>;
+
+
+/**
  * This type should be used when an array of strings is used for a component's `props` value.
  */
 export type ThisTypedComponentOptionsWithArrayProps<V extends Vue, Data, Methods, Computed, PropNames extends string> =

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -8,6 +8,7 @@ import {
   DirectiveOptions,
   DirectiveFunction,
   RecordPropsDefinition,
+  ThisTypedComponentOptionsWithNoProps,
   ThisTypedComponentOptionsWithArrayProps,
   ThisTypedComponentOptionsWithRecordProps,
   WatchOptions,
@@ -72,6 +73,7 @@ export interface VueConstructor<V extends Vue = Vue> {
 
   extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
   extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
+  extend<Data, Methods, Computed>(options?: ThisTypedComponentOptionsWithNoProps<V, Data, Methods, Computed, undefined>): ExtendedVue<V, Data, Methods, Computed, {}>;
   extend<Data, Methods, Computed, PropNames extends string>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
   extend<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
   extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
@@ -94,6 +96,7 @@ export interface VueConstructor<V extends Vue = Vue> {
   component<Data, Methods, Computed, Props>(id: string, definition: AsyncComponent<Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
   component<PropNames extends string>(id: string, definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
   component<Props>(id: string, definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
+  component<Data, Methods, Computed>(id: string, definition?: ThisTypedComponentOptionsWithNoProps<V, Data, Methods, Computed, undefined>): ExtendedVue<V, Data, Methods, Computed, {}>;
   component<Data, Methods, Computed, PropNames extends string>(id: string, definition?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
   component<Data, Methods, Computed, Props>(id: string, definition?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
   component(id: string, definition?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

It seems that @ktsn and I had the same problem at the same time, as I separately found and fixed the problem identified in https://github.com/vuejs/vue/pull/7131 with this PR.  I noticed @HerringtonDarkholme had open questions about the `never` type.  My solution to the problem was a separate overload for `Vue.extend` and `Vue.component` that involves a third typed props type. I'm not expert enough on typescript to know which of these is a better solution, but I figured I'd open the duplicate-ish PR since I had a different approach in case you prefer it.