### PR TITLE
feat(core): add 'Vue.prototype.$notify'

### DIFF
--- a/flow/component.js
+++ b/flow/component.js
@@ -43,6 +43,7 @@ declare interface Component {
   $on: (event: string | Array<string>, fn: Function) => Component;
   $once: (event: string, fn: Function) => Component;
   $off: (event?: string | Array<string>, fn?: Function) => Component;
+  $notify: (event: string, ...args: Array<mixed>) => Array<mixed>;
   $emit: (event: string, ...args: Array<mixed>) => Component;
   $nextTick: (fn: Function) => void | Promise<*>;
   $createElement: (tag?: string | Component, data?: Object, children?: VNodeChildren) => VNode;

--- a/src/core/instance/events.js
+++ b/src/core/instance/events.js
@@ -111,7 +111,7 @@ export function eventsMixin (Vue: Class<Component>) {
     return vm
   }
 
-  Vue.prototype.$emit = function (event: string): Component {
+  Vue.prototype.$notify = function (event: string): Array<mixed> {
     const vm: Component = this
     if (process.env.NODE_ENV !== 'production') {
       const lowerCaseEvent = event.toLowerCase()
@@ -126,17 +126,24 @@ export function eventsMixin (Vue: Class<Component>) {
       }
     }
     let cbs = vm._events[event]
+    const retValues: Array<mixed> = []
     if (cbs) {
       cbs = cbs.length > 1 ? toArray(cbs) : cbs
       const args = toArray(arguments, 1)
+      retValues.length = cbs.length
       for (let i = 0, l = cbs.length; i < l; i++) {
         try {
-          cbs[i].apply(vm, args)
+          retValues[i] = cbs[i].apply(vm, args)
         } catch (e) {
           handleError(e, vm, `event handler for "${event}"`)
         }
       }
     }
-    return vm
+    return retValues
+  }
+
+  Vue.prototype.$emit = function (event: string): Component {
+    Vue.prototype.$notify.apply(this, arguments)
+    return this
   }
 }

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -399,6 +399,38 @@ describe('Directive v-on', () => {
     Vue.config.keyCodes = Object.create(null)
   })
 
+  it('should return this for $emit', () => {
+    vm = new Vue({
+      el,
+      template: '<bar @custom="foo"></bar>',
+      methods: { foo: () => 123 },
+      components: {
+        bar: {
+          template: '<span>Hello</span>'
+        }
+      }
+    })
+    const retValue = vm.$children[0].$emit('custom', 'foo', 'bar')
+    expect(retValue).toBe(vm.$children[0])
+  })
+
+  it('should return an array for $notify', () => {
+    vm = new Vue({
+      el,
+      template: '<bar @custom="foo"></bar>',
+      methods: { foo: () => 123 },
+      components: {
+        bar: {
+          template: '<span>Hello</span>'
+        }
+      }
+    })
+    const retValue = vm.$children[0].$notify('custom', 'foo', 'bar')
+    expect(Array.isArray(retValue)).toBe(true)
+    expect(retValue.length).toBe(1)
+    expect(retValue[0]).toBe(123)
+  })
+
   it('should bind to a child component', () => {
     vm = new Vue({
       el,

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -47,6 +47,7 @@ class Test extends Vue {
     this.$once("", () => {});
     this.$off("", () => {});
     this.$emit("", 1, 2, 3);
+    this.$notify("", 1, 2, 3);
     this.$nextTick(function() {
       this.$nextTick;
     });

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -56,6 +56,7 @@ export interface Vue {
   $once(event: string, callback: Function): this;
   $off(event?: string | string[], callback?: Function): this;
   $emit(event: string, ...args: any[]): this;
+  $notify(event: string, ...args: any[]): any[];
   $nextTick(callback: (this: this) => void): void;
   $nextTick(): Promise<void>;
   $createElement: CreateElement;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR adds a new function `Vue.prototype.$notify`, which works basically like `$emit`, except it returns an array that collects all return values of its event callbacks.

**Motivation:**

Developers of an component may want to collect data from callbacks of an event. There are a few options to do this:

1. Bind a function directly into the component. But it forces users of the component to write a function or needs the creator of the component writes property type checks to determine whether the prop value is callable or not.
2. Pass a callback parameter for the event. But nobody wants callbacks today.

To solve this issue, I'd like `$emit` or something else returns an array that collects all return values of its event callbacks. In order not to break old code, the behavior of `$emit` was kept ( which returns this ), but I wrote a new function instead. The function name `$notify` is not decided, but I can't come up with a better name.

Related issue: https://github.com/vuejs/vue/issues/5443
Related question: https://segmentfault.com/q/1010000011143372