### PR TITLE
Provide amd id for umd build

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -71,6 +71,9 @@ const builds = {
     entry: resolve('web/entry-runtime.js'),
     dest: resolve('dist/vue.runtime.js'),
     format: 'umd',
+    amd: {
+      id: 'vue',
+    },
     env: 'development',
     banner
   },
@@ -79,6 +82,9 @@ const builds = {
     entry: resolve('web/entry-runtime.js'),
     dest: resolve('dist/vue.runtime.min.js'),
     format: 'umd',
+    amd: {
+      id: 'vue',
+    },
     env: 'production',
     banner
   },
@@ -87,6 +93,9 @@ const builds = {
     entry: resolve('web/entry-runtime-with-compiler.js'),
     dest: resolve('dist/vue.js'),
     format: 'umd',
+    amd: {
+      id: 'vue',
+    },
     env: 'development',
     alias: { he: './entity-decoder' },
     banner
@@ -96,6 +105,9 @@ const builds = {
     entry: resolve('web/entry-runtime-with-compiler.js'),
     dest: resolve('dist/vue.min.js'),
     format: 'umd',
+    amd: {
+      id: 'vue',
+    },
     env: 'production',
     alias: { he: './entity-decoder' },
     banner
@@ -189,6 +201,10 @@ function genConfig (name) {
       banner: opts.banner,
       name: opts.moduleName || 'Vue'
     }
+  }
+  
+  if (opts.amd) {
+    config.amd = opts.amd 
   }
 
   if (opts.env) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
We are running a dev-setup where all our code is converted to amd module and then concatenated to one file. This is the approach that [Bazel](https://bazel.build/) takes for js dev. For more details see: https://github.com/alexeagle/angular-bazel-example/wiki/Running-a-devserver-under-Bazel When depending on the vue build the problem is it does not have an id so when the umd file is being loaded requirejs complains about an anonymous module. Just by providing the id this is fixed and we can depend on vue from our application.