### PR TITLE
feat(weex): invoke handlers on virtual component instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,8 +136,9 @@
     "shelljs": "^0.8.1",
     "typescript": "^2.7.1",
     "uglify-js": "^3.0.15",
+    "vue-template-es2015-compiler": "^1.6.0",
     "webpack": "^3.11.0",
-    "weex-js-runtime": "^0.23.6",
+    "weex-js-runtime": "^0.23.7",
     "weex-styler": "^0.3.0",
     "yorkie": "^1.0.1"
   },

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -237,10 +237,10 @@ export function genData (el: ASTElement, state: CodegenState): string {
   }
   // event handlers
   if (el.events) {
-    data += `${genHandlers(el.events, false, state.warn)},`
+    data += `${genHandlers(el.events, false, state.options)},`
   }
   if (el.nativeEvents) {
-    data += `${genHandlers(el.nativeEvents, true, state.warn)},`
+    data += `${genHandlers(el.nativeEvents, true, state.options)},`
   }
   // slot target
   // only for non-scoped slots

--- a/src/platforms/weex/compiler/modules/event.js
+++ b/src/platforms/weex/compiler/modules/event.js
@@ -1,0 +1,71 @@
+/* @flow */
+
+// this will be preserved during build
+// $flow-disable-line
+const transpile = require('vue-template-es2015-compiler')
+
+import { simplePathRE, fnExpRE } from 'compiler/codegen/events'
+import { functionCallRE, generateBinding } from 'weex/util/parser'
+
+// Generate handler code with binding params for Weex platform
+/* istanbul ignore next */
+export function genWeexHandlerWithParams (handlerCode: string): string {
+  const match = functionCallRE.exec(handlerCode)
+  if (!match) {
+    return ''
+  }
+  const handlerExp = match[1]
+  const params = match[2].split(/\s*,\s*/)
+  const exps = params.filter(exp => simplePathRE.test(exp) && exp !== '$event')
+  const bindings = exps.map(exp => generateBinding(exp))
+  const args = exps.map((exp, index) => {
+    const key = `$$_${index + 1}`
+    for (let i = 0; i < params.length; ++i) {
+      if (params[i] === exp) {
+        params[i] = key
+      }
+    }
+    return key
+  })
+  args.push('$event')
+  return `{
+    handler: function (${args.join(',')}) {
+      ${handlerExp}(${params.join(',')});
+    },
+    params:${JSON.stringify(bindings)}
+  }`
+}
+
+export function genWeexHandler (handler: ASTElementHandler, options: CompilerOptions): string {
+  let code = handler.value
+  const isMethodPath = simplePathRE.test(code)
+  const isFunctionExpression = fnExpRE.test(code)
+  const isFunctionCall = functionCallRE.test(code)
+
+  // using dynamic this in recyclable event handlers
+  if (options.recyclable) {
+    if (isMethodPath) {
+      return `function($event){this.${code}()}`
+    }
+    if (isFunctionExpression && options.warn) {
+      options.warn(`Function expression is not supported in recyclable components: ${code}.`)
+    }
+    if (isFunctionCall) {
+      return `function($event){this.${code}}`
+    }
+    // inline statement
+    code = transpile(`with(this){${code}}`, {
+      transforms: { stripWith: true }
+    })
+  }
+
+  if (isMethodPath || isFunctionExpression) {
+    return code
+  }
+  /* istanbul ignore if */
+  if (handler.params) {
+    return genWeexHandlerWithParams(handler.value)
+  }
+  // inline statement
+  return `function($event){${code}}`
+}

