### PR TITLE
refactor: wraps schedulers three flush state var into a object

### DIFF
--- a/src/core/observer/scheduler.js
+++ b/src/core/observer/scheduler.js
@@ -16,27 +16,29 @@ const queue: Array<Watcher> = []
 const activatedChildren: Array<Component> = []
 let has: { [key: number]: ?true } = {}
 let circular: { [key: number]: number } = {}
-let waiting = false
-let flushing = false
-let index = 0
+const flushState = {
+  waiting: false,
+  flushing: false,
+  index: 0
+}
 
 /**
  * Reset the scheduler's state.
  */
 function resetSchedulerState () {
-  index = queue.length = activatedChildren.length = 0
+  flushState.index = queue.length = activatedChildren.length = 0
   has = {}
   if (process.env.NODE_ENV !== 'production') {
     circular = {}
   }
-  waiting = flushing = false
+  flushState.waiting = flushState.flushing = false
 }
 
 /**
  * Flush both queues and run the watchers.
  */
 function flushSchedulerQueue () {
-  flushing = true
+  flushState.flushing = true
   let watcher, id
 
   // Sort queue before flush.
@@ -51,8 +53,8 @@ function flushSchedulerQueue () {
 
   // do not cache length because more watchers might be pushed
   // as we run existing watchers
-  for (index = 0; index < queue.length; index++) {
-    watcher = queue[index]
+  for (flushState.index = 0; flushState.index < queue.length; flushState.index++) {
+    watcher = queue[flushState.index]
     if (watcher.before) {
       watcher.before()
     }
@@ -131,20 +133,20 @@ export function queueWatcher (watcher: Watcher) {
   const id = watcher.id
   if (has[id] == null) {
     has[id] = true
-    if (!flushing) {
+    if (!flushState.flushing) {
       queue.push(watcher)
     } else {
       // if already flushing, splice the watcher based on its id
       // if already past its id, it will be run next immediately.
       let i = queue.length - 1
-      while (i > index && queue[i].id > watcher.id) {
+      while (i > flushState.index && queue[i].id > watcher.id) {
         i--
       }
       queue.splice(i + 1, 0, watcher)
     }
     // queue the flush
-    if (!waiting) {
-      waiting = true
+    if (!flushState.waiting) {
+      flushState.waiting = true
       nextTick(flushSchedulerQueue)
     }
   }


### PR DESCRIPTION
Those three separate variables make me feel as if they are local variables when I read the source code.
So I think it's better to wrap those variable in a object.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
