### PR TITLE
refactor: ignore control-regex lint for unsafeAttrCharRE

### DIFF
--- a/src/platforms/web/server/util.js
+++ b/src/platforms/web/server/util.js
@@ -18,7 +18,7 @@ const isAttr = makeMap(
   'target,title,type,usemap,value,width,wrap'
 )
 
-const unsafeAttrCharRE = /[>/="'\u0009\u000a\u000c\u0020]/
+const unsafeAttrCharRE = /[>/="'\u0009\u000a\u000c\u0020]/ // eslint-disable-line no-control-regex
 export const isSSRUnsafeAttr = (name: string): boolean => {
   return unsafeAttrCharRE.test(name)
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Fix lint error, because [eslint-plugin-vue-libs](https://github.com/vuejs/eslint-plugin-vue-libs/blob/master/config.js#L49) is turning on the rule.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
