### PR TITLE
Fix: CSS FOUC issues

### DIFF
--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -61,6 +61,7 @@ export default class TemplateRenderer {
     if (options.clientManifest) {
       const clientManifest = this.clientManifest = options.clientManifest
       this.publicPath = clientManifest.publicPath.replace(/\/$/, '')
+
       // preload/prefetch directives
       this.preloadFiles = (clientManifest.initial || []).map(normalizeFile)
       this.prefetchFiles = (clientManifest.async || []).map(normalizeFile)
@@ -113,8 +114,9 @@ export default class TemplateRenderer {
       : []
     return (
       // render links for css files
+      // <script> to block fault in firefox
       (cssFiles.length
-        ? cssFiles.map(file => `<link rel="stylesheet" href="${this.publicPath}/${file}">`).join('')
+        ? cssFiles.map(file => `<link rel="stylesheet" href="${this.publicPath}/${file}">`).join('') + '<script> </script>'
         : '') +
       // context.styles is a getter exposed by vue-style-loader which contains
       // the inline component styles collected during SSR

--- a/test/ssr/ssr-template.spec.js
+++ b/test/ssr/ssr-template.spec.js
@@ -233,6 +233,8 @@ describe('SSR: template option', () => {
       (options.noPrefetch ? `` : `<link rel="prefetch" href="/1.js">`) +
       // css assets should be loaded
       `<link rel="stylesheet" href="/test.css">` +
+      // Firefox fout fix
+      `<script> </script>` +
     `</head><body>` +
       `<div data-server-rendered="true"><div>async test.woff2 test.png</div></div>` +
       // state should be inlined before scripts


### PR DESCRIPTION
## Changes
- Browser like firefox currently render <style> tags after js. Causing
brief FOUC.
- In order to prevent this you can add a `<script> </script>` to ensure
render is blocked until all css has been loaded.

### before
![fouc-before](https://user-images.githubusercontent.com/7272211/35365856-92d15c22-016e-11e8-815b-84f7d2b721dd.gif)
### after
![fouc-after](https://user-images.githubusercontent.com/7272211/35365855-92a5cb98-016e-11e8-96e8-59a3a2640a9c.gif)
