### PR TITLE
fix(renderer): allow overwrite server renderer defaults

### DIFF
--- a/src/platforms/web/entry-server-renderer.js
+++ b/src/platforms/web/entry-server-renderer.js
@@ -14,14 +14,15 @@ export function createRenderer (options?: Object = {}): {
   renderToString: Function,
   renderToStream: Function
 } {
-  return _createRenderer(extend(extend({}, options), {
+  const defaults = {
     isUnaryTag,
     canBeLeftOpenTag,
     modules,
     // user can provide server-side implementations for custom directives
     // when creating the renderer.
     directives: extend(baseDirectives, options.directives)
-  }))
+  }
+  return _createRenderer(extend(extend({}, defaults), options))
 }
 
 export const createBundleRenderer = createBundleRendererCreator(createRenderer)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

This change allows to overwrite the defaults (e.g. `isUnaryTag`) for the `vue-server-renderer`. Which should allow to build some more advanced features (e.g. allow to render RSS). Also, it changes the initialization of the SSR `renderFunction` as it passes along the `isUnaryTag` to the creation of the `compileFunctions`.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**