### PR TITLE
fix(compiler): fix double escaping of ssrNode attribute values (fix #7223)

### DIFF
--- a/src/server/optimizing-compiler/modules.js
+++ b/src/server/optimizing-compiler/modules.js
@@ -77,7 +77,7 @@ function genAttrSegment (name: string, value: string): StringSegment {
         ? ` ${name}="${name}"`
         : value === '""'
           ? ` ${name}`
-          : ` ${name}=${value}`
+          : ` ${name}="${JSON.parse(value)}"`
     }
   } else {
     return {


### PR DESCRIPTION
This fixes a double escaping of attribute values in the SSR optimizing
compiler, because literal attribute values get escaped early during the
call to `addAttr` inside `processAttrs` before it is known, if this
attribute will be serialized to an _ssrNode string template.

Later on the _ssrNode string template gets escaped again to preserve
whitespace and this causes double escaping of the whitespace inside the
attribute value.

This approach fixes the problem by undoing the escaping by parsing the
attribute value JSON in `genAttrSegment`, which is the easiest fix to
the problem, but probably not the best.

This fixes #7223 at least for the cases where I encountered the problem.

See #7223 for an in-depth description of the problem and a test-case.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I would love to add a breaking test, that shows that the fix is working, but I'm not sure were to add it with the large test suite, so some advise on that would be appreciated.