### PR TITLE
fix(props): handle misspelled keys on prop validation object

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -23,6 +23,7 @@ import {
   handleError,
   nativeWatch,
   validateProp,
+  assertPropObject,
   isPlainObject,
   isServerRendering,
   isReservedAttribute
@@ -71,6 +72,9 @@ function initProps (vm: Component, propsOptions: Object) {
   // root instance props should be converted
   observerState.shouldConvert = isRoot
   for (const key in propsOptions) {
+    if (process.env.NODE_ENV !== 'production') {
+      assertPropObject(propsOptions[key], key, vm)
+    }
     keys.push(key)
     const value = validateProp(key, propsOptions, propsData, vm)
     /* istanbul ignore else */

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -23,7 +23,6 @@ import {
   handleError,
   nativeWatch,
   validateProp,
-  assertPropObject,
   isPlainObject,
   isServerRendering,
   isReservedAttribute
@@ -72,9 +71,6 @@ function initProps (vm: Component, propsOptions: Object) {
   // root instance props should be converted
   observerState.shouldConvert = isRoot
   for (const key in propsOptions) {
-    if (process.env.NODE_ENV !== 'production') {
-      assertPropObject(propsOptions[key], key, vm)
-    }
     keys.push(key)
     const value = validateProp(key, propsOptions, propsData, vm)
     /* istanbul ignore else */

--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -283,12 +283,12 @@ function normalizeProps (options: Object, vm: ?Component) {
     for (const key in props) {
       val = props[key]
       name = camelize(key)
+      if (process.env.NODE_ENV !== 'production' && isPlainObject(val)) {
+        assertPropObject(name, val, vm)
+      }
       res[name] = isPlainObject(val)
         ? val
         : { type: val }
-      if (process.env.NODE_ENV !== 'production') {
-        assertPropObject(name, res[name], vm)
-      }
     }
   } else if (process.env.NODE_ENV !== 'production') {
     warn(

--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -4,6 +4,7 @@ import config from '../config'
 import { warn } from './debug'
 import { nativeWatch } from './env'
 import { set } from '../observer/index'
+import { assertPropObject } from './props'
 
 import {
   ASSET_TYPES,
@@ -285,6 +286,9 @@ function normalizeProps (options: Object, vm: ?Component) {
       res[name] = isPlainObject(val)
         ? val
         : { type: val }
+      if (process.env.NODE_ENV !== 'production') {
+        assertPropObject(res[name], name, vm)
+      }
     }
   } else if (process.env.NODE_ENV !== 'production') {
     warn(

--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -287,7 +287,7 @@ function normalizeProps (options: Object, vm: ?Component) {
         ? val
         : { type: val }
       if (process.env.NODE_ENV !== 'production') {
-        assertPropObject(res[name], name, vm)
+        assertPropObject(name, res[name], vm)
       }
     }
   } else if (process.env.NODE_ENV !== 'production') {

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -94,7 +94,7 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
 /**
  * Assert whether a prop object keys are valid.
  */
-function assertPropObject (
+export function assertPropObject (
   prop: Object,
   key: string,
   vm: ?Component
@@ -119,7 +119,6 @@ function assertProp (
   vm: ?Component,
   absent: boolean
 ) {
-  assertPropObject(prop, name, vm)
   if (prop.required && absent) {
     warn(
       'Missing required prop: "' + name + '"',

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -18,6 +18,13 @@ type PropOptions = {
   validator: ?Function
 };
 
+const propOptionsNames = [
+  'type',
+  'default',
+  'required',
+  'validator'
+]
+
 export function validateProp (
   key: string,
   propOptions: Object,
@@ -85,6 +92,24 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
 }
 
 /**
+ * Assert whether a prop object keys are valid.
+ */
+function assertPropObject (
+  prop: Object,
+  key: string,
+  vm: ?Component
+) {
+  Object.keys(prop)
+    .filter(name => propOptionsNames.indexOf(name) === -1)
+    .forEach(name => {
+      warn(
+        'Invalid key "' + name + '" in validation rules object for prop "' + key + '".',
+        vm
+      )
+    })
+}
+
+/**
  * Assert whether a prop is valid.
  */
 function assertProp (
@@ -94,6 +119,7 @@ function assertProp (
   vm: ?Component,
   absent: boolean
 ) {
+  assertPropObject(prop, name, vm)
   if (prop.required && absent) {
     warn(
       'Missing required prop: "' + name + '"',

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -95,18 +95,18 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
  * Assert whether a prop object keys are valid.
  */
 export function assertPropObject (
+  propName: string,
   prop: Object,
-  key: string,
   vm: ?Component
 ) {
-  Object.keys(prop)
-    .filter(name => propOptionsNames.indexOf(name) === -1)
-    .forEach(name => {
+  for (const key in prop) {
+    if (propOptionsNames.indexOf(key) === -1) {
       warn(
-        'Invalid key "' + name + '" in validation rules object for prop "' + key + '".',
+        `Invalid key "${key}" in validation rules object for prop "${propName}".`,
         vm
       )
-    })
+    }
+  }
 }
 
 /**

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -512,4 +512,21 @@ describe('Options props', () => {
       expect(`"${attr}" is a reserved attribute`).toHaveBeenWarned()
     })
   })
+
+  it('should warn about misspelled keys in prop validation object', () => {
+    new Vue({
+      template: '<test></test>',
+      components: {
+        test: {
+          template: '<div></div>',
+          props: {
+            value: { reqquired: true },
+            count: { deafult: 1 }
+          }
+        }
+      }
+    }).$mount()
+    expect(`Invalid key "reqquired" in validation rules object for prop "value".`).toHaveBeenWarned()
+    expect(`Invalid key "deafult" in validation rules object for prop "count".`).toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

When using object for validating props, there are no checks about object content. This may take a long time before noticing that you forget to pass required prop, but there are no warnings with a misprint.

Fail cases:
- Typo in key name `deafult: false` or `require: true`
- Using non-english letter in key name (for example, russian)

P.S.: Will be great to add instance sections names validation, but I have no idea how to solve this (once I spent a lot of time before see that writed `component: {}` section instead `components: {}`).