### PR TITLE
The first parameter in plugin.install.apply can also be defined as: null or undefined

### DIFF
--- a/src/core/global-api/use.js
+++ b/src/core/global-api/use.js
@@ -13,7 +13,8 @@ export function initUse (Vue: GlobalAPI) {
     const args = toArray(arguments, 1)
     args.unshift(this)
     if (typeof plugin.install === 'function') {
-      plugin.install.apply(plugin, args)
+      // plugin null undefined
+      plugin.install.apply(undefined, args)
     } else if (typeof plugin === 'function') {
       plugin.apply(null, args)
     }


### PR DESCRIPTION
Whether the first parameter in plugin.install.apply can be null or undefined. In fact, at the same time when the plugin is installed, the plugin can get the context of the current plugin. It is not necessary to pass the context via install.apply.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
