### PR TITLE
fix: correct the `has` implementation in the `_renderProxy`

### DIFF
--- a/src/core/instance/proxy.js
+++ b/src/core/instance/proxy.js
@@ -45,7 +45,7 @@ if (process.env.NODE_ENV !== 'production') {
   const hasHandler = {
     has (target, key) {
       const has = key in target
-      const isAllowed = allowedGlobals(key) || key.charAt(0) === '_'
+      const isAllowed = allowedGlobals(key) || (typeof key === 'string' && key.charAt(0) === '_')
       if (!has && !isAllowed) {
         warnNonPresent(target, key)
       }

--- a/test/unit/features/instance/render-proxy.spec.js
+++ b/test/unit/features/instance/render-proxy.spec.js
@@ -28,5 +28,22 @@ if (typeof Proxy !== 'undefined') {
       }).$mount()
       expect(`Property or method "a" is not defined`).not.toHaveBeenWarned()
     })
+
+    it('support symbols using the `in` operator in hand-written render functions', () => {
+      const sym = Symbol()
+
+      const vm = new Vue({
+        created () {
+          this[sym] = 'foo'
+        },
+        render (h) {
+          if (sym in this) {
+            return h('div', [this[sym]])
+          }
+        }
+      }).$mount()
+
+      expect(vm.$el.textContent).toBe('foo')
+    })
   })
 }


### PR DESCRIPTION
It's feasible that someone might ask if something other than a string is
in the proxy such as a `Symbol` that lacks a `charAt` method.  This aligns
the implementation with the `getHandler`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This issue was discovered when using `vue-test-utils` and the associated test helpers it provides.  Ref: https://github.com/vuejs/vue-test-utils/issues/452
