### PR TITLE
fix(observer): invoke getters on initial observation if setter defined. Corrects #7302

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -147,10 +147,10 @@ export function defineReactive (
 
   // cater for pre-defined getter/setters
   const getter = property && property.get
-  if (!getter && arguments.length === 2) {
+  const setter = property && property.set
+  if ((!getter || setter) && arguments.length === 2) {
     val = obj[key]
   }
-  const setter = property && property.set
 
   let childOb = !shallow && observe(val)
   Object.defineProperty(obj, key, {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

After #7302, there's an asymmetry in `defineReactive` for properties that have both a getter and a setter.  On initial creation, the value returned by the getter is not made reactive since #7302 makes sure not to fetch it and `observe(val)` is a no-op.  However, if the value is set again after the property has been made reactive, it is made reactive as well since `observe(newVal)` in `set` is not gated on missing a getter.  (The premise justifying the change in #7280 that "why should we get the value of the property in walk, despite the fact, that it is used only if the property has no getter" is wrong, as the value was used in the call to `observe` even if the property had a getter.)

With the present change, properties that _only_ have a getter will still not have their value fetched and won't be made reactive, which should continue to satisfy @DeyLak's needs IIUC.  However, properties that have both a getter and a setter will continue to behave like they did before, being made recursively reactive, and their initial value treated consistently with subsequently set ones.

If you think that treating getter vs getter/setter properties differently is confusing, then you may want to revert #7302 instead so all values are made recursively reactive, irrespective of how the property is defined.  This may be easier for developers to understand but would break @DeyLak's use case.
