### PR TITLE
fix(types): make VNodeChildrenArrayContents type more accurate

### DIFF
--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,4 +1,4 @@
-import Vue from "../index";
+import Vue, { VNode } from "../index";
 import { AsyncComponent, ComponentOptions, FunctionalComponentOptions } from "../index";
 import { CreateElement } from "../vue";
 
@@ -274,6 +274,19 @@ Vue.component('component-with-scoped-slot', {
         ])
       }
     }
+  }
+})
+
+Vue.component('narrow-array-of-vnode-type', {
+  render (h): VNode {
+    const slot = this.$scopedSlots.default({})
+    if (typeof slot !== 'string') {
+      const first = slot[0]
+      if (!Array.isArray(first) && typeof first !== 'string') {
+        return first;
+      }
+    }
+    return h();
   }
 })
 

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -3,9 +3,7 @@ import { Vue } from "./vue";
 export type ScopedSlot = (props: any) => VNodeChildrenArrayContents | string;
 
 export type VNodeChildren = VNodeChildrenArrayContents | [ScopedSlot] | string;
-export interface VNodeChildrenArrayContents {
-  [x: number]: VNode | string | VNodeChildren;
-}
+export interface VNodeChildrenArrayContents extends Array<VNode | string | VNodeChildrenArrayContents> {}
 
 export interface VNode {
   tag?: string;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
- Replaced `VNodeChildren` with `VNodeChildrenArrayContents` in its recursive declaration. The current `VNodeChildrenArrayContents` type looks inaccurate because it can include a scoped slot in the returned value of another scoped slot.
- `VNodeChildrenArrayContents` inherits `Array` interface so that we can narrow the type with `Array.isArray` function.