### PR TITLE
fix(core): fix defineReactive unnecessary getters call fix #7280

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -145,7 +145,7 @@ export function defineReactive (
 
   // cater for pre-defined getter/setters
   const getter = property && property.get
-  if (!getter && arguments.length <= 2) {
+  if (!getter && arguments.length === 2) {
     val = obj[key]
   }
   const setter = property && property.set

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -61,7 +61,7 @@ export class Observer {
   walk (obj: Object) {
     const keys = Object.keys(obj)
     for (let i = 0; i < keys.length; i++) {
-      defineReactive(obj, keys[i], obj[keys[i]])
+      defineReactive(obj, keys[i])
     }
   }
 
@@ -145,6 +145,9 @@ export function defineReactive (
 
   // cater for pre-defined getter/setters
   const getter = property && property.get
+  if (!getter && arguments.length <= 2) {
+    val = obj[key]
+  }
   const setter = property && property.set
 
   let childOb = !shallow && observe(val)


### PR DESCRIPTION
The defineReactive gets the property of the object, only if it has no getter

fix #7280

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
