### PR TITLE
fix: no _ssr* in ssr functional tempalte

### DIFF
--- a/src/core/vdom/create-functional-component.js
+++ b/src/core/vdom/create-functional-component.js
@@ -15,6 +15,18 @@ import {
   validateProp
 } from '../util/index'
 
+function fillSSRHelpers (Context, Ctor) {
+  const proto = Context.prototype
+  const ctorProto = Ctor.prototype
+  if (ctorProto._ssrNode && !proto._ssrNode) {
+    for (const key in ctorProto) {
+      if (key.indexOf('_ssr') === 0) {
+        proto[key] = ctorProto[key]
+      }
+    }
+  }
+}
+
 function FunctionalRenderContext (
   data,
   props,
@@ -22,6 +34,7 @@ function FunctionalRenderContext (
   parent,
   Ctor
 ) {
+  fillSSRHelpers(Ctor, FunctionalRenderContext)
   const options = Ctor.options
   this.data = data
   this.props = props


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fix https://github.com/nuxt/nuxt.js/issues/2565
When use Functional Components in ssr mode, the `FunctionalRenderContext` which is built in `runtime` is lack of _ssr* properties(_ssrNode, _ssrList, ...)