### PR TITLE
Use rest params operator instead of the `arguments` variable

### DIFF
--- a/test/unit/features/instance/methods-events.spec.js
+++ b/test/unit/features/instance/methods-events.spec.js
@@ -8,10 +8,10 @@ describe('Instance methods events', () => {
   })
 
   it('$on', () => {
-    vm.$on('test', function () {
+    vm.$on('test', function (...params) {
       // expect correct context
       expect(this).toBe(vm)
-      spy.apply(this, arguments)
+      spy.apply(this, params)
     })
     vm.$emit('test', 1, 2, 3, 4)
     expect(spy.calls.count()).toBe(1)

--- a/test/unit/features/instance/methods-events.spec.js
+++ b/test/unit/features/instance/methods-events.spec.js
@@ -19,9 +19,9 @@ describe('Instance methods events', () => {
   })
 
   it('$on multi event', () => {
-    vm.$on(['test1', 'test2'], function () {
+    vm.$on(['test1', 'test2'], function (...params) {
       expect(this).toBe(vm)
-      spy.apply(this, arguments)
+      spy.apply(this, params)
     })
     vm.$emit('test1', 1, 2, 3, 4)
     expect(spy.calls.count()).toBe(1)


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters