### PR TITLE
feat(extends): allow extending globally registered components, closes #7310

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import config from '../config'
+import Vue from 'core/instance'
 import { warn } from './debug'
 import { nativeWatch } from './env'
 import { set } from '../observer/index'
@@ -17,7 +18,8 @@ import {
   toRawType,
   capitalize,
   isBuiltInTag,
-  isPlainObject
+  isPlainObject,
+  isPrimitive
 } from 'shared/util'
 
 /**
@@ -378,8 +380,11 @@ export function mergeOptions (
   normalizeProps(child, vm)
   normalizeInject(child, vm)
   normalizeDirectives(child)
-  const extendsFrom = child.extends
+  let extendsFrom = child.extends
   if (extendsFrom) {
+    if (isPrimitive(extendsFrom)) {
+      extendsFrom = Vue.component(extendsFrom)
+    }
     parent = mergeOptions(parent, extendsFrom, vm)
   }
   if (child.mixins) {

--- a/test/unit/features/options/extends.spec.js
+++ b/test/unit/features/options/extends.spec.js
@@ -48,6 +48,30 @@ describe('Options extends', () => {
     expect(vm.c).toBe(3)
   })
 
+  it('should work with globally registered components by string', () => {
+    Vue.component('A', {
+      data () {
+        return { a: 1 }
+      }
+    })
+    Vue.component('B', {
+      extends: 'A',
+      data () {
+        return { b: 2 }
+      }
+    })
+    const vm = new Vue({
+      extends: 'B',
+      data: {
+        c: 3
+      }
+    })
+
+    expect(vm.a).toBe(1)
+    expect(vm.b).toBe(2)
+    expect(vm.c).toBe(3)
+  })
+
   if (nativeWatch) {
     it('should work with global mixins + Object.prototype.watch', done => {
       Vue.mixin({})


### PR DESCRIPTION
Allows extending globally registered components by referencing their name as a string.

implements #7310

Feel free to close this PR if it's not something we need to support (I've only done it because I've been reading through the issues, and this seemed like a quick one). I'm not sure if there's a better way than importing Vue, I couldn't find a way to resolve a globally registered component.

**Note**: Tests seem to pass, although I'm having a hard time running the weex specific tests locally.
Edit: tests do fail for weex, I can look into that if intending to merge, let me know.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

  