### PR TITLE
(fix #8337) test(component-slot): new child vnode gets destroyed instead of old one

### DIFF
--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -138,6 +138,9 @@ export function createPatchFunction (backend) {
       // reference node. Instead, we clone the node on-demand before creating
       // associated DOM element for it.
       vnode = ownerArray[index] = cloneVNode(vnode)
+      if (vnode.children) {
+        vnode.children = vnode.children.map(cloneVNode)
+      }
     }
 
     vnode.isRootInsert = !nested // for transition enter check

--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -886,4 +886,47 @@ describe('Component slot', () => {
       expect(vm.$el.textContent).toBe('foo')
     }).then(done)
   })
+
+  // #8337
+  it('should not destroy the new child vm', done => {
+    const Parent = {
+      render (h) {
+        return h(this.API.tag, this.$slots.default)
+      },
+      data () {
+        return { API: { tag: 'p' }}
+      },
+      provide () {
+        return { key: this.API }
+      }
+    }
+
+    const Child = {
+      template: '<div></div>',
+      inject: { wrapper: 'key' },
+      created () {
+        this.wrapper.tag = 'div'
+      }
+    }
+
+    const vm = new Vue({
+      components: {
+        Child,
+        Parent
+      },
+      template: `
+        <parent>
+          <div>
+            <child ref="child" />
+          </div>
+        </parent>
+      `
+    }).$mount()
+
+    expect(vm.$refs.child).toBeDefined()
+
+    waitForUpdate(() => {
+      expect(vm.$refs.child).toBeDefined()
+    }).then(done)
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I'm not confident in the quality of the fix (whether it's addressing the bug directly or indirectly) but deep-cloning the vnode in `createElm` when a vnode used in a previous render is encountered seems to fix the bug.

In any case, a test has been added to repro the bug.