### PR TITLE
feat(parser): add hasShadowRoot option

### DIFF
--- a/dist/vue.js
+++ b/dist/vue.js
@@ -9676,6 +9676,7 @@ function isTextTag (el) {
 }
 
 function isForbiddenTag (el) {
+  console.log(el);
   return (
     el.tag === 'style' ||
     (el.tag === 'script' && (

--- a/dist/vue.js
+++ b/dist/vue.js
@@ -9676,7 +9676,6 @@ function isTextTag (el) {
 }
 
 function isForbiddenTag (el) {
-  console.log(el);
   return (
     el.tag === 'style' ||
     (el.tag === 'script' && (

--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -18,6 +18,7 @@ declare type CompilerOptions = {
   shouldDecodeTags?: boolean;
   shouldDecodeNewlines?:  boolean;
   shouldDecodeNewlinesForHref?: boolean;
+  hasShadowRoot?: boolean;
 
   // runtime user-configurable
   delimiters?: [string, string]; // template delimiters

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -130,7 +130,7 @@ export function parse (
         element.ns = ns
       }
 
-      if (isForbiddenTag(element) && !isServerRendering()) {
+      if (isForbiddenTag(element, options.hasShadowRoot) && !isServerRendering()) {
         element.forbidden = true
         process.env.NODE_ENV !== 'production' && warn(
           'Templates should only be responsible for mapping the state to the ' +
@@ -632,9 +632,9 @@ function isTextTag (el): boolean {
   return el.tag === 'script' || el.tag === 'style'
 }
 
-function isForbiddenTag (el): boolean {
+function isForbiddenTag (el, hasShadowRoot): boolean {
   return (
-    el.tag === 'style' ||
+    (el.tag === 'style' && !hasShadowRoot) ||
     (el.tag === 'script' && (
       !el.attrsMap.type ||
       el.attrsMap.type === 'text/javascript'

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -73,10 +73,12 @@ describe('parser', () => {
   })
 
   it('allow tags on shadowRoot enabled element', () => {
+    const options = extend({}, baseOptions)
+    options.hasShadowRoot = true
     // style
     const styleAst = parse(
       '<style>notError { color: red; }</style>',
-      Object.assign({}, baseOptions, { hasShadowRoot: true })
+      options
     )
     expect(styleAst.tag).toBe('style')
     expect(styleAst.plain).toBe(true)

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -72,6 +72,19 @@ describe('parser', () => {
     expect('Templates should only be responsible for mapping the state').toHaveBeenWarned()
   })
 
+  it('allow tags on shadowRoot enabled element', () => {
+    // style
+    const styleAst = parse(
+      '<style>notError { color: red; }</style>',
+      Object.assign({}, baseOptions, { hasShadowRoot: true })
+    )
+    expect(styleAst.tag).toBe('style')
+    expect(styleAst.plain).toBe(true)
+    expect(styleAst.forbidden).toBe(undefined)
+    expect(styleAst.children[0].text).toBe('notError { color: red; }')
+    expect('Templates should only be responsible for mapping the state').not.toHaveBeenWarned()
+  })
+
   it('not contain root element', () => {
     parse('hello world', baseOptions)
     expect('Component template requires a root element, rather than just text').toHaveBeenWarned()

--- a/test/weex/helpers/index.js
+++ b/test/weex/helpers/index.js
@@ -71,8 +71,8 @@ export function compileVue (source, componentName) {
         return module.exports;
       })());
     ` + (componentName
-        ? `Vue.component('${componentName}', ${name});\n`
-        : `${name}.el = 'body';new Vue(${name});`)
+      ? `Vue.component('${componentName}', ${name});\n`
+      : `${name}.el = 'body';new Vue(${name});`)
     )
 
     let cssText = ''


### PR DESCRIPTION
The style tag checking should be ignored in the template checking if we are building a shadow root enabled custom element. In a shadow root component, style css are scoped by default.

With this fix,  vuejs/vue-web-component-wrapper#11 can be fixed in the source code by wrapping the `Vue.compile` function with this option.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: This change will help to fix the issue in the web component wrapper module.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
