### PR TITLE
fix(transition-group): ensure remove class v-enter-to after it was added

### DIFF
--- a/src/platforms/web/runtime/components/transition-group.js
+++ b/src/platforms/web/runtime/components/transition-group.js
@@ -16,6 +16,7 @@ import { addClass, removeClass } from '../class-util'
 import { transitionProps, extractTransitionData } from './transition'
 
 import {
+  nextFrame,
   hasTransition,
   getTransitionInfo,
   transitionEndEvent,
@@ -162,7 +163,7 @@ function callPendingCbs (c: VNode) {
   }
   /* istanbul ignore if */
   if (c.elm._enterCb) {
-    c.elm._enterCb()
+    nextFrame(c.elm._enterCb)
   }
 }
 

--- a/test/unit/features/transition/transition-group.spec.js
+++ b/test/unit/features/transition/transition-group.spec.js
@@ -340,5 +340,29 @@ if (!isIE9) {
         )
       }).then(done)
     })
+
+    it('should remove class v-enter-to', done => {
+      const vm = new Vue({
+        template: `
+          <div>
+            <transition-group name="group">
+              <div v-if="ok" key="foo">foo</div>
+            </transition-group>
+          </div>
+        `,
+        data: { ok: false }
+      }).$mount(el)
+
+      vm.ok = true
+      waitForUpdate(() => {
+        vm.$forceUpdate()
+      }).thenWaitFor(duration + buffer).then(() => {
+        expect(vm.$el.innerHTML).toBe(
+          `<span>` +
+            `<div>foo</div>` +
+          `</span>`
+        )
+      }).then(done)
+    })
   })
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
*  related to #5800 
* in component transition-group, `_enterCb` could excute before [nextFrame](https://github.com/vuejs/vue/blob/dev/src/platforms/web/runtime/modules/transition.js#L151), so put `_enterCb` into `nextFrame`