### PR TITLE
fix #7367: Replace isAndroid with window.ConpositionEvent.

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -6,7 +6,7 @@
 import { isTextInputType } from 'web/util/element'
 import { looseEqual, looseIndexOf } from 'shared/util'
 import { mergeVNodeHook } from 'core/vdom/helpers/index'
-import { warn, isAndroid, isIE9, isIE, isEdge } from 'core/util/index'
+import { warn, isIE9, isIE, isEdge } from 'core/util/index'
 
 /* istanbul ignore if */
 if (isIE9) {

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -6,7 +6,7 @@
 import { isTextInputType } from 'web/util/element'
 import { looseEqual, looseIndexOf } from 'shared/util'
 import { mergeVNodeHook } from 'core/vdom/helpers/index'
-import { warn, isIE9, isIE, isEdge } from 'core/util/index'
+import { warn, inBrowser, isIE9, isIE, isEdge } from 'core/util/index'
 
 /* istanbul ignore if */
 if (isIE9) {
@@ -18,6 +18,8 @@ if (isIE9) {
     }
   })
 }
+
+const isCompositionEventSupported = inBrowser && typeof window.CompositionEvent === 'function'
 
 const directive = {
   inserted (el, binding, vnode, oldVnode) {
@@ -34,14 +36,14 @@ const directive = {
     } else if (vnode.tag === 'textarea' || isTextInputType(el.type)) {
       el._vModifiers = binding.modifiers
       if (!binding.modifiers.lazy) {
-        // Safari < 10.2 & UIWebView doesn't fire compositionend when
-        // switching focus before confirming composition choice
-        // this also fixes the issue where some browsers e.g. iOS Chrome
-        // fires "change" instead of "input" on autocomplete.
-        el.addEventListener('change', onCompositionEnd)
-        if (typeof window.CompositionEvent === 'function') {
+        if (isCompositionEventSupported) {
           el.addEventListener('compositionstart', onCompositionStart)
           el.addEventListener('compositionend', onCompositionEnd)
+          // Safari < 10.2 & UIWebView doesn't fire compositionend when
+          // switching focus before confirming composition choice
+          // this also fixes the issue where some browsers e.g. iOS Chrome
+          // fires "change" instead of "input" on autocomplete.
+          el.addEventListener('change', onCompositionEnd)
         }
         /* istanbul ignore if */
         if (isIE9) {

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -39,7 +39,7 @@ const directive = {
         // this also fixes the issue where some browsers e.g. iOS Chrome
         // fires "change" instead of "input" on autocomplete.
         el.addEventListener('change', onCompositionEnd)
-        if (!isAndroid) {
+        if (typeof window.CompositionEvent === 'function') {
           el.addEventListener('compositionstart', onCompositionStart)
           el.addEventListener('compositionend', onCompositionEnd)
         }

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { isIE9, isIE, isAndroid } from 'core/util/env'
+import { isIE9, isIE } from 'core/util/env'
 
 describe('Directive v-model text', () => {
   it('should update value both ways', done => {
@@ -183,7 +183,7 @@ describe('Directive v-model text', () => {
     })
   }
 
-  if (!isAndroid) {
+  if (typeof window.CompositionEvent === 'function') {
     it('compositionevents', function (done) {
       const vm = new Vue({
         data: {
@@ -291,7 +291,7 @@ describe('Directive v-model text', () => {
     expect('conflicts with v-model').not.toHaveBeenWarned()
   })
 
-  if (!isAndroid) {
+  if (!typeof window.CompositionEvent === 'function') {
     it('does not trigger extra input events with single compositionend', () => {
       const spy = jasmine.createSpy()
       const vm = new Vue({

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -1,5 +1,7 @@
 import Vue from 'vue'
-import { isIE9, isIE } from 'core/util/env'
+import { inBrowser, isIE9, isIE } from 'core/util/env'
+
+const isCompositionEventSupported = inBrowser && typeof window.CompositionEvent === 'function'
 
 describe('Directive v-model text', () => {
   it('should update value both ways', done => {
@@ -183,7 +185,7 @@ describe('Directive v-model text', () => {
     })
   }
 
-  if (typeof window.CompositionEvent === 'function') {
+  if (isCompositionEventSupported) {
     it('compositionevents', function (done) {
       const vm = new Vue({
         data: {
@@ -291,7 +293,7 @@ describe('Directive v-model text', () => {
     expect('conflicts with v-model').not.toHaveBeenWarned()
   })
 
-  if (!typeof window.CompositionEvent === 'function') {
+  if (isCompositionEventSupported) {
     it('does not trigger extra input events with single compositionend', () => {
       const spy = jasmine.createSpy()
       const vm = new Vue({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

#7367 
