### PR TITLE
fix(shared): check dates in looseEqual

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -282,6 +282,8 @@ export function looseEqual (a: any, b: any): boolean {
         return a.length === b.length && a.every((e, i) => {
           return looseEqual(e, b[i])
         })
+      } else if (a instanceof Date && b instanceof Date) {
+        return a.getTime() === b.getTime()
       } else if (!isArrayA && !isArrayB) {
         const keysA = Object.keys(a)
         const keysB = Object.keys(b)

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -588,4 +588,31 @@ describe('Directive v-model select', () => {
       }).then(done)
     })
   })
+
+  // #7928
+  it('should correctly handle option with date value', done => {
+    const vm = new Vue({
+      data: {
+        dates: [
+          new Date(1520000000000),
+          new Date(1522000000000),
+          new Date(1516000000000)
+        ],
+        selectedDate: null
+      },
+      template:
+        '<div>' +
+          '<select v-model="selectedDate">' +
+            '<option v-for="(date, i) in dates" :key="i" :value="date">' +
+              '{{date}}' +
+            '</option>' +
+          '</select>' +
+        '</div>'
+    }).$mount()
+
+    vm.selectedDate = vm.dates[2]
+    waitForUpdate(() => {
+      expect(vm.$el.firstChild.selectedIndex).toBe(2)
+    }).then(done)
+  })
 })


### PR DESCRIPTION
Fix #7928
thanks to @w3cj for the initial version. This one is using getTime instead of toUTCString because it
is much faster to compare

Initially, I wanted to keep your commit but it wasn't yours (somehow) from a git perspective, so you didn't appear in the history 🙁 , I ended up creating a single new commit

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
