### PR TITLE
fix(types): scoped slots can return a single VNode

### DIFF
--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -307,11 +307,15 @@ Vue.component('component-with-scoped-slot', {
 Vue.component('narrow-array-of-vnode-type', {
   render (h): VNode {
     const slot = this.$scopedSlots.default({})
-    if (typeof slot !== 'string') {
+    if (Array.isArray(slot)) {
       const first = slot[0]
       if (!Array.isArray(first) && typeof first !== 'string') {
         return first;
       }
+    } else if (typeof slot === 'string') {
+      return h('div', slot.toUpperCase())
+    } else {
+      return slot
     }
     return h();
   }

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -1,6 +1,6 @@
 import { Vue } from "./vue";
 
-export type ScopedSlot = (props: any) => VNodeChildrenArrayContents | string;
+export type ScopedSlot = (props: any) => VNodeChildrenArrayContents | VNode | string;
 
 export type VNodeChildren = VNodeChildrenArrayContents | [ScopedSlot] | string;
 export interface VNodeChildrenArrayContents extends Array<VNode | string | VNodeChildrenArrayContents> {}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] Maybe, but it was wrong to start with

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
