### PR TITLE
fix(codegen): support filters with () in older browsers

### DIFF
--- a/src/compiler/parser/filter-parser.js
+++ b/src/compiler/parser/filter-parser.js
@@ -92,6 +92,6 @@ function wrapFilter (exp: string, filter: string): string {
   } else {
     const name = filter.slice(0, i)
     const args = filter.slice(i + 1)
-    return `_f("${name}")(${exp},${args}`
+    return `_f("${name}")(${exp}${args !== ')' ? ',' + args : args}`
   }
 }

--- a/test/unit/modules/compiler/codegen.spec.js
+++ b/test/unit/modules/compiler/codegen.spec.js
@@ -44,6 +44,13 @@ describe('codegen', () => {
     )
   })
 
+  it('generate filters with no arguments', () => {
+    assertCodegen(
+      '<div>{{ d | e() }}</div>',
+      `with(this){return _c('div',[_v(_s(_f("e")(d)))])}`
+    )
+  })
+
   it('generate v-for directive', () => {
     assertCodegen(
       '<div><li v-for="item in items" :key="item.uid"></li></div>',


### PR DESCRIPTION
Fix #7544
Make sure no extra , is added at the end of the call so it also work with older browsers

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
