### PR TITLE
[types] lifecycle hooks run in context of instance

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -74,15 +74,15 @@ export interface ComponentOptions<
   staticRenderFns?: ((createElement: CreateElement) => VNode)[];
 
   beforeCreate?(this: V): void;
-  created?(): void;
-  beforeDestroy?(): void;
-  destroyed?(): void;
-  beforeMount?(): void;
-  mounted?(): void;
-  beforeUpdate?(): void;
-  updated?(): void;
-  activated?(): void;
-  deactivated?(): void;
+  created?(this: V): void;
+  beforeDestroy?(this: V): void;
+  destroyed?(this: V): void;
+  beforeMount?(this: V): void;
+  mounted?(this: V): void;
+  beforeUpdate?(this: V): void;
+  updated?(this: V): void;
+  activated?(this: V): void;
+  deactivated?(this: V): void;
   errorCaptured?(err: Error, vm: Vue, info: string): boolean | void;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -171,6 +171,9 @@ Vue.extend({
   methods: {
     foo() {}
   },
+  beforeCreate() {
+    this.foo()
+  },
   mounted () {
     this.foo()
   },

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -86,7 +86,7 @@ export interface VueConstructor<V extends Vue = Vue> {
   extend<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
   extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
   extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
-  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, { [key: string]: (this: V, ...args: any[]) => any }, {}, {}>;
 
   nextTick(callback: () => void, context?: any[]): void;
   nextTick(): Promise<void>

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -86,7 +86,7 @@ export interface VueConstructor<V extends Vue = Vue> {
   extend<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
   extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
   extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
-  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, { [key: string]: (this: V, ...args: any[]) => any }, {}, {}>;
+  extend(options?: ComponentOptions<V, Data = object, Methods = object>): ExtendedVue<V, Data, Methods, {}, {}>;
 
   nextTick(callback: () => void, context?: any[]): void;
   nextTick(): Promise<void>

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -86,7 +86,7 @@ export interface VueConstructor<V extends Vue = Vue> {
   extend<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
   extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
   extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
-  extend(options?: ComponentOptions<V, Data = object, Methods = object>): ExtendedVue<V, Data, Methods, {}, {}>;
+  extend(options?: ComponentOptions<V, Data, Methods>): ExtendedVue<V, Data, Methods, {}, {}>;
 
   nextTick(callback: () => void, context?: any[]): void;
   nextTick(): Promise<void>


### PR DESCRIPTION
beforeCreate was correct. all others did not have `this` properly defined

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
