### PR TITLE
fix(slots): preserve reactivity inside of $slots, fix #7856

### DIFF
--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -21,7 +21,7 @@ export function initRender (vm: Component) {
   const options = vm.$options
   const parentVnode = vm.$vnode = options._parentVnode // the placeholder node in parent tree
   const renderContext = parentVnode && parentVnode.context
-  vm.$slots = resolveSlots(options._renderChildren, renderContext)
+  defineReactive(vm, '$slots', resolveSlots(options._renderChildren, renderContext), null, true)
   vm.$scopedSlots = emptyObject
   // bind the createElement fn to this instance
   // so that we get proper render context inside it.

--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -886,4 +886,34 @@ describe('Component slot', () => {
       expect(vm.$el.textContent).toBe('foo')
     }).then(done)
   })
+
+  it('should preserve reactivity', (done) => {
+    const vm = new Vue({
+      template: `<foo ref="foo">{{ value }}</foo>`,
+      data: {
+        value: 1
+      },
+      components: {
+        foo: {
+          template: `<div>content moved</div>`
+        }
+      }
+    })
+
+    const portal = new Vue({
+      parent: vm,
+      render (h) {
+        return h('span', vm.$refs.foo.$slots.default)
+      }
+    })
+
+    vm.$mount()
+    portal.$mount()
+
+    expect(portal.$el.innerHTML).toBe('1')
+    vm.value = 2
+    waitForUpdate(() => {
+      expect(portal.$el.innerHTML).toBe('2')
+    }).then(done)
+  })
 })


### PR DESCRIPTION
Previously $slots was not reactive which caused use cases such as
portal-vue to not update when the contents of the slots updated. This
was because there were no reactive properties accessed when using $slots
and renders were only being triggered by calls to $forceUpdate when slot
contents changed.

This change makes $slots reactive, so updates are detected appropriately
regardless of where the slot is used.

fixes #7856

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

**Other information:**

Related to https://github.com/LinusBorg/portal-vue/issues/105
