### PR TITLE
fix #8865: skip mixins and extends if child is already merged

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -378,15 +378,22 @@ export function mergeOptions (
   normalizeProps(child, vm)
   normalizeInject(child, vm)
   normalizeDirectives(child)
-  const extendsFrom = child.extends
-  if (extendsFrom && !child._base) {
-    parent = mergeOptions(parent, extendsFrom, vm)
-  }
-  if (child.mixins && !child._base) {
-    for (let i = 0, l = child.mixins.length; i < l; i++) {
-      parent = mergeOptions(parent, child.mixins[i], vm)
+  
+  // Apply extends and mixins on the child options,
+  // but only if it is a raw options object that isn't
+  // the result of another mergeOptions call.
+  // Only merged options has the _base property.
+  if (!child._base) {
+    if (child.extends) {
+      parent = mergeOptions(parent, child.extends, vm)
+    }
+    if (child.mixins) {
+      for (let i = 0, l = child.mixins.length; i < l; i++) {
+        parent = mergeOptions(parent, child.mixins[i], vm)
+      }
     }
   }
+
   const options = {}
   let key
   for (key in parent) {

--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -379,10 +379,10 @@ export function mergeOptions (
   normalizeInject(child, vm)
   normalizeDirectives(child)
   const extendsFrom = child.extends
-  if (extendsFrom) {
+  if (extendsFrom && !child._base) {
     parent = mergeOptions(parent, extendsFrom, vm)
   }
-  if (child.mixins) {
+  if (child.mixins && !child._base) {
     for (let i = 0, l = child.mixins.length; i < l; i++) {
       parent = mergeOptions(parent, child.mixins[i], vm)
     }

--- a/test/unit/features/global-api/extend.spec.js
+++ b/test/unit/features/global-api/extend.spec.js
@@ -71,6 +71,25 @@ describe('Global API: extend', () => {
     expect(calls).toEqual([1, 2, 3])
   })
 
+  it('should not merge nested mixins', () => {
+    const A = Vue.extend({
+      created: () => {}
+    })
+    const B = Vue.extend({
+      mixins: [A],
+      created: () => {}
+    })
+    const C = Vue.extend({
+      extends: B,
+      created: () => {}
+    })
+    const D = Vue.extend({
+      mixins: [C],
+      created: () => {}
+    })
+    expect(D.options.created.length).toBe(4)
+  })
+
   it('should merge methods', () => {
     const A = Vue.extend({
       methods: {

--- a/test/unit/features/global-api/extend.spec.js
+++ b/test/unit/features/global-api/extend.spec.js
@@ -71,7 +71,7 @@ describe('Global API: extend', () => {
     expect(calls).toEqual([1, 2, 3])
   })
 
-  it('should not merge nested mixins', () => {
+  it('should not merge nested mixins created with Vue.extend', () => {
     const A = Vue.extend({
       created: () => {}
     })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
fixes #8865