### PR TITLE
feat(types): add vue-template-compiler types

### DIFF
--- a/packages/vue-template-compiler/package.json
+++ b/packages/vue-template-compiler/package.json
@@ -24,5 +24,8 @@
   "dependencies": {
     "he": "^1.1.0",
     "de-indent": "^1.0.2"
+  },
+  "devDependencies": {
+    "vue": "file:../.."
   }
 }

--- a/packages/vue-template-compiler/package.json
+++ b/packages/vue-template-compiler/package.json
@@ -6,6 +6,7 @@
   "unpkg": "browser.js",
   "jsdelivr": "browser.js",
   "browser": "browser.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vuejs/vue.git"

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -1,0 +1,208 @@
+/*
+ * Template compilation options / results
+ */
+interface CompilerOptions {
+  modules?: ModuleOptions[];
+  directives?: Record<string, DirectiveFunction>;
+  preserveWhitespace?: boolean;
+}
+
+interface CompiledResult {
+  ast: ASTElement | undefined;
+  render: string;
+  staticRenderFns: string[];
+  errors: string[];
+}
+
+interface CompiledResultFunctions {
+  render: Function;
+  staticRenderFns: Function[];
+}
+
+interface ModuleOptions {
+  preTransformNode: (el: ASTElement) => ASTElement | undefined;
+  transformNode: (el: ASTElement) => ASTElement | undefined;
+  postTransformNode: (el: ASTElement) => void;
+  genData: (el: ASTElement) => string;
+  transformCode?: (el: ASTElement, code: string) => string;
+  staticKeys?: string[];
+}
+
+type DirectiveFunction = (node: ASTElement, directiveMeta: ASTDirective) => void;
+
+/*
+ * AST Types
+ */
+interface ASTModifiers {
+  [key: string]: boolean;
+}
+
+interface ASTIfCondition {
+  exp: string | undefined;
+  block: ASTElement;
+}
+
+interface ASTElementHandler {
+  value: string;
+  params?: any[];
+  modifiers: ASTModifiers | undefined;
+}
+
+interface ASTElementHandlers {
+  [key: string]: ASTElementHandler | ASTElementHandler[];
+}
+
+interface ASTDirective {
+  name: string;
+  rawName: string;
+  value: string;
+  arg: string | undefined;
+  modifiers: ASTModifiers | undefined;
+}
+
+type ASTNode = ASTElement | ASTText | ASTExpression;
+
+interface ASTElement {
+  type: 1;
+  tag: string;
+  attrsList: { name: string; value: any }[];
+  attrsMap: Record<string, any>;
+  parent: ASTElement | undefined;
+  children: ASTNode[];
+
+  processed?: true;
+
+  static?: boolean;
+  staticRoot?: boolean;
+  staticInFor?: boolean;
+  staticProcessed?: boolean;
+  hasBindings?: boolean;
+
+  text?: string;
+  attrs?: { name: string; value: any }[];
+  props?: { name: string; value: string }[];
+  plain?: boolean;
+  pre?: true;
+  ns?: string;
+
+  component?: string;
+  inlineTemplate?: true;
+  transitionMode?: string | null;
+  slotName?: string;
+  slotTarget?: string;
+  slotScope?: string;
+  scopedSlots?: Record<string, ASTElement>;
+
+  ref?: string;
+  refInFor?: boolean;
+
+  if?: string;
+  ifProcessed?: boolean;
+  elseif?: string;
+  else?: true;
+  ifConditions?: ASTIfCondition[];
+
+  for?: string;
+  forProcessed?: boolean;
+  key?: string;
+  alias?: string;
+  iterator1?: string;
+  iterator2?: string;
+
+  staticClass?: string;
+  classBinding?: string;
+  staticStyle?: string;
+  styleBinding?: string;
+  events?: ASTElementHandlers;
+  nativeEvents?: ASTElementHandlers;
+
+  transition?: string | true;
+  transitionOnAppear?: boolean;
+
+  model?: {
+    value: string;
+    callback: string;
+    expression: string;
+  };
+
+  directives?: ASTDirective[];
+
+  forbidden?: true;
+  once?: true;
+  onceProcessed?: boolean;
+  wrapData?: (code: string) => string;
+  wrapListeners?: (code: string) => string;
+
+  // 2.4 ssr optimization
+  ssrOptimizability?: number;
+
+  // weex specific
+  appendAsTree?: boolean;
+}
+
+interface ASTExpression {
+  type: 2;
+  expression: string;
+  text: string;
+  tokens: (string | Record<string, any>)[];
+  static?: boolean;
+  // 2.4 ssr optimization
+  ssrOptimizability?: number;
+}
+
+interface ASTText {
+  type: 3;
+  text: string;
+  static?: boolean;
+  isComment?: boolean;
+  // 2.4 ssr optimization
+  ssrOptimizability?: number;
+}
+
+/*
+ * SFC parser related types
+ */
+interface SFCParserOptions {
+  pad?: true | 'line' | 'space';
+}
+
+interface SFCBlock {
+  type: string;
+  content: string;
+  attrs: Record<string, string>;
+  start?: number;
+  end?: number;
+  lang?: string;
+  src?: string;
+  scoped?: boolean;
+  module?: string | boolean;
+}
+
+interface SFCDescriptor {
+  template: SFCBlock | undefined;
+  script: SFCBlock | undefined;
+  styles: SFCBlock[];
+  customBlocks: SFCBlock[];
+}
+
+/*
+ * Exposed functions
+ */
+export function compile(
+  template: string,
+  options?: CompilerOptions
+): CompiledResult;
+
+export function compileToFunctions(template: string): CompiledResultFunctions;
+
+export function ssrCompile(
+  template: string,
+  options?: CompilerOptions
+): CompiledResult;
+
+export function ssrCompileToFunctions(template: string): CompiledResultFunctions;
+
+export function parseComponent(
+  file: string,
+  options?: SFCParserOptions
+): SFCDescriptor;

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -33,26 +33,26 @@ type DirectiveFunction = (node: ASTElement, directiveMeta: ASTDirective) => void
 /*
  * AST Types
  */
