### PR TITLE
Add hint to developer when registering a component that is not defined

### DIFF
--- a/src/server/render.js
+++ b/src/server/render.js
@@ -40,7 +40,7 @@ const normalizeRender = vm => {
       vm.$options.staticRenderFns = compiled.staticRenderFns
     } else {
       throw new Error(
-        `render function or template not defined in component: ${
+        `render function or template not defined in component (is it possible you registered a component mistakenly?): ${
           vm.$options.name || vm.$options._componentTag || 'anonymous'
         }`
       )


### PR DESCRIPTION
To indicate to new developers that they might've included a component
(e.g., with local registration) but failed to import or define them
enhance the error string.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Troubleshooting enhancement.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
