### PR TITLE
fix(observer): Disable reactive non-numerical property of array (fix #8535)

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -206,7 +206,7 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
     target.splice(key, 1, val)
     return val
   }
-  if (key in target && !(key in Object.prototype)) {
+  if (Array.isArray(target) || (key in target && !(key in Object.prototype))) {
     target[key] = val
     return val
   }
@@ -236,8 +236,12 @@ export function del (target: Array<any> | Object, key: any) {
   ) {
     warn(`Cannot delete reactive property on undefined, null, or primitive value: ${(target: any)}`)
   }
-  if (Array.isArray(target) && isValidArrayIndex(key)) {
-    target.splice(key, 1)
+  if (Array.isArray(target)) {
+    if (isValidArrayIndex(key)) {
+      target.splice(key, 1)
+    } else {
+      delete target[key]
+    }
     return
   }
   const ob = (target: any).__ob__

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -291,10 +291,10 @@ describe('Observer', () => {
     spyOn(dep2, 'notify')
     setProp(arr2, 'b', 2)
     expect(arr2.b).toBe(2)
-    expect(dep2.notify.calls.count()).toBe(1)
+    expect(dep2.notify.calls.count()).toBe(0)
     delProp(arr2, 'b')
     expect(hasOwn(arr2, 'b')).toBe(false)
-    expect(dep2.notify.calls.count()).toBe(2)
+    expect(dep2.notify.calls.count()).toBe(0)
   })
 
   it('warning set/delete on a Vue instance', done => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Pre-defined non-numerical properties are never reactive, new non-numerical properties' behaviors
should be consistent with them.

/test/e2e/specs/modal.js failed, but the previous commit also failed.