### PR TITLE
fix(ssr): fix double escaping of staticClass values (fix #7859)

### DIFF
--- a/src/server/optimizing-compiler/modules.js
+++ b/src/server/optimizing-compiler/modules.js
@@ -92,7 +92,7 @@ export function genClassSegments (
   classBinding: ?string
 ): Array<StringSegment> {
   if (staticClass && !classBinding) {
-    return [{ type: RAW, value: ` class=${staticClass}` }]
+    return [{ type: RAW, value: ` class="${JSON.parse(staticClass)}"` }]
   } else {
     return [{
       type: EXPRESSION,

--- a/test/ssr/ssr-string.spec.js
+++ b/test/ssr/ssr-string.spec.js
@@ -1211,6 +1211,20 @@ describe('SSR: renderToString', () => {
     })
   })
 
+  // #7859
+  it('should not double escape class values', done => {
+    renderVmWithOptions({
+      template: `
+      <div>
+        <div class="a\nb"></div>
+      </div>
+      `
+    }, result => {
+      expect(result).toContain(`<div class="a\nb"></div>`)
+      done()
+    })
+  })
+
   it('should expose ssr helpers on functional context', done => {
     let called = false
     renderVmWithOptions({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This fixes a double escaping of literal class values in the SSR optimizing compiler by unescaping the value in `genClassSegments`.

This bugfix is very similar to https://github.com/vuejs/vue/pull/7224. Literal class values get escaped twice during [`transformNode`](https://github.com/vuejs/vue/blob/79c0d7bcfbcd1ac492e7ceb77f5024d09efdc6b3/src/platforms/web/compiler/modules/class.js#L25) and [`flattenSegments`](https://github.com/vuejs/vue/blob/79c0d7bcfbcd1ac492e7ceb77f5024d09efdc6b3/src/server/optimizing-compiler/codegen.js#L240), causing the double escape.

fix #7859 


<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
