### PR TITLE
feat(core): Added another test to ensure default slot contents are pr…

### DIFF
--- a/test/unit/features/component/component-scoped-slot.spec.js
+++ b/test/unit/features/component/component-scoped-slot.spec.js
@@ -625,4 +625,75 @@ describe('Component scoped slot', () => {
 
     expect(vm.$el.querySelector('.bar').textContent.trim()).toBe('hi!')
   })
+
+  it('passing down merged scoped slots with v-bind', () => {
+    const Bar = {
+      template: `
+        <div class="bar">
+          <slot name="one" msg="1" />
+          <slot name="two" msg="2" />
+        </div>
+      `
+    }
+
+    const Ney = {
+      template: `
+        <div class="ney">
+          <slot name="three" msg="3">
+            3?
+          </slot>
+        </div>
+      `
+    }
+
+    const Foo = {
+      components: { Bar, Ney },
+      template: `
+        <div class="foo">
+          <bar v-bind="{ scopedSlots: $scopedSlots }"></bar>
+          <ney v-bind="{ scopedSlots: $scopedSlots }"></ney>
+        </div>
+      `
+    }
+
+    const vm1 = new Vue({
+      components: { Foo },
+      template: `
+        <foo>
+          <template slot="one" slot-scope="props">
+            {{ props.msg + '!' }}
+          </template>
+          <template slot="two" slot-scope="props">
+            {{ props.msg + '!!' }}
+          </template>
+        </foo>
+      `
+    }).$mount()
+
+    expect(vm1.$el.textContent.trim().replace(/\s+/g, '')).toBe('1!2!!3?')
+
+    const vm2 = new Vue({
+      components: { Foo },
+      methods: {
+        tickle (me) {
+          return me + ' tickled!'
+        }
+      },
+      template: `
+        <foo>
+          <template slot="one" slot-scope="props">
+            {{ props.msg + '!' }}
+          </template>
+          <template slot="two" slot-scope="props">
+            {{ props.msg + '!!' }}
+          </template>
+          <template slot="three" slot-scope="props">
+            {{ tickle( props.msg )}}
+          </template>
+        </foo>
+      `
+    }).$mount()
+
+    expect(vm2.$el.textContent.trim().replace(/\s+/g, '')).toBe('1!2!!3tickled!')
+  })
 })


### PR DESCRIPTION
…eserved as well as slots passed to children.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Added another test for the feature

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
