### PR TITLE
fix(SSR): Properly handle newlines and whitespace in SSR classnames (fix #7859)

### DIFF
--- a/src/platforms/web/compiler/modules/class.js
+++ b/src/platforms/web/compiler/modules/class.js
@@ -22,7 +22,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
     }
   }
   if (staticClass) {
-    el.staticClass = JSON.stringify(staticClass.replace(/\n/g, ' ').replace(/ +/g, ' '))
+    el.staticClass = JSON.stringify(staticClass.replace(/\s+/g, ' '))
   }
   const classBinding = getBindingAttr(el, 'class', false /* getStatic */)
   if (classBinding) {

--- a/src/platforms/web/compiler/modules/class.js
+++ b/src/platforms/web/compiler/modules/class.js
@@ -22,7 +22,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
     }
   }
   if (staticClass) {
-    el.staticClass = JSON.stringify(staticClass)
+    el.staticClass = JSON.stringify(staticClass.replace(/\n/g, ' ').replace(/ +/g, ' '))
   }
   const classBinding = getBindingAttr(el, 'class', false /* getStatic */)
   if (classBinding) {

--- a/test/ssr/ssr-string.spec.js
+++ b/test/ssr/ssr-string.spec.js
@@ -1228,7 +1228,7 @@ describe('SSR: renderToString', () => {
   })
 
   // #7859
-  it('should trim excess whigtespace in class attributes', done => {
+  it('should trim excess whitespace in class attributes', done => {
     renderVmWithOptions({
       template: `
       <div>

--- a/test/ssr/ssr-string.spec.js
+++ b/test/ssr/ssr-string.spec.js
@@ -1211,6 +1211,37 @@ describe('SSR: renderToString', () => {
     })
   })
 
+  // #7859
+  it('should remove and trim newlines in class attributes', done => {
+    renderVmWithOptions({
+      template: `
+      <div>
+        <div class="a b
+                    c d">
+        </div>
+      </div>
+      `
+    }, result => {
+      expect(result).toContain(`<div class="a b c d"></div>`)
+      done()
+    })
+  })
+
+  // #7859
+  it('should trim excess whigtespace in class attributes', done => {
+    renderVmWithOptions({
+      template: `
+      <div>
+        <div class="a    b c      d">
+        </div>
+      </div>
+      `
+    }, result => {
+      expect(result).toContain(`<div class="a b c d"></div>`)
+      done()
+    })
+  })
+
   it('should expose ssr helpers on functional context', done => {
     let called = false
     renderVmWithOptions({


### PR DESCRIPTION
When encountering newlines in SSR classnames, do not render "\n" and
instead replace the new line with a space.

Once newlines are removed, indentation from subsequent lines can leave
classnames abnormally spaced out, so replace multiple spaces with a
single space

fix #7859

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
