### PR TITLE
feat(compiler): Allow style element inside svg

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -130,7 +130,7 @@ export function parse (
         element.ns = ns
       }
 
-      if (isForbiddenTag(element) && !isServerRendering()) {
+      if (isForbiddenTag(element, ns) && !isServerRendering()) {
         element.forbidden = true
         process.env.NODE_ENV !== 'production' && warn(
           'Templates should only be responsible for mapping the state to the ' +
@@ -632,9 +632,9 @@ function isTextTag (el): boolean {
   return el.tag === 'script' || el.tag === 'style'
 }
 
-function isForbiddenTag (el): boolean {
+function isForbiddenTag (el, ns): boolean {
   return (
-    el.tag === 'style' ||
+    (el.tag === 'style' && ns !== 'svg') ||
     (el.tag === 'script' && (
       !el.attrsMap.type ||
       el.attrsMap.type === 'text/javascript'

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -72,6 +72,18 @@ describe('parser', () => {
     expect('Templates should only be responsible for mapping the state').toHaveBeenWarned()
   })
 
+  it('allows style element inside svg', () => {
+    const ast = parse('<svg><defs><style>error { color: red; }</style></defs></svg>', baseOptions)
+    expect(ast.tag).toBe('svg')
+    expect(ast.ns).toBe('svg')
+    expect(ast.plain).toBe(true)
+    expect(ast.children[0].tag).toBe('defs')
+    expect(ast.children[0].children[0].tag).toBe('style')
+    expect(ast.children[0].children[0].forbidden).toBeUndefined()
+    expect(ast.children[0].children[0].children[0].text).toBe('error { color: red; }')
+    expect(ast.children[0].parent).toBe(ast)
+  })
+
   it('not contain root element', () => {
     parse('hello world', baseOptions)
     expect('Component template requires a root element, rather than just text').toHaveBeenWarned()


### PR DESCRIPTION
fix #7678

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This would be useful for inlining SVGs with styles and for packages like https://github.com/visualfanatic/vue-svg-loader