--- a/src/platforms/weex/compiler/modules/recycle-list/v-on.js
+++ b/src/platforms/weex/compiler/modules/recycle-list/v-on.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-const inlineStatementRE = /^\s*([A-Za-z_$0-9\['\."\]]+)*\s*\(\s*(([A-Za-z_$0-9\['\."\]]+)?(\s*,\s*([A-Za-z_$0-9\['\."\]]+))*)\s*\)$/
+import { functionCallRE } from 'weex/util/parser'
 
 function parseHandlerParams (handler: ASTElementHandler) {
-  const res = inlineStatementRE.exec(handler.value)
+  const res = functionCallRE.exec(handler.value)
   if (res && res[2]) {
     handler.params = res[2].split(/\s*,\s*/)
   }

--- a/src/platforms/weex/util/parser.js
+++ b/src/platforms/weex/util/parser.js
@@ -8,6 +8,8 @@ const acorn = require('acorn') // $flow-disable-line
 const walk = require('acorn/dist/walk') // $flow-disable-line
 const escodegen = require('escodegen')
 
+export const functionCallRE = /^\s*([A-Za-z_$0-9\['\."\]]+)*\s*\(\s*(([A-Za-z_$0-9\['\."\]]+)?(\s*,\s*([A-Za-z_$0-9\['\."\]]+))*)\s*\)$/
+
 export function nodeToBinding (node: Object): any {
   switch (node.type) {
     case 'Literal': return node.value

--- a/test/weex/cases/recycle-list/v-on-inline.vdom.js
+++ b/test/weex/cases/recycle-list/v-on-inline.vdom.js
@@ -6,6 +6,7 @@
       { type: 'A' },
       { type: 'A' }
     ],
+    index: 'i',
     switch: 'type',
     alias: 'item'
   },
@@ -32,6 +33,15 @@
       type: 'text',
       event: [{ type: 'disappear' }],
       attr: { value: 'Tips' }
+    }, {
+      type: 'text',
+      event: [{
+        type: 'swipe',
+        params: [
+          { '@binding': 'i' }
+        ]
+      }],
+      attr: { value: 'Inc' }
     }]
   }]
 })

--- a/test/weex/cases/recycle-list/v-on-inline.vue
+++ b/test/weex/cases/recycle-list/v-on-inline.vue
@@ -1,9 +1,10 @@
 <template>
-  <recycle-list for="item in longList" switch="type">
+  <recycle-list for="(item, i) in longList" switch="type">
     <cell-slot case="A">
       <text v-on:click="toggle()" @longpress="toggle(item.key)"></text>
       <text @appear="onappear(item.index, 'static', item.type, $event)">Button</text>
       <text @disappear="onappear(25, 'static')">Tips</text>
+      <text @swipe="inc(i)">Inc</text>
     </cell-slot>
   </recycle-list>
 </template>
@@ -19,10 +20,9 @@
       }
     },
     methods: {
-      hide () {},
+      inc () {},
       toggle () {},
       onappear () {}
     }
   }
 </script>
-


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Feature

**Does this PR introduce a breaking change?**

- [x] No

**Other information:**

> **These modifications only take effects on Weex platform.**

This is a partial feature of recycle-list.

Because of there is no virtual dom in virtual components, the event handler can only be bind on the virtual component template, but the event handler should be executed in the virtual component context (refer to this [brief explanation](https://segmentfault.com/a/1190000013697211#articleHeader13)). So at least two processes should be changed to support this feature.

**1. Using dynamic `this` for the event handler**

When compiling the `v-on` directive, the expression will be compiled into a handler function. Along with the `with(this){}` magic, the handler function's context (`this`) always be same as the render function. But it should be dynamic for virtual components, the real context of the event handler could be re-assigned at runtime.

To achieve this, I added an explicit `this` to the event handlers which are used in recyclable components.  ([platforms/weex/compiler/modules/event.js#L45-L60](https://github.com/Hanks10100/vue/blob/6be2fc83130c1aa1cf696800a2b7fb23eec9f6e1/src/platforms/weex/compiler/modules/event.js#L45-L60)) 

**2. Finding the expected context when invoking the event handler.**

At runtime, if an event is dispatched to a virtual component template, then find the real context by `componentId` and invoke the handler in the expected context. ([platforms/weex/runtime/modules/events.js#L48-L65](https://github.com/Hanks10100/vue/blob/6be2fc83130c1aa1cf696800a2b7fb23eec9f6e1/src/platforms/weex/runtime/modules/events.js#L48-L65))
