### PR TITLE
chore(package.json): Add sideEffects: false field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dist/*.js",
     "types/*.d.ts"
   ],
+  "sideEffects": false,
   "scripts": {
     "dev": "rollup -w -c scripts/config.js --environment TARGET:web-full-dev",
     "dev:cjs": "rollup -w -c scripts/config.js --environment TARGET:web-runtime-cjs",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: `package.json` field addition

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

This PR adds the `"sideEffects": false` property in vue's `package.json` file. This allow's webpack (for those who want to opt-in to requiring vue's original source files (instead of the flattened esm bundles) and want to remove flow type through a babel-transform, then this will allow webpack to aggressively ignore and treeshake unused exports throughout the module system. 

In many cases this can yield hidden and surprising build time improvements and size reductions in the case that modules flattened from rollup aren't actually needed when webpack performs a scope analysis. 

The angular team has adopted this approach for the CLI yielding some strong build time speed for webpack (since unused exports are also not resolved, parsed, etc.). From my assessment of the module graph created, it looks that there are no sideEffects created against existing re-exports throughout the codebase, therefore even if a user did opt in on their own will, and remove flow types, there should be no danger of removing code that is needed and causing breakages. 

Overall, this already will not be a breaking change in any way but just provides extra benefits to those (and for the cli (if realized) when using webpack 4 and `mode: production`).

Happy to answer any other questions.
~Sean + [webpack team](https://github.com/webpack) 

**Other information:**
