### PR TITLE
feat(warn): Warn component names hyphenated into reserved names, fix #8025

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -4,6 +4,7 @@ import config from '../config'
 import { warn } from './debug'
 import { nativeWatch } from './env'
 import { set } from '../observer/index'
+import { hyphenate } from '../../shared/util'
 
 import {
   ASSET_TYPES,
@@ -260,7 +261,8 @@ export function validateComponentName (name: string) {
       'and must start with a letter.'
     )
   }
-  if (isBuiltInTag(name) || config.isReservedTag(name)) {
+  const hyphenatedName = hyphenate(name)
+  if (isBuiltInTag(hyphenatedName) || config.isReservedTag(hyphenatedName)) {
     warn(
       'Do not use built-in or reserved HTML elements as component ' +
       'id: ' + name

--- a/test/unit/features/options/components.spec.js
+++ b/test/unit/features/options/components.spec.js
@@ -69,6 +69,15 @@ describe('Options components', () => {
     expect('Do not use built-in or reserved HTML elements as component').toHaveBeenWarned()
   })
 
+  it('should warn component names translated into native HTML elements', () => {
+    new Vue({
+      components: {
+        Div: { template: '<div></div>' }
+      }
+    })
+    expect('Do not use built-in or reserved HTML elements as component').toHaveBeenWarned()
+  })
+
   it('should warn built-in elements', () => {
     new Vue({
       components: {


### PR DESCRIPTION
Currently, component names like 'Map' is silently ignored, because they translated into reserved names but the component names are not exactly the same as the reserved names. The component names, thus, should be hyphenated before checking if reserved.

Resolve #8025.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The reason of using `hyphenate` instead of `.toLowerCase()` is that we should allow a name like `MaP`, as it is shown as `ma-p` in template and thus should be allowed.