### PR TITLE
fix(#7913): Prevent erroneous warning when using <slot> inside slot-scope

### DIFF
--- a/src/core/instance/render-helpers/render-slot.js
+++ b/src/core/instance/render-helpers/render-slot.js
@@ -9,7 +9,8 @@ export function renderSlot (
   name: string,
   fallback: ?Array<VNode>,
   props: ?Object,
-  bindObject: ?Object
+  bindObject: ?Object,
+  inSlotScope: ?boolean
 ): ?Array<VNode> {
   const scopedSlotFn = this.$scopedSlots[name]
   let nodes
@@ -29,7 +30,7 @@ export function renderSlot (
     const slotNodes = this.$slots[name]
     // warn duplicate slot usage
     if (slotNodes) {
-      if (process.env.NODE_ENV !== 'production' && slotNodes._rendered) {
+      if (process.env.NODE_ENV !== 'production' && !inSlotScope && slotNodes._rendered) {
         warn(
           `Duplicate presence of slot "${name}" found in the same render tree ` +
           `- this will likely cause render errors.`,

--- a/test/unit/modules/compiler/codegen.spec.js
+++ b/test/unit/modules/compiler/codegen.spec.js
@@ -161,21 +161,21 @@ describe('codegen', () => {
   it('generate single slot', () => {
     assertCodegen(
       '<div><slot></slot></div>',
-      `with(this){return _c('div',[_t("default")],2)}`
+      `with(this){return _c('div',[_t("default",null,null,null,false)],2)}`
     )
   })
 
   it('generate named slot', () => {
     assertCodegen(
       '<div><slot name="one"></slot></div>',
-      `with(this){return _c('div',[_t("one")],2)}`
+      `with(this){return _c('div',[_t("one",null,null,null,false)],2)}`
     )
   })
 
   it('generate slot fallback content', () => {
     assertCodegen(
       '<div><slot><div>hi</div></slot></div>',
-      `with(this){return _c('div',[_t("default",[_c('div',[_v("hi")])])],2)}`
+      `with(this){return _c('div',[_t("default",[_c('div',[_v("hi")])],null,null,false)],2)}`
     )
   })
 


### PR DESCRIPTION
Because slotNodes inside a slot-scope context are already set to \_rendered = true after initial
render, the warning for duplicate slot presence always fires when a slot-scope prop change triggers
a re-render. With this change, the compiler tracks whether any slot-scoped elements have been
encountered yet at the point the slot is compiled. If so, the direct ancestors of the slot are checked
for slot-scope presence, and if one is found, the warning is supressed.

This is admittedly not a perfect solution, as within a slot-scope context the warning now does not fire even when there _are_ duplicate slots, but I couldn't find a good way to get around that.

fix #7913

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
