### PR TITLE
Fix the env detection of server side rendering

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -38,7 +38,7 @@ let _isServer
 export const isServerRendering = () => {
   if (_isServer === undefined) {
     /* istanbul ignore if */
-    if (!inBrowser && typeof global !== 'undefined') {
+    if (!inBrowser && !inWeex && typeof global !== 'undefined') {
       // detect presence of vue-server-renderer and avoid
       // Webpack shimming the process
       _isServer = global['process'].env.VUE_ENV === 'server'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

**Other information:**

In Weex, `global` does exist, but `global.process` does not. I think it's more reliable to exclude Weex platform when detecting the ssr env.

  [edits: minor grammar edits]
  