### PR TITLE
feat(compiler): add support for scoped slot pass down in templates

### DIFF
--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -347,13 +347,15 @@ function genScopedSlot (
   if (el.for && !el.forProcessed) {
     return genForScopedSlot(key, el, state)
   }
-  const fn = `function(${String(el.slotScope)}){` +
-    `return ${el.tag === 'template'
-      ? el.if
-        ? `${el.if}?${genChildren(el, state) || 'undefined'}:undefined`
-        : genChildren(el, state) || 'undefined'
-      : genElement(el, state)
-    }}`
+  const fn = (el.tag === 'slot')
+    ? `$scopedSlots[${el.slotName || '"default"'}]`
+    : `function(${String(el.slotScope)}){` +
+        `return ${el.tag === 'template'
+          ? el.if
+            ? `${el.if}?${genChildren(el, state) || 'undefined'}:undefined`
+            : genChildren(el, state) || 'undefined'
+          : genElement(el, state)
+        }}`
   return `{key:${key},fn:${fn}}`
 }
 
@@ -468,7 +470,9 @@ function genSlot (el: ASTElement, state: CodegenState): string {
   if (bind) {
     res += `${attrs ? '' : ',null'},${bind}`
   }
-  return res + ')'
+  return el.slotScope
+    ? `!$scopedSlots[${slotName}]&&${res})`
+    : res + ')'
 }
 
 // componentName is el.component, take it as argument to shun flow's pessimistic refinement


### PR DESCRIPTION
fix #7178

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Need review, I'm not good at vue internals.
ESLint check in pre-commit script was skipped because of "eslint: command not found" error. Anyway, it was performed during build phase.
Happy New Year!