### PR TITLE
chore: add unittests for core/observer/dep

### DIFF
--- a/test/unit/modules/observer/dep.spec.js
+++ b/test/unit/modules/observer/dep.spec.js
@@ -1,0 +1,63 @@
+import Dep from 'core/observer/dep'
+
+describe('Dep', () => {
+  let dep
+
+  beforeEach(() => {
+    dep = new Dep()
+  })
+
+  describe('instance', () => {
+    it('should be created with correct properties', () => {
+      expect(dep.subs.length).toBe(0)
+      expect(new Dep().id).toBe(dep.id + 1)
+    })
+  })
+
+  describe('addSub()', () => {
+    it('should add sub', () => {
+      dep.addSub(null)
+      expect(dep.subs.length).toBe(1)
+      expect(dep.subs[0]).toBe(null)
+    })
+  })
+
+  describe('removeSub()', () => {
+    it('should remove sub', () => {
+      dep.subs.push(null)
+      dep.removeSub(null)
+      expect(dep.subs.length).toBe(0)
+    })
+  })
+
+  describe('depend()', () => {
+    let _target
+
+    beforeAll(() => {
+      _target = Dep.target
+    })
+
+    afterAll(() => {
+      Dep.target = _target
+    })
+
+    it('should do nothing if no target', () => {
+      Dep.target = null
+      dep.depend()
+    })
+
+    it('should add itself to target', () => {
+      Dep.target = jasmine.createSpyObj('TARGET', ['addDep'])
+      dep.depend()
+      expect(Dep.target.addDep).toHaveBeenCalledWith(dep)
+    })
+  })
+
+  describe('notify()', () => {
+    it('should notify subs', () => {
+      dep.subs.push(jasmine.createSpyObj('SUB', ['update']))
+      dep.notify()
+      expect(dep.subs[0].update).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Tests coverage extending

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Hey folks, I like autotests and would like to start to contribute to `vue` because heard many positive reviews about it.