### PR TITLE
Lazy load for components, filters and directives (fix #8106)

### DIFF
--- a/src/core/instance/render-helpers/resolve-filter.js
+++ b/src/core/instance/render-helpers/resolve-filter.js
@@ -6,5 +6,5 @@ import { identity, resolveAsset } from 'core/util/index'
  * Runtime helper for resolving filters
  */
 export function resolveFilter (id: string): Function {
-  return resolveAsset(this.$options, 'filters', id, true) || identity
+  return resolveAsset(this, 'filters', id, true) || identity
 }

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -102,7 +102,7 @@ export function _createElement (
         config.parsePlatformTagName(tag), data, children,
         undefined, undefined, context
       )
-    } else if (isDef(Ctor = resolveAsset(context.$options, 'components', tag))) {
+    } else if (isDef(Ctor = resolveAsset(context, 'components', tag))) {
       // component
       vnode = createComponent(Ctor, data, context, children, tag)
     } else {

--- a/src/core/vdom/modules/directives.js
+++ b/src/core/vdom/modules/directives.js
@@ -97,7 +97,7 @@ function normalizeDirectives (
       dir.modifiers = emptyModifiers
     }
     res[getRawDirName(dir)] = dir
-    dir.def = resolveAsset(vm.$options, 'directives', dir.name, true)
+    dir.def = resolveAsset(vm, 'directives', dir.name, true)
   }
   // $flow-disable-line
   return res

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -174,6 +174,20 @@ export const hyphenate = cached((str: string): string => {
 })
 
 /**
+ * Get all variations of a identifier spelling.
+ */
+export const identifierSpellings = cached((str: string): Object => {
+  const camelized = camelize(str)
+  return {
+    raw: str,
+    hyphenated: hyphenate(str),
+    camelized: camelized,
+    PascalCase: capitalize(camelized),
+    toString: () => str
+  }
+})
+
+/**
  * Simple bind polyfill for environments that do not support it... e.g.
  * PhantomJS 1.x. Technically we don't need this anymore since native bind is
  * now more performant in most browsers, but removing it would be breaking for


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The convincing reason was explained at length over at #8106. I know this will not be merged, in fact I'm gonna close it myself. But I'm publishing this PR for reference for anyone else interested.

The initial need was for components, but when reviewing the code I thought the most elegant way to do this was by changing the `resolveAsset()` function to call a user function defined on the `$options` object:

```
getComponent(id: string, identifierSpellings: Object): void | Component | AsyncComponent
getDirective(id: string, identifierSpellings: Object): void | Directive
getFilter(id: string, identifiesSpellings: Object): void | Filter
```

The `identifierSpellings` object has normalized spellings in case the user needs it:

- raw: the way it was called
- hyphenated
- camelized
- PascalCase
- and a toString() method, which returns the raw version

The nice thing about this is that it gives all the power to the user, and enables him to do many things which aren't possible with the current api, and the biggest use case is to **lazily load async components only when they are needed.**

I know that to submit a decent PR, I'd still need to write tests and documentation... that is the next step.

A running example can be seen here:

https://unpkg.com/@arijs/vue-generator@0.1.4/outra/pagina/

My version is released at:
https://unpkg.com/@arijs/vue@2.5.17-beta1.0/
https://www.npmjs.com/package/@arijs/vue