### PR TITLE
fix(refs): allow ref key to be zero (fix #7669)

### DIFF
--- a/src/core/vdom/modules/ref.js
+++ b/src/core/vdom/modules/ref.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { remove } from 'shared/util'
+import { remove, isDef } from 'shared/util'
 
 export default {
   create (_: any, vnode: VNodeWithData) {
@@ -19,7 +19,7 @@ export default {
 
 export function registerRef (vnode: VNodeWithData, isRemoval: ?boolean) {
   const key = vnode.data.ref
-  if (!key) return
+  if (!isDef(key)) return
 
   const vm = vnode.context
   const ref = vnode.componentInstance || vnode.elm

--- a/test/unit/features/ref.spec.js
+++ b/test/unit/features/ref.spec.js
@@ -9,6 +9,10 @@ describe('ref', () => {
     test2: {
       id: 'test2',
       template: '<div>test2</div>'
+    },
+    test3: {
+      id: 'test3',
+      template: '<div>test3</div>'
     }
   }
 
@@ -20,6 +24,7 @@ describe('ref', () => {
       template: `<div>
         <test ref="foo"></test>
         <test2 :ref="value"></test2>
+        <test3 :ref="0"></test3>
       </div>`,
       components
     })
@@ -28,6 +33,8 @@ describe('ref', () => {
     expect(vm.$refs.foo.$options.id).toBe('test')
     expect(vm.$refs.bar).toBeTruthy()
     expect(vm.$refs.bar.$options.id).toBe('test2')
+    expect(vm.$refs['0']).toBeTruthy()
+    expect(vm.$refs['0'].$options.id).toBe('test3')
   })
 
   it('should dynamically update refs', done => {


### PR DESCRIPTION
prevents missing elements when :ref value is "0"

fix #7669

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
