### PR TITLE
feat(warning): allow symbol as vdom key

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -270,7 +270,7 @@ export function createPatchFunction (backend) {
         createElm(children[i], insertedVnodeQueue, vnode.elm, null, true)
       }
     } else if (isPrimitive(vnode.text)) {
-      nodeOps.appendChild(vnode.elm, nodeOps.createTextNode(vnode.text))
+      nodeOps.appendChild(vnode.elm, nodeOps.createTextNode(String(vnode.text)))
     }
   }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -27,6 +27,8 @@ export function isPrimitive (value: any): boolean %checks {
   return (
     typeof value === 'string' ||
     typeof value === 'number' ||
+    // $flow-disable-line
+    typeof value === 'symbol' ||
     typeof value === 'boolean'
   )
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -24,13 +24,12 @@ export function isFalse (v: any): boolean %checks {
  * Check if value is primitive
  */
 export function isPrimitive (value: any): boolean %checks {
-  const type = typeof value
   return (
-    type === 'string' ||
-    type === 'number' ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
     // $flow-disable-line
-    type === 'symbol' ||
-    type === 'boolean'
+    typeof value === 'symbol' ||
+    typeof value === 'boolean'
   )
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -24,12 +24,13 @@ export function isFalse (v: any): boolean %checks {
  * Check if value is primitive
  */
 export function isPrimitive (value: any): boolean %checks {
+  const type = typeof value
   return (
-    typeof value === 'string' ||
-    typeof value === 'number' ||
+    type === 'string' ||
+    type === 'number' ||
     // $flow-disable-line
-    typeof value === 'symbol' ||
-    typeof value === 'boolean'
+    type === 'symbol' ||
+    type === 'boolean'
   )
 }
 

--- a/test/unit/modules/vdom/create-element.spec.js
+++ b/test/unit/modules/vdom/create-element.spec.js
@@ -215,6 +215,15 @@ describe('create-element', () => {
     expect('Avoid using non-primitive value as key').not.toHaveBeenWarned()
   })
 
+  it('doesn\'t warn symbol key', () => {
+    new Vue({
+      render (h) {
+        return h('div', { key: Symbol('symbol') })
+      }
+    }).$mount()
+    expect('Avoid using non-primitive value as key').not.toHaveBeenWarned()
+  })
+
   it('nested child elements should be updated correctly', done => {
     const vm = new Vue({
       data: { n: 1 },


### PR DESCRIPTION
fix #7157

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Flow still doesn't support `typeof symbol`, a suppression comment is added. 
Also, all usage of `isPrimitive` is checked, additional `String` cast is added for compatibility.