### PR TITLE
fix(types): relax the return type of props default option

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -133,7 +133,7 @@ export type PropValidator<T> = PropOptions<T> | Prop<T> | Prop<T>[];
 export interface PropOptions<T=any> {
   type?: Prop<T> | Prop<T>[];
   required?: boolean;
-  default?: T | null | undefined | (() => object);
+  default?: T | null | undefined | (() => T | null | undefined);
   validator?(value: T): boolean;
 }
 

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -79,6 +79,18 @@ Vue.component('union-prop', {
   }
 });
 
+Vue.component('prop-with-primitive-default', {
+  props: {
+    id: {
+      type: String,
+      default: () => String(Math.round(Math.random() * 10000000))
+    }
+  },
+  created() {
+    this.id;
+  }
+});
+
 Vue.component('component', {
   data() {
     this.$mount


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Currently, the return type of `default` option is annotated with `object` since it is used for generating fresh object for each component instance. But there is another use case for `default` option of function in [portal-vue](https://github.com/LinusBorg/portal-vue) which is for dynamically generating unique value as default.
https://github.com/LinusBorg/portal-vue/blob/develop/src/components/portal.js#L16

The current typing breaks `this` type inference when the `default` function returns non-object type. I just relaxed the return type to `any` to avoid breaking the inference.