### PR TITLE
Need judge styles[transitionProp 'Duration'] is undefined (fix #7444)

### DIFF
--- a/src/platforms/web/runtime/transition-util.js
+++ b/src/platforms/web/runtime/transition-util.js
@@ -122,11 +122,11 @@ export function getTransitionInfo (el: Element, expectedType?: ?string): {
   hasTransform: boolean;
 } {
   const styles: any = window.getComputedStyle(el)
-  const transitionDelays: Array<string> = styles[transitionProp + 'Delay'].split(', ')
-  const transitionDurations: Array<string> = styles[transitionProp + 'Duration'].split(', ')
+  const transitionDelays: Array<string> = (styles[transitionProp + 'Delay'] || '').split(', ')
+  const transitionDurations: Array<string> = (styles[transitionProp + 'Duration'] || '').split(', ')
   const transitionTimeout: number = getTimeout(transitionDelays, transitionDurations)
-  const animationDelays: Array<string> = styles[animationProp + 'Delay'].split(', ')
-  const animationDurations: Array<string> = styles[animationProp + 'Duration'].split(', ')
+  const animationDelays: Array<string> = (styles[animationProp + 'Delay'] || '').split(', ')
+  const animationDurations: Array<string> = (styles[animationProp + 'Duration'] || '').split(', ')
   const animationTimeout: number = getTimeout(animationDelays, animationDurations)
 
   let type: ?string

--- a/src/platforms/web/runtime/transition-util.js
+++ b/src/platforms/web/runtime/transition-util.js
@@ -122,6 +122,7 @@ export function getTransitionInfo (el: Element, expectedType?: ?string): {
   hasTransform: boolean;
 } {
   const styles: any = window.getComputedStyle(el)
+  // JSDOM may return undefined for transition properties
   const transitionDelays: Array<string> = (styles[transitionProp + 'Delay'] || '').split(', ')
   const transitionDurations: Array<string> = (styles[transitionProp + 'Duration'] || '').split(', ')
   const transitionTimeout: number = getTimeout(transitionDelays, transitionDurations)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

`jsdom` returns `undefined` from `style` instead of empty string.

```
$ node
> const jsdom = require("jsdom");
undefined
> const { JSDOM } = jsdom;
undefined
> const dom = new JSDOM(`<!DOCTYPE html><p style="color: red;">Hello world</p>`);
undefined
> dom.window.document.querySelector("p").style
CSSStyleDeclaration {
  '0': 'color',
  _values: { color: 'red' },
  _importants: { color: '' },
  _length: 1,
  _onChange: [Function] }
> dom.window.document.querySelector("p").style.color
'red'
> dom.window.document.querySelector("p").style.unexisted
undefined
>
```

So a solution is to do like that:

```
(styles[transitionProp + 'Delay'] || '').split(', ')
```