### PR TITLE
fix(codegen): support IE11 and Edge use of "Esc" key (close #7880)

### DIFF
--- a/src/compiler/codegen/events.js
+++ b/src/compiler/codegen/events.js
@@ -18,7 +18,8 @@ const keyCodes: { [key: string]: number | Array<number> } = {
 
 // KeyboardEvent.key aliases
 const keyNames: { [key: string]: string | Array<string> } = {
-  esc: 'Escape',
+  // #7880: IE11 and Edge use `Esc` for Escape key name.
+  esc: ['Esc', 'Escape'],
   tab: 'Tab',
   enter: 'Enter',
   space: ' ',


### PR DESCRIPTION
Closes #7880

IE11 and Edge use "Esc" as key name, other browsers use "Escape".

I was able to test on Edge 16/15/14 and IE11.

- More reference: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5290772/
- Reproduction link: http://codepen.io/anon/pen/QjxPGB

![screenshot 2018-03-23 13 05 45](https://user-images.githubusercontent.com/1292945/37840101-f5ed1270-2e9a-11e8-890c-f0c761de0abc.png)




<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
