### PR TITLE
fix(#8728): only execute the dependArray function once

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -158,10 +158,11 @@ export function defineReactive (
     configurable: true,
     get: function reactiveGetter () {
       const value = getter ? getter.call(obj) : val
-      if (Dep.target) {
+      const targetWatcher = Dep.target
+      if (targetWatcher) {
         dep.depend()
         if (childOb) {
-          const needDepend = Array.isArray(value) && !Dep.target.checkRelated(childOb.dep)
+          const needDepend = Array.isArray(value) && !targetWatcher.checkRelated(childOb.dep)
           childOb.dep.depend()
           if (needDepend) {
             dependArray(value)

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -161,8 +161,9 @@ export function defineReactive (
       if (Dep.target) {
         dep.depend()
         if (childOb) {
+          const needDepend = Array.isArray(value) && !Dep.target.checkRelated(childOb.dep)
           childOb.dep.depend()
-          if (Array.isArray(value)) {
+          if (needDepend) {
             dependArray(value)
           }
         }

--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -140,6 +140,13 @@ export default class Watcher {
   }
 
   /**
+   * Check if a dependency has been associated with the current watcher.
+   */
+  checkRelated (dep: Dep) {
+    return this.newDepIds.has(dep.id)
+  }
+
+  /**
    * Clean up for dependency collection.
    */
   cleanupDeps () {

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -6,7 +6,7 @@ import {
   del as delProp
 } from 'core/observer/index'
 import Dep from 'core/observer/dep'
-import { hasOwn, Set } from 'core/util/index'
+import { hasOwn, _Set as Set } from 'core/util/index'
 
 describe('Observer', () => {
   it('create on non-observables', () => {

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -356,6 +356,33 @@ describe('Observer', () => {
     })
   })
 
+  it('Array\'s getter is triggered multiple times, the Watcher should only associate with Dep once.', () => {
+    const data = {
+      arr: [{}]
+    }
+    observe(data)
+    // mock a watcher!
+    const watcher = {
+      newDepIds: new Set(),
+      addDep (dep) {
+        this.newDepIds.add(dep.id)
+        dep.addSub(this)
+      },
+      checkRelated: function (dep) {
+        return this.newDepIds.has(dep.id)
+      }
+    }
+    spyOn(watcher, 'checkRelated').and.callThrough()
+    Dep.target = watcher
+    data.arr
+    data.arr
+    Dep.target = null
+    expect(watcher.checkRelated.calls.count()).toBe(2)
+    const allCalls = watcher.checkRelated.calls.all()
+    expect(allCalls[0].returnValue).toBe(false)
+    expect(allCalls[1].returnValue).toBe(true)
+  })
+
   it('warn set/delete on non valid values', () => {
     try {
       setProp(null, 'foo', 1)

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -6,7 +6,7 @@ import {
   del as delProp
 } from 'core/observer/index'
 import Dep from 'core/observer/dep'
-import { hasOwn } from 'core/util/index'
+import { hasOwn, Set } from 'core/util/index'
 
 describe('Observer', () => {
   it('create on non-observables', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: This PR is not a bug fix, but a performance improvement for issue #8728.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The `newDepIds` property of each Watcher instance object holds all the dependencies collected by this evaluation. We can prevent the `dependArray` function from being called multiple times by checking if the dependency has been collected.
