### PR TITLE
fix: In development mode, warns if user tries to Vue.set a property t…

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -196,10 +196,15 @@ export function defineReactive (
  * already exist.
  */
 export function set (target: Array<any> | Object, key: any, val: any): any {
-  if (process.env.NODE_ENV !== 'production' &&
-    (isUndef(target) || isPrimitive(target))
-  ) {
-    warn(`Cannot set reactive property on undefined, null, or primitive value: ${(target: any)}`)
+  if (process.env.NODE_ENV !== 'production') {
+    if (isUndef(target) || isPrimitive(target)) {
+      warn(`Cannot set reactive property on undefined, null, or primitive value: ${(target: any)}`)
+    }
+    if (Object.getOwnPropertyDescriptor(target, key) &&
+      (typeof (Object.getOwnPropertyDescriptor(target, key).get) === 'undefined') &&
+      !Array.isArray(target)) {
+      warn(`Cannot enable reactivity on a property that is already defined: ${(key: any)}`)
+    }
   }
   if (Array.isArray(target) && isValidArrayIndex(key)) {
     target.length = Math.max(target.length, key)


### PR DESCRIPTION
…hat already exists.

In development mode, warns if user tries to Vue.set a property that already exists. Issue reported
in #8129. Codepen demonstrating the issue available at
https://codepen.io/chrisvfritz/pen/rvzgBR?editors=1010

fix #8129

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
