### PR TITLE
feat(option): add optionNormalizeStrategies

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -11,6 +11,7 @@ import { LIFECYCLE_HOOKS } from 'shared/constants'
 export type Config = {
   // user
   optionMergeStrategies: { [key: string]: Function };
+  optionNormalizeStrategies: { [key: string]: Function };
   silent: boolean;
   productionTip: boolean;
   performance: boolean;
@@ -38,6 +39,12 @@ export default ({
    */
   // $flow-disable-line
   optionMergeStrategies: Object.create(null),
+
+  /**
+   * Option normalize strategies (used in core/util/options)
+   */
+  // $flow-disable-line
+  optionNormalizeStrategies: Object.create(null),
 
   /**
    * Whether to suppress warnings.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

when I write my vue plugin,I use custom properties in the options.But when I want to support different kind of option,for example ,both array and object,just like the props option, I found  I have to write the normalize code in the mergeStrategy code, expecially considering of mixin condition.It seems wired and not good for reuse other merge strategy .What I do is to support extract the normalize code from merge code.

**Other information:**
