### PR TITLE
refactor(compiler): Document and refactor filter parser

### DIFF
--- a/src/compiler/parser/filter-parser.js
+++ b/src/compiler/parser/filter-parser.js
@@ -57,10 +57,9 @@ export function parseFilters (exp: string): string {
       if (c === CHAR_FORWARD_SLASH) {
         // a '/' can be a division or a regex expression.
         // they can be distinguished by what is preceding.
-        let j = i - 1
         let p
         // find first non-whitespace prev char
-        for (; j >= 0; j--) {
+        for (let j = i - 1; j >= 0; j--) {
           p = exp.charAt(j)
           if (p !== ' ') break
         }

--- a/src/compiler/parser/filter-parser.js
+++ b/src/compiler/parser/filter-parser.js
@@ -1,5 +1,17 @@
 /* @flow */
 
+const CHAR_PIPE = 0x7C
+const CHAR_DOUBLE_QUOTE = 0x22
+const CHAR_SINGLE_QUOTE = 0x27
+const CHAR_BACKTICK = 0x60
+const CHAR_PARENTHESIS_OPEN = 0x28
+const CHAR_PARENTHESIS_CLOSE = 0x29
+const CHAR_BRACKET_OPEN = 0x5B
+const CHAR_BRACKET_CLOSE = 0x5D
+const CHAR_CURLY_OPEN = 0x7B
+const CHAR_CURLY_CLOSE = 0x7D
+const CHAR_FORWARD_SLASH = 0x2f
+
 const validDivisionCharRE = /[\w).+\-_$\]]/
 
 export function parseFilters (exp: string): string {
@@ -12,11 +24,11 @@ export function parseFilters (exp: string): string {
   for (i = 0; i < exp.length; i++) {
     c = exp.charCodeAt(i)
     if (
-      // a pipe that separates filters is a
-      c === 0x7C && // pipe
+      // a pipe that separates filters is a pipe
+      c === CHAR_PIPE &&
       // but not a ||:
-      exp.charCodeAt(i + 1) !== 0x7C &&
-      exp.charCodeAt(i - 1) !== 0x7C &&
+      exp.charCodeAt(i + 1) !== CHAR_PIPE &&
+      exp.charCodeAt(i - 1) !== CHAR_PIPE &&
       // and not inside any curlies, squares or parens.
       !curly && !square && !paren
     ) {
@@ -29,18 +41,20 @@ export function parseFilters (exp: string): string {
       }
     } else {
       switch (c) {
-        case 0x22: case 0x27: case 0x60:          // ", ' or `
+        case CHAR_DOUBLE_QUOTE:
+        case CHAR_SINGLE_QUOTE:
+        case CHAR_BACKTICK:
           // find string end.
           i = seek(exp, i + 1, c); break
-        case 0x28: paren++; break                 // (
-        case 0x29: paren--; break                 // )
-        case 0x5B: square++; break                // [
-        case 0x5D: square--; break                // ]
-        case 0x7B: curly++; break                 // {
-        case 0x7D: curly--; break                 // }
+        case CHAR_PARENTHESIS_OPEN: paren++; break
+        case CHAR_PARENTHESIS_CLOSE: paren--; break
+        case CHAR_BRACKET_OPEN: square++; break
+        case CHAR_BRACKET_CLOSE: square--; break
+        case CHAR_CURLY_OPEN: curly++; break
+        case CHAR_CURLY_CLOSE: curly--; break
       }
 
-      if (c === 0x2f) { // /
+      if (c === CHAR_FORWARD_SLASH) {
         // a '/' can be a division or a regex expression.
         // they can be distinguished by what is preceding.
         let j = i - 1
@@ -56,7 +70,7 @@ export function parseFilters (exp: string): string {
         // it is a regex expression.
         if (!p || !validDivisionCharRE.test(p)) {
           // find matching '/' for end.
-          i = seek(exp, i + 1, 0x2f)
+          i = seek(exp, i + 1, CHAR_FORWARD_SLASH)
         }
       }
     }

--- a/src/compiler/parser/filter-parser.js
+++ b/src/compiler/parser/filter-parser.js
@@ -11,6 +11,7 @@ const CHAR_BRACKET_CLOSE = 0x5D
 const CHAR_CURLY_OPEN = 0x7B
 const CHAR_CURLY_CLOSE = 0x7D
 const CHAR_FORWARD_SLASH = 0x2f
+const CHAR_BACK_SLASH = 0x5C
 
 const validDivisionCharRE = /[\w).+\-_$\]]/
 
@@ -104,7 +105,7 @@ function seek (string: string, start: number, forchar: number): number {
       // found position of next matching character.
       return i
     }
-    if (c === 0x5C) {
+    if (c === CHAR_BACK_SLASH) {
       // skip next character as it is escaped.
       i++
     }

--- a/test/unit/features/filter/filter.spec.js
+++ b/test/unit/features/filter/filter.spec.js
@@ -194,4 +194,8 @@ describe('Filters', () => {
   it('support template string', () => {
     expect(parseFilters('`a | ${b}c` | d')).toBe('_f("d")(`a | ${b}c`)')
   })
+
+  it('unterminated string', () => {
+    expect(parseFilters('a"msg\\')).toBe('a"msg\\')
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Adding documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Hey, I am a member of a group of students (@LarsStegman, @PhilipeLouchtch, @TimSpeelman) that has been analysing Vue for the course Software Architecture. As part of this course it was suggested to create a contribution to reduce technical debt.
During this analysis we found that the filter parser was hard to understand,
this PR is supposed to remedy this by adding additional documentation.
String (single, double, template quoted) and regex matching have been overhauled to use a special method to seek the ending quote instead, this effectively behaves the same as the code did before.

We ran a benchmark with a weird filter string, the result of which indicated there is no degradation in performance.