### PR TITLE
Fix #8798: $refs TypeScript type definition

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -26,7 +26,7 @@ export interface Vue {
   readonly $parent: Vue;
   readonly $root: Vue;
   readonly $children: Vue[];
-  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[] };
+  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[] | undefined };
   readonly $slots: { [key: string]: VNode[] };
   readonly $scopedSlots: { [key: string]: ScopedSlot };
   readonly $isServer: boolean;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Fixes #8798 

When you refer to `$refs`, the type if always something truthy, while it is possible that the value is `undefined`.
Without this change, one can refer to a `ref` that is `undefined`, but TypeScript thinks it is `Element` or `Vue`.

This PR added `undefined` type to the type of `$refs`. This way it is more type-safe when using `$refs`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

This change will break code written in TypeScript which does not null-check the value of `this.$refs.foo`.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

~~If adding a **new feature**, the PR's description includes:~~
~~- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)~~

**Other information:**
