### PR TITLE
fix(sfc): do not deindent space-padded output

### DIFF
--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -83,7 +83,10 @@ export function parseComponent (
   function end (tag: string, start: number, end: number) {
     if (depth === 1 && currentBlock) {
       currentBlock.end = start
-      let text = deindent(content.slice(currentBlock.start, currentBlock.end))
+      let text = content.slice(currentBlock.start, currentBlock.end)
+      if (options.pad !== 'space') {
+        text = deindent(text)
+      }
       // pad content so that linters and pre-processors can output correct
       // line numbers in errors and warnings
       if (currentBlock.type !== 'template' && options.pad) {

--- a/test/unit/modules/sfc/sfc-parser.spec.js
+++ b/test/unit/modules/sfc/sfc-parser.spec.js
@@ -78,14 +78,14 @@ describe('Single File Component parser', () => {
     expect(padSpace.script.content).toBe(`<template>
         <div></div>
       </template>
-      <script>`.replace(/./g, ' ') + '\nexport default {}\n')
+      <script>`.replace(/./g, ' ') + '\n        export default {}\n      ')
     expect(padSpace.styles[0].content).toBe(`<template>
         <div></div>
       </template>
       <script>
         export default {}
       </script>
-      <style>`.replace(/./g, ' ') + '\nh1 { color: red }\n')
+      <style>`.replace(/./g, ' ') + '\n        h1 { color: red }\n      ')
   })
 
   it('should handle template blocks with lang as special text', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

`parseComponent('...', { pad: 'space' }).script.content` will contain code with base indent if SFC content has base indent. Also applies to styles or etc.

As #5058 and #5059, `pad: 'space'` is for character-oriented tools that calculate positions by distance from the beginning of the file instead of by line. This should be applied to source code itself, so I think it was buggy and breaking change is unavoidable. 

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

I'm personally creating tool to convert `export default { ... }` to `vue-property-decorators` style, so I'm using `vue-template-compiler` with `@vue/component-compiler-utils` and code with original indent is needed.