### PR TITLE
perf(Dep.js): Dep now uses an object to handle subscriptions

### DIFF
--- a/src/core/observer/dep.js
+++ b/src/core/observer/dep.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import type Watcher from './watcher'
-import { remove } from '../util/index'
 
 let uid = 0
 
@@ -12,19 +11,19 @@ let uid = 0
 export default class Dep {
   static target: ?Watcher;
   id: number;
-  subs: Array<Watcher>;
+  subs: {[key: string | number]: Watcher};
 
   constructor () {
     this.id = uid++
-    this.subs = []
+    this.subs = {}
   }
 
   addSub (sub: Watcher) {
-    this.subs.push(sub)
+    this.subs[sub.id] = sub
   }
 
   removeSub (sub: Watcher) {
-    remove(this.subs, sub)
+    delete this.subs[sub.id]
   }
 
   depend () {
@@ -34,8 +33,7 @@ export default class Dep {
   }
 
   notify () {
-    // stabilize the subscriber list first
-    const subs = this.subs.slice()
+    const subs = Object.keys(this.subs).map(key => this.subs[key])
     for (let i = 0, l = subs.length; i < l; i++) {
       subs[i].update()
     }

--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -171,7 +171,7 @@ export default class Watcher {
       // It initializes as lazy by default, and only becomes activated when
       // it is depended on by at least one subscriber, which is typically
       // another computed property or a component's render function.
-      if (this.dep.subs.length === 0) {
+      if (Object.keys(this.dep.subs).length === 0) {
         // In lazy mode, we don't want to perform computations until necessary,
         // so we simply mark the watcher as dirty. The actual computation is
         // performed just-in-time in this.evaluate() when the computed property

--- a/test/unit/modules/observer/dep.spec.js
+++ b/test/unit/modules/observer/dep.spec.js
@@ -9,24 +9,24 @@ describe('Dep', () => {
 
   describe('instance', () => {
     it('should be created with correct properties', () => {
-      expect(dep.subs.length).toBe(0)
+      expect(Object.keys(dep.subs).length).toBe(0)
       expect(new Dep().id).toBe(dep.id + 1)
     })
   })
 
   describe('addSub()', () => {
     it('should add sub', () => {
-      dep.addSub(null)
-      expect(dep.subs.length).toBe(1)
-      expect(dep.subs[0]).toBe(null)
+      dep.addSub({ id: 123 })
+      console.log(dep)
+      expect(dep.subs).toEqual({ 123: { id: 123 }})
     })
   })
 
   describe('removeSub()', () => {
     it('should remove sub', () => {
-      dep.subs.push(null)
-      dep.removeSub(null)
-      expect(dep.subs.length).toBe(0)
+      dep[123] = { id: 123 }
+      dep.removeSub({ id: 123 })
+      expect(Object.keys(dep.subs).length).toBe(0)
     })
   })
 
@@ -55,9 +55,9 @@ describe('Dep', () => {
 
   describe('notify()', () => {
     it('should notify subs', () => {
-      dep.subs.push(jasmine.createSpyObj('SUB', ['update']))
+      dep.subs[123] = { id: 123, update: jasmine.createSpy('update') }
       dep.notify()
-      expect(dep.subs[0].update).toHaveBeenCalled()
+      expect(dep.subs[123].update).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Performance increase

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Tearing down a big set of Vue elements (table rows) with lot of reactive dependencies, was very slow due to array [traversing](https://forum.vuejs.org/t/destroying-a-component-with-many-children/23533). Using an object sped up the whole process. Page 170 rows from 8s to 1sec and 800rows with less reactive data from 6sec to 2.5~sec. This could be observed best while navigating between routes.