### PR TITLE
fix(core): Make set/delete warning condition for undefined, null and primitive values more precise.  Corrects #7452

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -10,6 +10,8 @@ import {
   hasProto,
   isObject,
   isPlainObject,
+  isPrimitive,
+  isUndef,
   isValidArrayIndex,
   isServerRendering
 } from '../util/index'
@@ -195,10 +197,9 @@ export function defineReactive (
  */
 export function set (target: Array<any> | Object, key: any, val: any): any {
   if (process.env.NODE_ENV !== 'production' &&
-    !Array.isArray(target) &&
-    !isObject(target)
+    (isUndef(target) || isPrimitive(target))
   ) {
-    warn(`Cannot set reactive property on non-object/array value: ${target}`)
+    warn(`Cannot set reactive property on undefined, null, or primitive value: ${(target: any)}`)
   }
   if (Array.isArray(target) && isValidArrayIndex(key)) {
     target.length = Math.max(target.length, key)
@@ -231,10 +232,9 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
  */
 export function del (target: Array<any> | Object, key: any) {
   if (process.env.NODE_ENV !== 'production' &&
-    !Array.isArray(target) &&
-    !isObject(target)
+    (isUndef(target) || isPrimitive(target))
   ) {
-    warn(`Cannot delete reactive property on non-object/array value: ${target}`)
+    warn(`Cannot delete reactive property on undefined, null, or primitive value: ${(target: any)}`)
   }
   if (Array.isArray(target) && isValidArrayIndex(key)) {
     target.splice(key, 1)

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -360,12 +360,12 @@ describe('Observer', () => {
     try {
       setProp(null, 'foo', 1)
     } catch (e) {}
-    expect(`Cannot set reactive property on non-object/array value`).toHaveBeenWarned()
+    expect(`Cannot set reactive property on undefined, null, or primitive value`).toHaveBeenWarned()
 
     try {
       delProp(null, 'foo')
     } catch (e) {}
-    expect(`Cannot delete reactive property on non-object/array value`).toHaveBeenWarned()
+    expect(`Cannot delete reactive property on undefined, null, or primitive value`).toHaveBeenWarned()
   })
 
   it('should lazy invoke existing getters', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Limiting set/delete to objects and arrays is overly restrictive; for example, there's no problem in setting properties on functions.  I just changed the condition to what the original PR's description claimed and clarified the warning message.
