### PR TITLE
fix #8093: Use custom toString method when interpolating objects if implemented

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -77,7 +77,7 @@ export function isValidArrayIndex (val: any): boolean {
 export function toString (val: any): string {
   return val == null
     ? ''
-    : isPlainObject(val) && val.toString === _toString
+    : Array.isArray(val) || (isPlainObject(val) && val.toString === _toString)
       ? JSON.stringify(val, null, 2)
       : String(val)
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -77,7 +77,7 @@ export function isValidArrayIndex (val: any): boolean {
 export function toString (val: any): string {
   return val == null
     ? ''
-    : typeof val === 'object'
+    : typeof val === 'object' && (!isPlainObject(val) || val.toString() === _toString.call(val))
       ? JSON.stringify(val, null, 2)
       : String(val)
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -77,7 +77,7 @@ export function isValidArrayIndex (val: any): boolean {
 export function toString (val: any): string {
   return val == null
     ? ''
-    : typeof val === 'object' && (!isPlainObject(val) || val.toString === _toString)
+    : isPlainObject(val) && val.toString === _toString
       ? JSON.stringify(val, null, 2)
       : String(val)
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -77,7 +77,7 @@ export function isValidArrayIndex (val: any): boolean {
 export function toString (val: any): string {
   return val == null
     ? ''
-    : typeof val === 'object' && (!isPlainObject(val) || val.toString() === _toString.call(val))
+    : typeof val === 'object' && (!isPlainObject(val) || val.toString === _toString)
       ? JSON.stringify(val, null, 2)
       : String(val)
 }

--- a/test/unit/features/directives/html.spec.js
+++ b/test/unit/features/directives/html.spec.js
@@ -44,6 +44,12 @@ describe('Directive v-html', () => {
       vm.a = {}
     }).then(() => {
       expect(vm.$el.innerHTML).toBe('{}')
+      vm.a = { toString () { return 'foo' } }
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('foo')
+      vm.a = { toJSON () { return { foo: 'bar' } } }
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('{\n  "foo": "bar"\n}')
       vm.a = 123
     }).then(() => {
       expect(vm.$el.innerHTML).toBe('123')

--- a/test/unit/features/directives/text.spec.js
+++ b/test/unit/features/directives/text.spec.js
@@ -30,6 +30,12 @@ describe('Directive v-text', () => {
       vm.a = {}
     }).then(() => {
       expect(vm.$el.innerHTML).toBe('{}')
+      vm.a = { toString () { return 'foo' } }
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('foo')
+      vm.a = { toJSON () { return { foo: 'bar' } } }
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('{\n  "foo": "bar"\n}')
       vm.a = 123
     }).then(() => {
       expect(vm.$el.innerHTML).toBe('123')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Description:**

Hi, 
When interpolating an object, it uses the JSON.stringify method instead of toString, which is normally the proper method to set a way to convert an object to a string. 
This PR allow you to use your custom `toString` method to render your object if it exists. It's tested (I've also added a test for toJson), and it should not be a breaking change.

Thanks you for your amazing work folks, and see you in Paris next month!