### PR TITLE
types: add AsyncComponentFactory type

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -21,6 +21,14 @@ export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never
   reject: (reason?: any) => void
 ) => Promise<Component | EsModuleComponent> | void;
 
+export type AsyncComponentFactory<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = () => {
+  component: AsyncComponent<Data, Methods, Computed, Props>;
+  loading?: Component | EsModuleComponent;
+  error?: Component | EsModuleComponent;
+  delay?: number;
+  timeout?: number;
+}
+
 /**
  * When the `Computed` type parameter on `ComponentOptions` is inferred,
  * it should have a property with the return type of every get-accessor.
@@ -86,7 +94,7 @@ export interface ComponentOptions<
   errorCaptured?(err: Error, vm: Vue, info: string): boolean | void;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };
-  components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> };
+  components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> | AsyncComponentFactory<any, any, any, any> };
   transitions?: { [key: string]: object };
   filters?: { [key: string]: Function };
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -15,14 +15,18 @@ export type Component<Data=DefaultData<never>, Methods=DefaultMethods<never>, Co
 interface EsModuleComponent {
   default: Component
 }
+                      
+export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps>
+  = AsyncComponentPromise<Data, Methods, Computed, Props>
+  | AsyncComponentFactory<Data, Methods, Computed, Props>
 
-export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = (
+export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = (
   resolve: (component: Component<Data, Methods, Computed, Props>) => void,
   reject: (reason?: any) => void
 ) => Promise<Component | EsModuleComponent> | void;
 
 export type AsyncComponentFactory<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = () => {
-  component: AsyncComponent<Data, Methods, Computed, Props>;
+  component: AsyncComponentPromise<Data, Methods, Computed, Props>;
   loading?: Component | EsModuleComponent;
   error?: Component | EsModuleComponent;
   delay?: number;
@@ -94,7 +98,7 @@ export interface ComponentOptions<
   errorCaptured?(err: Error, vm: Vue, info: string): boolean | void;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };
-  components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> | AsyncComponentFactory<any, any, any, any> };
+  components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> };
   transitions?: { [key: string]: object };
   filters?: { [key: string]: Function };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Typescript

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The current type definition for `ComponentOptions` does not have a definition for [async component factories](https://vuejs.org/v2/guide/components-dynamic-async.html) and as such causes errors when using the syntax with [vue-class-component](https://github.com/vuejs/vue-class-component).