### PR TITLE
Fix: CSS FOUC in firefox

### DIFF
--- a/packages/vue-server-renderer/types/index.d.ts
+++ b/packages/vue-server-renderer/types/index.d.ts
@@ -28,6 +28,7 @@ interface BundleRenderer {
 interface RendererOptions {
   template?: string;
   inject?: boolean;
+  stylesheetBeforeScript?: boolean;
   shouldPreload?: (file: string, type: string) => boolean;
   shouldPrefetch?: (file: string, type: string) => boolean;
   cache?: RenderCache;

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -14,6 +14,7 @@ type TemplateRendererOptions = {
   template: ?string;
   inject?: boolean;
   clientManifest?: ClientManifest;
+  stylesheetBeforeScript?: boolean;
   shouldPreload?: (file: string, type: string) => boolean;
   shouldPrefetch?: (file: string, type: string) => boolean;
 };
@@ -41,6 +42,7 @@ type Resource = {
 export default class TemplateRenderer {
   options: TemplateRendererOptions;
   inject: boolean;
+  stylesheetBeforeScript: boolean;
   parsedTemplate: ParsedTemplate | null;
   publicPath: string;
   clientManifest: ClientManifest;
@@ -51,6 +53,7 @@ export default class TemplateRenderer {
   constructor (options: TemplateRendererOptions) {
     this.options = options
     this.inject = options.inject !== false
+    this.stylesheetBeforeScript = options.stylesheetBeforeScript === true
     // if no template option is provided, the renderer is created
     // as a utility object for rendering assets like preload links and scripts.
     this.parsedTemplate = options.template
@@ -89,8 +92,9 @@ export default class TemplateRenderer {
       return (
         template.head(context) +
         (context.head || '') +
+        (this.stylesheetBeforeScript ? this.renderStyles(context) : '') +
         this.renderResourceHints(context) +
-        this.renderStyles(context) +
+        (this.stylesheetBeforeScript ? '' : this.renderStyles(context)) +
         template.neck(context) +
         content +
         this.renderState(context) +

--- a/test/ssr/ssr-template.spec.js
+++ b/test/ssr/ssr-template.spec.js
@@ -221,6 +221,7 @@ describe('SSR: template option', () => {
 
   const expectedHTMLWithManifest = (options = {}) =>
     `<html><head>` +
+      (options.stylesBeforeScript ? `<link rel="stylesheet" href="/test.css">` : ``) +
       // used chunks should have preload
       `<link rel="preload" href="/manifest.js" as="script">` +
       `<link rel="preload" href="/main.js" as="script">` +
@@ -232,7 +233,7 @@ describe('SSR: template option', () => {
       // unused chunks should have prefetch
       (options.noPrefetch ? `` : `<link rel="prefetch" href="/1.js">`) +
       // css assets should be loaded
-      `<link rel="stylesheet" href="/test.css">` +
+      (options.stylesBeforeScript ? `` : `<link rel="stylesheet" href="/test.css">`) +
     `</head><body>` +
       `<div data-server-rendered="true"><div>async test.woff2 test.png</div></div>` +
       // state should be inlined before scripts
@@ -298,6 +299,25 @@ describe('SSR: template option', () => {
         stream.on('end', () => {
           expect(res).toContain(expectedHTMLWithManifest({
             noPrefetch: true
+          }))
+          done()
+        })
+      })
+    })
+
+    it('bundleRenderer + renderToStream + clientManifest + stylesheetBeforeScript : true', done => {
+      createRendererWithManifest('split.js', {
+        runInNewContext,
+        stylesBeforeScript: true
+      }, renderer => {
+        const stream = renderer.renderToStream({ state: { a: 1 }})
+        let res = ''
+        stream.on('data', chunk => {
+          res += chunk.toString()
+        })
+        stream.on('end', () => {
+          expect(res).toContain(expectedHTMLWithManifest({
+            stylesBeforeScript: true
           }))
           done()
         })

--- a/types/test/ssr-test.ts
+++ b/types/test/ssr-test.ts
@@ -63,6 +63,7 @@ declare const cacheClient: { [key: string]: string };
 
 const bundleRenderer = createBundleRenderer('/path/to/vue-ssr-server-bundle.json', {
   inject: false,
+  stylesheetBeforeScript: true,
   runInNewContext: 'once',
   basedir: '/path/to/base',
 


### PR DESCRIPTION
- Add option to set stylesheet to be rendered before scripts, to prevent
FOUC.
- https://aaronsaray.com/2009/flash-of-unstyled-content-in-firefox-3
- Added as an option as it should be user choice how they render there
content

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
