### PR TITLE
fix(core): Use native bind function instead of own (fix #7408)

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -174,7 +174,7 @@ export const hyphenate = cached((str: string): string => {
 })
 
 /**
- * Bind funciton context
+ * Bind function context
  */
 export function bind (fn: Function, ctx: Object): Function {
   if(!Function.prototype.bind) {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -174,20 +174,10 @@ export const hyphenate = cached((str: string): string => {
 })
 
 /**
- * Simple bind, faster than native
+ * Bind funciton context
  */
 export function bind (fn: Function, ctx: Object): Function {
-  function boundFn (a) {
-    const l: number = arguments.length
-    return l
-      ? l > 1
-        ? fn.apply(ctx, arguments)
-        : fn.call(ctx, a)
-      : fn.call(ctx)
-  }
-  // record original fn length
-  boundFn._length = fn.length
-  return boundFn
+  return fn.bind(ctx)
 }
 
 /**

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -174,9 +174,13 @@ export const hyphenate = cached((str: string): string => {
 })
 
 /**
- * Bind function context
+ * Simple bind polyfill for environments that do not support it... e.g.
+ * PhantomJS 1.x. Technically we don't need this anymore since native bind is
+ * now more performant in most browsers, but removing it would be breaking for
+ * code that was able to run in PhantomJS 1.x, so this must be kept for
+ * backwards compatibility.
  */
-function ownBind (fn: Function, ctx: Object): Function {
+function polyfillBind (fn: Function, ctx: Object): Function {
   function boundFn (a) {
     const l = arguments.length
     return l
@@ -190,11 +194,13 @@ function ownBind (fn: Function, ctx: Object): Function {
   return boundFn
 }
 
-function nativeBind(fn: Function, ctx: Object): Function {
+function nativeBind (fn: Function, ctx: Object): Function {
   return fn.bind(ctx)
 }
 
-export const bind = Function.prototype.bind ? nativeBind : ownBind
+export const bind = Function.prototype.bind
+  ? nativeBind
+  : polyfillBind
 
 /**
  * Convert an Array-like object to a real Array.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -176,24 +176,25 @@ export const hyphenate = cached((str: string): string => {
 /**
  * Bind function context
  */
-export function bind (fn: Function, ctx: Object): Function {
-  if(!Function.prototype.bind) {
-    function boundFn (a) {
-      const l = arguments.length
-      return l
-        ? l > 1
-          ? fn.apply(ctx, arguments)
-          : fn.call(ctx, a)
-        : fn.call(ctx)
-    }
-    // record original fn length
-    boundFn._length = fn.length
-    
-    return boundFn
+function ownBind (fn: Function, ctx: Object): Function {
+  function boundFn (a) {
+    const l = arguments.length
+    return l
+      ? l > 1
+        ? fn.apply(ctx, arguments)
+        : fn.call(ctx, a)
+      : fn.call(ctx)
   }
-  
+
+  boundFn._length = fn.length
+  return boundFn
+}
+
+function nativeBind(fn: Function, ctx: Object): Function {
   return fn.bind(ctx)
 }
+
+export const bind = Function.prototype.bind ? nativeBind : ownBind
 
 /**
  * Convert an Array-like object to a real Array.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -177,6 +177,21 @@ export const hyphenate = cached((str: string): string => {
  * Bind funciton context
  */
 export function bind (fn: Function, ctx: Object): Function {
+  if(!Function.prototype.bind) {
+    function boundFn (a) {
+      const l = arguments.length
+      return l
+        ? l > 1
+          ? fn.apply(ctx, arguments)
+          : fn.call(ctx, a)
+        : fn.call(ctx)
+    }
+    // record original fn length
+    boundFn._length = fn.length
+    
+    return boundFn
+  }
+  
   return fn.bind(ctx)
 }
 


### PR DESCRIPTION
Simple refactor bind function for easy revert.
Custom bind implementation performance is lower than native. ( https://jsperf.com/vue-bind-perf )

issue link: https://github.com/vuejs/vue/issues/7408

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
