### PR TITLE
Adds missing `asyncMeta` during VNode cloning

### DIFF
--- a/src/core/vdom/vnode.js
+++ b/src/core/vdom/vnode.js
@@ -103,7 +103,7 @@ export function cloneVNode (vnode: VNode): VNode {
   cloned.fnContext = vnode.fnContext
   cloned.fnOptions = vnode.fnOptions
   cloned.fnScopeId = vnode.fnScopeId
-  cloned.asyncMeta = vnode.asyncMeta;
+  cloned.asyncMeta = vnode.asyncMeta
   cloned.isCloned = true
   return cloned
 }

--- a/src/core/vdom/vnode.js
+++ b/src/core/vdom/vnode.js
@@ -103,6 +103,7 @@ export function cloneVNode (vnode: VNode): VNode {
   cloned.fnContext = vnode.fnContext
   cloned.fnOptions = vnode.fnOptions
   cloned.fnScopeId = vnode.fnScopeId
+  cloned.asyncMeta = vnode.asyncMeta;
   cloned.isCloned = true
   return cloned
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup

**Other information:**
This fixes a crash during SSR, where a parent functional component is using an async component in the render function. If the prop is not copied, `renderAsyncComponent` crashes during rendering. Looks like this bug was introduced in 62a922e865f5e578f67b386cb614abfc173d7851