### PR TITLE
refactor(state.js): Warning of defining a data that starts with _ or $

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -143,7 +143,13 @@ function initData (vm: Component) {
         `Use prop default value instead.`,
         vm
       )
-    } else if (!isReserved(key)) {
+    }
+    if (isReserved(key)) {
+      process.env.NODE_ENV !== 'production' && warn(
+        `Avoid defining the data property "${key}" that starts with _ or $ . `,
+        vm
+      )
+    } else {
       proxy(vm, `_data`, key)
     }
   }


### PR DESCRIPTION
When we defining a data that starts with _ or $ in data() and use this._xxx in created() or
mounted(), it returns 'undefined' instead of the value we have defined.But there is no any tips for
this phenomenon.

BREAKING CHANGE: When this occur,console will show vue warning.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
Console will show a vue warning of defining a data in data() that starts with _ or $.But I don't know the migration path, sorry.
**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
