### PR TITLE
fix: check js assets more accurate in ssr webpack plugin

### DIFF
--- a/src/server/webpack-plugin/server.js
+++ b/src/server/webpack-plugin/server.js
@@ -43,7 +43,7 @@ export default class VueSSRServerPlugin {
       }
 
       stats.assets.forEach(asset => {
-        if (asset.name.match(/\.js$/)) {
+        if (isJS(asset.name)) {
           bundle.files[asset.name] = compilation.assets[asset.name].source()
         } else if (asset.name.match(/\.js\.map$/)) {
           bundle.maps[asset.name.replace(/\.map$/, '')] = JSON.parse(compilation.assets[asset.name].source())


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

If we config `chunkName` as `'[name].js?v=[chunkhash]'`, the previous regex cannot match the js assets in webpack plugin, so use `isJS` to perfect match files

Pr will aslo resove https://github.com/nuxt/nuxt.js/issues/3387