### PR TITLE
fix(core): fix dependency collection for computed properties (fix #7960)

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -244,8 +244,10 @@ function createComputedGetter (key) {
   return function computedGetter () {
     const watcher = this._computedWatchers && this._computedWatchers[key]
     if (watcher) {
+      watcher.evaluate()
       watcher.depend()
-      return watcher.evaluate()
+
+      return watcher.value
     }
   }
 }

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -252,4 +252,28 @@ describe('Options computed', () => {
       expect(updatedSpy.calls.count()).toBe(1)
     }).then(done)
   })
+
+  it('should collect dependencies correctly when using Vue.set in the getter function', done => {
+    const vm = new Vue({
+      data: {
+        value: 1,
+        someobject: {}
+      },
+      computed: {
+        a () {
+          const result = this.value + 1
+          this.$set(this.someobject, 'somekey', 'somevalue')
+          return result
+        }
+      },
+      template: `<div>{{ a }}</div>`
+    }).$mount()
+
+    expect(vm.$el.textContent).toBe('2')
+
+    vm.value = 2
+    waitForUpdate(() => {
+      expect(vm.$el.textContent).toBe('3')
+    }).then(done)
+  })
 })


### PR DESCRIPTION
This fix addresses a regression introduced in https://github.com/vuejs/vue/commit/653aac2c57d15f0e93a2c1cc7e6fad156658df19, by altering the order of `watcher.evaluate` and `watcher.depend`, thus preventing the `Vue.set`s in a computed property getter from
accidentally clearing the `deps` array of the computed watcher.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
