### PR TITLE
fix(vdom): svg inside foreignObject should be rendered with correct namespace (fix #7330)

### DIFF
--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -139,7 +139,8 @@ function applyNS (vnode, ns, force) {
   if (isDef(vnode.children)) {
     for (let i = 0, l = vnode.children.length; i < l; i++) {
       const child = vnode.children[i]
-      if (isDef(child.tag) && (isUndef(child.ns) || isTrue(force))) {
+      if (isDef(child.tag) && (
+        isUndef(child.ns) || (isTrue(force) && child.tag !== 'svg'))) {
         applyNS(child, ns, force)
       }
     }

--- a/test/unit/modules/vdom/create-element.spec.js
+++ b/test/unit/modules/vdom/create-element.spec.js
@@ -139,10 +139,11 @@ describe('create-element', () => {
     expect(vnode.ns).toBe('svg')
     expect(vnode.children[0].ns).toBe('svg')
     expect(vnode.children[0].children[0].ns).toBeUndefined()
+    // #7330
     expect(vnode.children[0].children[1].ns).toBe('svg')
   })
 
-  // #6642 #7330
+  // #6642
   it('render svg foreignObject component with correct namespace', () => {
     const vm = new Vue({
       template: `

--- a/test/unit/modules/vdom/create-element.spec.js
+++ b/test/unit/modules/vdom/create-element.spec.js
@@ -135,10 +135,11 @@ describe('create-element', () => {
   it('render svg foreignObject with correct namespace', () => {
     const vm = new Vue({})
     const h = vm.$createElement
-    const vnode = h('svg', [h('foreignObject', [h('p')])])
+    const vnode = h('svg', [h('foreignObject', [h('p'), h('svg')])])
     expect(vnode.ns).toBe('svg')
     expect(vnode.children[0].ns).toBe('svg')
     expect(vnode.children[0].children[0].ns).toBeUndefined()
+    expect(vnode.children[0].children[1].ns).toBe('svg')
   })
 
   // #6642 #7330
@@ -154,7 +155,6 @@ describe('create-element', () => {
           template: `
           <foreignObject>
             <p xmlns="http://www.w3.org/1999/xhtml"></p>
-            <svg></svg>
           </foreignObject>
           `
         }
@@ -166,8 +166,6 @@ describe('create-element', () => {
     expect(testComp._vnode.ns).toBe('svg')
     expect(testComp._vnode.children[0].tag).toBe('p')
     expect(testComp._vnode.children[0].ns).toBeUndefined()
-    expect(testComp._vnode.children[1].tag).toBe('svg')
-    expect(testComp._vnode.children[1].ns).toBe('svg')
   })
 
   // #6506

--- a/test/unit/modules/vdom/create-element.spec.js
+++ b/test/unit/modules/vdom/create-element.spec.js
@@ -141,7 +141,7 @@ describe('create-element', () => {
     expect(vnode.children[0].children[0].ns).toBeUndefined()
   })
 
-  // #6642
+  // #6642 #7330
   it('render svg foreignObject component with correct namespace', () => {
     const vm = new Vue({
       template: `
@@ -154,6 +154,7 @@ describe('create-element', () => {
           template: `
           <foreignObject>
             <p xmlns="http://www.w3.org/1999/xhtml"></p>
+            <svg></svg>
           </foreignObject>
           `
         }
@@ -165,6 +166,8 @@ describe('create-element', () => {
     expect(testComp._vnode.ns).toBe('svg')
     expect(testComp._vnode.children[0].tag).toBe('p')
     expect(testComp._vnode.children[0].ns).toBeUndefined()
+    expect(testComp._vnode.children[1].tag).toBe('svg')
+    expect(testComp._vnode.children[1].ns).toBe('svg')
   })
 
   // #6506


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
fix #7330