### PR TITLE
fix(patch): static tree should ba as same vnode(#8021)

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -44,7 +44,7 @@ function sameVnode (a, b) {
         isTrue(a.isAsyncPlaceholder) &&
         a.asyncFactory === b.asyncFactory &&
         isUndef(b.asyncFactory.error)
-      )
+      ) || sameStaticVnode(a, b)
     )
   )
 }
@@ -55,6 +55,12 @@ function sameInputType (a, b) {
   const typeA = isDef(i = a.data) && isDef(i = i.attrs) && i.type
   const typeB = isDef(i = b.data) && isDef(i = i.attrs) && i.type
   return typeA === typeB || isTextInputType(typeA) && isTextInputType(typeB)
+}
+
+function sameStaticVnode (a, b) {
+  return isTrue(a.isStatic) &&
+  isTrue(b.isStatic) &&
+  (isTrue(b.isCloned) || isTrue(b.isOnce))
 }
 
 function createKeyToOldIdx (children, beginIdx, endIdx) {
@@ -518,10 +524,9 @@ export function createPatchFunction (backend) {
     // note we only do this if the vnode is cloned -
     // if the new node is not cloned it means the render functions have been
     // reset by the hot-reload-api and we need to do a proper re-render.
-    if (isTrue(vnode.isStatic) &&
-      isTrue(oldVnode.isStatic) &&
-      vnode.key === oldVnode.key &&
-      (isTrue(vnode.isCloned) || isTrue(vnode.isOnce))
+    if (
+      sameStaticVnode(oldVnode, vnode) &&
+      vnode.key === oldVnode.key
     ) {
       vnode.componentInstance = oldVnode.componentInstance
       return

--- a/test/unit/features/directives/once.spec.js
+++ b/test/unit/features/directives/once.spec.js
@@ -176,6 +176,42 @@ describe('Directive v-once', () => {
     }).then(done)
   })
 
+  it('should work inside v-for in component', done => {
+    const vm = new Vue({
+      data: {
+        comp: 'comp1',
+        list: [
+          { id: 0 }
+        ]
+      },
+      components: {
+        comp1: {
+          template: '<span>comp1</span>'
+        },
+        comp2: {
+          template: '<span>comp2</span>'
+        }
+      },
+      template: `
+        <div>
+          <div v-for="i in list" :key="i.id">
+            <component :is='comp' v-once></component>
+          </div>
+        </div>
+      `
+    }).$mount()
+
+    expect(vm.$el.textContent).toBe('comp1')
+
+    vm.comp = 'comp2'
+    waitForUpdate(() => {
+      expect(vm.$el.textContent).toBe('comp1')
+      vm.list.push({ id: 1 })
+    }).then(() => {
+      expect(vm.$el.textContent).toBe('comp1comp2')
+    }).then(done)
+  })
+
   it('should work inside v-for with v-if', done => {
     const vm = new Vue({
       data: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
if change `comp1` to `comp2`, `<component :is='comp'>` vnode's `tag` will be changed, but `<p>` won't, `tag` is not equal will be as not same vnode.  
I can't understand much source code, if I am wrong, please favour me you instruction.  
thanks for your time.