### PR TITLE
bug-fix: multiple possible types (1.0.21+) array shortcut not working

### DIFF
--- a/src/util/options.js
+++ b/src/util/options.js
@@ -274,7 +274,7 @@ function guardProps (options) {
     i = keys.length
     while (i--) {
       val = props[keys[i]]
-      if (typeof val === 'function') {
+      if (typeof val === 'function' || isArray(val)) {
         props[keys[i]] = { type: val }
       }
     }

--- a/test/unit/specs/util/options_spec.js
+++ b/test/unit/specs/util/options_spec.js
@@ -112,7 +112,8 @@ describe('Util - Option merging', function () {
       props: {
         a: { required: true },
         b: Boolean,
-        c: { type: Array }
+        c: { type: Array },
+        f: [String, Number]
       }
     })
     expect(typeof res.props.a).toBe('object')
@@ -122,6 +123,9 @@ describe('Util - Option merging', function () {
     expect(typeof res.props.c).toBe('object')
     expect(res.props.c.type).toBe(Array)
     expect(res.props.d).toBe(null)
+    expect(typeof res.props.f).toBe('object')
+    expect(res.props.f.type[0]).toBe(String)
+    expect(res.props.f.type[1]).toBe(Number)
 
     // check array syntax
     res = merge({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
