### PR TITLE
fix: stop render when failed setAttr

### DIFF
--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -88,27 +88,33 @@ function setAttr (el: Element, key: string, value: any) {
 }
 
 function baseSetAttr (el, key, value) {
-  if (isFalsyAttrValue(value)) {
-    el.removeAttribute(key)
-  } else {
-    // #7138: IE10 & 11 fires input event when setting placeholder on
-    // <textarea>... block the first input event and remove the blocker
-    // immediately.
-    /* istanbul ignore if */
-    if (
-      isIE && !isIE9 &&
-      el.tagName === 'TEXTAREA' &&
-      key === 'placeholder' && !el.__ieph
-    ) {
-      const blocker = e => {
-        e.stopImmediatePropagation()
-        el.removeEventListener('input', blocker)
+  try {
+    if (isFalsyAttrValue(value)) {
+      el.removeAttribute(key)
+    } else {
+      // #7138: IE10 & 11 fires input event when setting placeholder on
+      // <textarea>... block the first input event and remove the blocker
+      // immediately.
+      /* istanbul ignore if */
+      if (
+        isIE && !isIE9 &&
+        el.tagName === 'TEXTAREA' &&
+        key === 'placeholder' && !el.__ieph
+      ) {
+        const blocker = e => {
+          e.stopImmediatePropagation()
+          el.removeEventListener('input', blocker)
+        }
+        el.addEventListener('input', blocker)
+        // $flow-disable-line
+        el.__ieph = true /* IE placeholder patched */
       }
-      el.addEventListener('input', blocker)
-      // $flow-disable-line
-      el.__ieph = true /* IE placeholder patched */
+      el.setAttribute(key, value)
     }
-    el.setAttribute(key, value)
+  } catch (e) {
+    // catch DOMException
+    console.error(`[Vue warn]: ${e.message}${e.stack}`);
+    return;
   }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
* fix: stop render when failed setAttr
    * ex) when render compiled editable jade/pug texts, there are cases that have incorrect attrs.
    * change: stop render -> render & logging Vue warn