-interface ASTModifiers {
+export interface ASTModifiers {
   [key: string]: boolean;
 }
 
-interface ASTIfCondition {
+export interface ASTIfCondition {
   exp: string | undefined;
   block: ASTElement;
 }
 
-interface ASTElementHandler {
+export interface ASTElementHandler {
   value: string;
   params?: any[];
   modifiers: ASTModifiers | undefined;
 }
 
-interface ASTElementHandlers {
+export interface ASTElementHandlers {
   [key: string]: ASTElementHandler | ASTElementHandler[];
 }
 
-interface ASTDirective {
+export interface ASTDirective {
   name: string;
   rawName: string;
   value: string;
@@ -60,9 +60,9 @@ interface ASTDirective {
   modifiers: ASTModifiers | undefined;
 }
 
-type ASTNode = ASTElement | ASTText | ASTExpression;
+export type ASTNode = ASTElement | ASTText | ASTExpression;
 
-interface ASTElement {
+export interface ASTElement {
   type: 1;
   tag: string;
   attrsList: { name: string; value: any }[];
@@ -140,7 +140,7 @@ interface ASTElement {
   appendAsTree?: boolean;
 }
 
-interface ASTExpression {
+export interface ASTExpression {
   type: 2;
   expression: string;
   text: string;
@@ -150,7 +150,7 @@ interface ASTExpression {
   ssrOptimizability?: number;
 }
 
-interface ASTText {
+export interface ASTText {
   type: 3;
   text: string;
   static?: boolean;
@@ -166,7 +166,7 @@ interface SFCParserOptions {
   pad?: true | 'line' | 'space';
 }
 
-interface SFCBlock {
+export interface SFCBlock {
   type: string;
   content: string;
   attrs: Record<string, string>;
@@ -178,7 +178,7 @@ interface SFCBlock {
   module?: string | boolean;
 }
 
-interface SFCDescriptor {
+export interface SFCDescriptor {
   template: SFCBlock | undefined;
   script: SFCBlock | undefined;
   styles: SFCBlock[];

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -1,3 +1,5 @@
+import Vue, { VNode } from "vue"
+
 /*
  * Template compilation options / results
  */
@@ -16,8 +18,8 @@ interface CompiledResult {
 }
 
 interface CompiledResultFunctions {
-  render: Function;
-  staticRenderFns: Function[];
+  render: (this: Vue) => VNode;
+  staticRenderFns: ((this: Vue) => VNode)[];
 }
 
 interface ModuleOptions {

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -12,6 +12,7 @@ interface CompiledResult {
   render: string;
   staticRenderFns: string[];
   errors: string[];
+  tips: string[];
 }
 
 interface CompiledResultFunctions {

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -34,6 +34,16 @@ type DirectiveFunction = (node: ASTElement, directiveMeta: ASTDirective) => void
 /*
  * AST Types
  */
+
+/**
+ * - 0: FALSE - whole sub tree un-optimizable
+ * - 1: FULL - whole sub tree optimizable
+ * - 2: SELF - self optimizable but has some un-optimizable children
+ * - 3: CHILDREN - self un-optimizable but have fully optimizable children
+ * - 4: PARTIAL - self un-optimizable with some un-optimizable children
+ */
+export type SSROptimizability = 0 | 1 | 2 | 3 | 4
+
 export interface ASTModifiers {
   [key: string]: boolean;
 }
@@ -135,7 +145,7 @@ export interface ASTElement {
   wrapListeners?: (code: string) => string;
 
   // 2.4 ssr optimization
-  ssrOptimizability?: number;
+  ssrOptimizability?: SSROptimizability;
 
   // weex specific
   appendAsTree?: boolean;
@@ -148,7 +158,7 @@ export interface ASTExpression {
   tokens: (string | Record<string, any>)[];
   static?: boolean;
   // 2.4 ssr optimization
-  ssrOptimizability?: number;
+  ssrOptimizability?: SSROptimizability;
 }
 
 export interface ASTText {
@@ -157,7 +167,7 @@ export interface ASTText {
   static?: boolean;
   isComment?: boolean;
   // 2.4 ssr optimization
-  ssrOptimizability?: number;
+  ssrOptimizability?: SSROptimizability;
 }
 
 /*

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -18,8 +18,8 @@ interface CompiledResult {
 }
 
 interface CompiledResultFunctions {
-  render: (this: Vue) => VNode;
-  staticRenderFns: ((this: Vue) => VNode)[];
+  render: () => VNode;
+  staticRenderFns: (() => VNode)[];
 }
 
 interface ModuleOptions {

--- a/packages/vue-template-compiler/types/test.ts
+++ b/packages/vue-template-compiler/types/test.ts
@@ -1,0 +1,60 @@
+import Vue, { VNode } from "vue";
+import {
+  compile,
+  compileToFunctions,
+  ssrCompile,
+  ssrCompileToFunctions,
+  parseComponent
+} from "./";
+
+// check compile options
+const compiled = compile("<div>hi</div>", {
+  preserveWhitespace: false,
+  modules: [
+    {
+      preTransformNode: el => el,
+      transformNode: el => el,
+      postTransformNode: el => {
+        el.tag = "p";
+      },
+      genData: el => el.tag,
+      transformCode: (el, code) => code,
+      staticKeys: ["test"]
+    }
+  ],
+  directives: {
+    test: (node, directiveMeta) => {
+      node.tag;
+      directiveMeta.value;
+    }
+  }
+});
+
+// can be passed to function constructor
+new Function(compiled.render);
+compiled.staticRenderFns.map(fn => new Function(fn));
+
+const compiledFns = compileToFunctions("<div>hi</div>");
+
+// can be passed to component render / staticRenderFns options
+const vm = new Vue({
+  data() {
+    return {
+      test: "Test"
+    };
+  },
+  render: compiledFns.render,
+  staticRenderFns: compiledFns.staticRenderFns
+});
+
+// can be called with component instance
+const vnode: VNode = compiledFns.render.call(vm);
+
+// check SFC parser
+const desc = parseComponent("<template></template>", {
+  pad: "space"
+});
+
+const templateContent: string = desc.template!.content;
+const scriptContent: string = desc.script!.content;
+const styleContent: string = desc.styles.map(s => s.content).join("\n");

--- a/packages/vue-template-compiler/types/tsconfig.json
+++ b/packages/vue-template-compiler/types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true
+  },
+  "compileOnSave": false,
+  "include": [
+    "**/*.ts"
+  ]
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I just remembered I wrote `vue-template-compiler` typings for my own project when seeing [`component-compiler-utils` types](https://github.com/vuejs/component-compiler-utils/blob/master/lib/types.ts) 😄 
It would be convenient for anyone who writes static analysis / customized compiler / build tools in TypeScript.