### PR TITLE
feat(sfc): allow multiple template and script blocks in a SFC

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -171,7 +171,9 @@ declare type ASTText = {
 // an object format describing a single-file component.
 declare type SFCDescriptor = {
   template: ?SFCBlock;
+  templates: Array<SFCBlock>;
   script: ?SFCBlock;
+  scripts: Array<SFCBlock>;
   styles: Array<SFCBlock>;
   customBlocks: Array<SFCBlock>;
 };

--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -22,7 +22,9 @@ export function parseComponent (
 ): SFCDescriptor {
   const sfc: SFCDescriptor = {
     template: null,
+    templates: [],
     script: null,
+    scripts: [],
     styles: [],
     customBlocks: []
   }
@@ -50,8 +52,10 @@ export function parseComponent (
         checkAttrs(currentBlock, attrs)
         if (tag === 'style') {
           sfc.styles.push(currentBlock)
-        } else {
-          sfc[tag] = currentBlock
+        } else if (tag === 'script') {
+          sfc.scripts.push(currentBlock)
+        } else if (tag === 'template') {
+          sfc.templates.push(currentBlock)
         }
       } else { // custom blocks
         sfc.customBlocks.push(currentBlock)
@@ -111,6 +115,16 @@ export function parseComponent (
     start,
     end
   })
+
+  // set template property for backwards compat
+  if (sfc.templates.length) {
+    sfc.template = sfc.templates[0]
+  }
+
+  // set script property for backwards compat
+  if (sfc.scripts.length) {
+    sfc.script = sfc.scripts[0]
+  }
 
   return sfc
 }

--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -118,12 +118,12 @@ export function parseComponent (
 
   // set template property for backwards compat
   if (sfc.templates.length) {
-    sfc.template = sfc.templates[0]
+    sfc.template = sfc.templates[sfc.templates.length - 1]
   }
 
   // set script property for backwards compat
   if (sfc.scripts.length) {
-    sfc.script = sfc.scripts[0]
+    sfc.script = sfc.scripts[sfc.scripts.length - 1]
   }
 
   return sfc

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -175,4 +175,18 @@ describe('Single File Component parser', () => {
     const res = parseComponent(`<template>hi</`)
     expect(res.template.content).toBe('hi')
   })
+
+  it('should parse multiple template blocks', () => {
+    const res = parseComponent(`<template></template>\n<template second="true"></template>`)
+
+    expect(res.templates.length).toBe(2)
+    expect(res.templates[1].attrs.second).toBe('true')
+  })
+
+  it('should parse multiple script blocks', () => {
+    const res = parseComponent(`<script></script>\n<script second="true"></script>`)
+
+    expect(res.scripts.length).toBe(2)
+    expect(res.scripts[1].attrs.second).toBe('true')
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The reason I'm submitting this PR is because for `nativescript-vue` we would like to introduce code-sharing between web and native, but one limiting factor is that we can't have more than 1 `template` or `script` tag in a SFC.

We would like to write our SFC like so:
```html
<template native>
    <StackLayout></StackLayout>
</template>
<template web>
    <div></div>
</template>

<style native>
    StackLayout { background: red; }
</style>
<style web>
    div { background: red; }
</style>

<script>
    export default {
        methods: {} // the core code
    }
</script>
<script native>
    export default {
        methods: {} // methods that interact with the UI.
    }
</script>
<script web>
    export default {
        methods: {} // methods that interact with the UI.
    }
</script>
```

(More information can be found at https://github.com/tralves/ns-vue-loader/issues/2)

The current implementation assumes only 1 of these blocks, and only the last one is kept, with this PR it will parse all of the blocks, and return them in an array, while keeping it backwards compatible.