### PR TITLE
fix(types): make VNodeDirective properties optional, fix #8013

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -160,20 +160,9 @@ export interface WatchOptionsWithHandler<T> extends WatchOptions {
   handler: WatchHandler<T>;
 }
 
-export interface DirectiveBinding {
-  readonly name: string;
-  readonly rawName: string;
-  readonly def: DirectiveOptions;
-  readonly value: any;
-  readonly oldValue: any;
-  readonly expression: any;
-  readonly arg: string;
-  readonly modifiers: { [key: string]: boolean };
-}
-
 export type DirectiveFunction = (
   el: HTMLElement,
-  binding: DirectiveBinding,
+  binding: Readonly<VNodeDirective>,
   vnode: VNode,
   oldVnode: VNode
 ) => void;

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -160,9 +160,13 @@ export interface WatchOptionsWithHandler<T> extends WatchOptions {
   handler: WatchHandler<T>;
 }
 
+export interface DirectiveBinding extends Readonly<VNodeDirective> {
+  readonly modifiers: { [key: string]: boolean };
+}
+
 export type DirectiveFunction = (
   el: HTMLElement,
-  binding: Readonly<VNodeDirective>,
+  binding: DirectiveBinding,
   vnode: VNode,
   oldVnode: VNode
 ) => void;

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -160,9 +160,20 @@ export interface WatchOptionsWithHandler<T> extends WatchOptions {
   handler: WatchHandler<T>;
 }
 
+export interface DirectiveBinding {
+  readonly name: string;
+  readonly rawName: string;
+  readonly def: DirectiveOptions;
+  readonly value: any;
+  readonly oldValue: any;
+  readonly expression: any;
+  readonly arg: string;
+  readonly modifiers: { [key: string]: boolean };
+}
+
 export type DirectiveFunction = (
   el: HTMLElement,
-  binding: VNodeDirective,
+  binding: DirectiveBinding,
   vnode: VNode,
   oldVnode: VNode
 ) => void;

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -142,6 +142,10 @@ Vue.component('component', {
       props: {
         myProp: "bar"
       },
+      directives: [{
+        name: 'a',
+        value: 'foo'
+      }],
       domProps: {
         innerHTML: "baz"
       },

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -59,9 +59,9 @@ export interface VNodeData {
 
 export interface VNodeDirective {
   readonly name: string;
-  readonly value: any;
-  readonly oldValue: any;
-  readonly expression: any;
-  readonly arg: string;
-  readonly modifiers: { [key: string]: boolean };
+  readonly value?: any;
+  readonly oldValue?: any;
+  readonly expression?: any;
+  readonly arg?: string;
+  readonly modifiers?: { [key: string]: boolean };
 }

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -58,10 +58,10 @@ export interface VNodeData {
 }
 
 export interface VNodeDirective {
-  readonly name: string;
-  readonly value?: any;
-  readonly oldValue?: any;
-  readonly expression?: any;
-  readonly arg?: string;
-  readonly modifiers?: { [key: string]: boolean };
+  name: string;
+  value?: any;
+  oldValue?: any;
+  expression?: any;
+  arg?: string;
+  modifiers?: { [key: string]: boolean };
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix - fixes #8013
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Prevents `Property 'oldValue' is missing in type '{ name: string; value: string; }'.` when using directives in a render function (see test). 

There should probably actually be three different `VNodeDirective`s:
 - In `h('', data)` - mostly optional, not readonly
 - In `VNodeData` (returned from createElement) - normalised, not readonly
 - In `DirectiveFunction` - the current definition (before this change)