### PR TITLE
fix(ssr): pass async error to outside callback to display right response

### DIFF
--- a/src/server/bundle-renderer/create-bundle-renderer.js
+++ b/src/server/bundle-renderer/create-bundle-renderer.js
@@ -102,7 +102,7 @@ export function createBundleRendererCreator (
           cb(err)
         }).then(app => {
           if (app) {
-            renderer.renderToString(app, context, (err, res) => {
+            renderer.renderToString(app, context, (err = null, res) => {
               rewriteErrorTrace(err, maps)
               cb(err, res)
             })

--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -78,11 +78,11 @@ export function createRenderer ({
         return false
       }, cb)
       try {
-        render(component, write, context, () => {
+        render(component, write, context, (err) => {
           if (template) {
             result = templateRenderer.renderSync(result, context)
           }
-          cb(null, result)
+          cb(err, result)
         })
       } catch (e) {
         cb(e)

--- a/src/server/render-context.js
+++ b/src/server/render-context.js
@@ -25,8 +25,8 @@ export class RenderContext {
   renderStates: Array<RenderState>;
   write: (text: string, next: Function) => void;
   renderNode: (node: VNode, isRoot: boolean, context: RenderContext) => void;
-  next: () => void;
-  done: () => void;
+  next: (err: ?Error) => void;
+  done: (err: ?Error) => void;
 
   modules: Array<(node: VNode) => ?string>;
   directives: Object;
@@ -60,10 +60,10 @@ export class RenderContext {
     this.next = this.next.bind(this)
   }
 
-  next () {
+  next (err: ?Error) {
     const lastState = this.renderStates[this.renderStates.length - 1]
     if (isUndef(lastState)) {
-      return this.done()
+      return this.done(err)
     }
     switch (lastState.type) {
       case 'Element':

--- a/src/server/render.js
+++ b/src/server/render.js
@@ -200,7 +200,7 @@ function renderAsyncComponent (node, isRoot, context) {
   const reject = err => {
     console.error(`[vue-server-renderer] error when rendering async component:\n`)
     if (err) console.error(err.stack)
-    context.write(`<!--${node.text}-->`, context.next)
+    context.write(`<!--${node.text}-->`, context.next.bind(context, err))
   }
 
   if (factory.resolved) {


### PR DESCRIPTION
pass async error to outside callback to handle error correct and response right status (not 200)

BREAKING CHANGE: RenderContext.prototype.next pass error object to outside callback

close #6778

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

`RenderContext.prototype.next` now can pass error object to outside callback, and handle it correctly when an async error happened.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
