### PR TITLE
fix(weex): send createFinish signal after root component mounted

### DIFF
--- a/src/platforms/weex/entry-framework.js
+++ b/src/platforms/weex/entry-framework.js
@@ -61,11 +61,7 @@ export function createInstance (
   }, timerAPIs, env.services)
 
   appCode = `(function(global){ \n${appCode}\n })(Object.create(this))`
-
   callFunction(instanceVars, appCode)
-
-  // Send `createFinish` signal to native.
-  document.taskCenter.send('dom', { action: 'createFinish' }, [])
 
   return instance
 }
@@ -207,6 +203,16 @@ function createVueModuleInstance (instanceId, weex) {
         options.data = Object.assign(internalData, instance.data)
         // record instance by id
         instance.app = this
+      }
+    },
+    mounted () {
+      const options = this.$options
+      // root component (vm)
+      if (options.el && weex.document) {
+        try {
+          // Send "createFinish" signal to native.
+          weex.document.taskCenter.send('dom', { action: 'createFinish' }, [])
+        } catch (e) {}
       }
     }
   })


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**Other information:**

Make sure the timing of sending the "createFinish" signal is more reasonable, even if using asynchronous rendering (Call `new Vue()` in Promise or timer).
