### PR TITLE
fix(v-model): prevent double v-model update on functional components(#8436)

### DIFF
--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -150,8 +150,9 @@ export function createComponent (
   // component constructor creation
   resolveConstructorOptions(Ctor)
 
-  // transform component v-model data into props & events
-  if (isDef(data.model)) {
+  // transform component v-model data into props & events.
+  // make sure to transform model only once in functional components.
+  if (isDef(data.model) && !isTrue(Ctor.options.functional)) {
     transformModel(Ctor.options, data)
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Currently, when transforming `data.model` in `createElement` function, it does not check if the component is a functional component, causing a double update on `v-model`. This prevents double update on v-model in functional components by not transforming model when `Ctor.options.functional` is `true`.

fix #8436 and eventually https://github.com/vuetifyjs/vuetify/issues/4460