### PR TITLE
fix(types): make render option in functional components to optional

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -110,7 +110,7 @@ export interface FunctionalComponentOptions<Props = DefaultProps, PropDefs = Pro
   props?: PropDefs;
   inject?: InjectOptions;
   functional: boolean;
-  render(this: undefined, createElement: CreateElement, context: RenderContext<Props>): VNode;
+  render?(this: undefined, createElement: CreateElement, context: RenderContext<Props>): VNode;
 }
 
 export interface RenderContext<Props=DefaultProps> {

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -330,6 +330,10 @@ Vue.component('functional-component-object-inject', {
   }
 })
 
+Vue.component('functional-component-check-optional', {
+  functional: true
+})
+
 Vue.component("async-component", ((resolve, reject) => {
   setTimeout(() => {
     resolve(Vue.component("component"));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Since we can write a template of functional component in SFC, the `render` option of functional component can be omitted now.
