### PR TITLE
fix #8862: cannot watch unicode properties like 'a.中文'

### DIFF
--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -80,13 +80,21 @@ export default class Watcher {
     } else {
       this.getter = parsePath(expOrFn)
       if (!this.getter) {
+        if (this.getter === false) {
+          process.env.NODE_ENV !== 'production' && warn(
+            `Failed watching path: "${expOrFn}" ` +
+            'Watcher only accepts simple dot-delimited paths. ' +
+            'For full control, use a function instead.',
+            vm
+          )
+        } else {
+          process.env.NODE_ENV !== 'production' && warn(
+            `Failed watching path: "${expOrFn}" ` +
+            'Vue watchers only accept alphanumeric, $, or underscore naming of properties.',
+            vm
+          )
+        }
         this.getter = function () {}
-        process.env.NODE_ENV !== 'production' && warn(
-          `Failed watching path: "${expOrFn}" ` +
-          'Watcher only accepts simple dot-delimited paths. ' +
-          'For full control, use a function instead.',
-          vm
-        )
       }
     }
     this.value = this.lazy

--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -78,23 +78,28 @@ export default class Watcher {
     if (typeof expOrFn === 'function') {
       this.getter = expOrFn
     } else {
-      this.getter = parsePath(expOrFn)
-      if (!this.getter) {
-        if (this.getter === false) {
-          process.env.NODE_ENV !== 'production' && warn(
-            `Failed watching path: "${expOrFn}" ` +
-            'Watcher only accepts simple dot-delimited paths. ' +
-            'For full control, use a function instead.',
-            vm
-          )
-        } else {
-          process.env.NODE_ENV !== 'production' && warn(
-            `Failed watching path: "${expOrFn}" ` +
-            'Vue watchers only accept alphanumeric, $, or underscore naming of properties.',
-            vm
-          )
+      const bailRE = /[^\w.$]/
+      const delimiterRE = /[ ,/\\]/
+      if (bailRE.test(expOrFn)) {
+        if (process.env.NODE_ENV !== 'production') {
+          if (delimiterRE.test(expOrFn)) {
+            warn(
+              `Failed watching path: "${expOrFn}" ` +
+              'Watcher only accepts simple dot-delimited paths. ' +
+              'For full control, use a function instead.',
+              vm
+            )
+          } else {
+            warn(
+              `Failed watching path: "${expOrFn}" ` +
+              'Vue watchers only accept alphanumeric, $, or underscore naming of properties.',
+              vm
+            )
+          }
         }
         this.getter = function () {}
+      } else {
+        this.getter = parsePath(expOrFn)
       }
     }
     this.value = this.lazy

--- a/src/core/util/lang.js
+++ b/src/core/util/lang.js
@@ -24,8 +24,12 @@ export function def (obj: Object, key: string, val: any, enumerable?: boolean) {
  * Parse simple path.
  */
 const bailRE = /[^\w.$]/
+const delimiterRE = /[ ,/\\]/
 export function parsePath (path: string): any {
   if (bailRE.test(path)) {
+    if (delimiterRE.test(path)) {
+      return false
+    }
     return
   }
   const segments = path.split('.')

--- a/src/core/util/lang.js
+++ b/src/core/util/lang.js
@@ -23,15 +23,7 @@ export function def (obj: Object, key: string, val: any, enumerable?: boolean) {
 /**
  * Parse simple path.
  */
-const bailRE = /[^\w.$]/
-const delimiterRE = /[ ,/\\]/
 export function parsePath (path: string): any {
-  if (bailRE.test(path)) {
-    if (delimiterRE.test(path)) {
-      return false
-    }
-    return
-  }
   const segments = path.split('.')
   return function (obj) {
     for (let i = 0; i < segments.length; i++) {

--- a/test/unit/modules/observer/watcher.spec.js
+++ b/test/unit/modules/observer/watcher.spec.js
@@ -179,7 +179,7 @@ describe('Watcher', () => {
     expect('Failed watching path:').toHaveBeenWarned()
   })
 
-  it('does not support non-alphanumeric paths and throws a warns', () => {
+  it('does not support non-alphanumeric paths and throws a warning', () => {
     new Watcher(vm, '中文', spy)
     expect('Failed watching path:').toHaveBeenWarned()
   })

--- a/test/unit/modules/observer/watcher.spec.js
+++ b/test/unit/modules/observer/watcher.spec.js
@@ -178,4 +178,9 @@ describe('Watcher', () => {
     new Watcher(vm, 'd.e + c', spy)
     expect('Failed watching path:').toHaveBeenWarned()
   })
+
+  it('does not support non-alphanumeric paths and throws a warns', () => {
+    new Watcher(vm, '中文', spy)
+    expect('Failed watching path:').toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
Hi all at Vue!

This pull request resolves the issue regarding watchers not watching unicode properties like 'a.中文'.

My method for resolving this case is to throw a warning when non-alphanumeric, $, or _ characters are detected. My reasoning behind throwing a warning instead of supporting special characters is that I think  supporting special characters would promote poor naming habits that could only make code more difficult to read and understand.

I'm pretty new to open source so any feedback would be awesome and please let me know if you'd like to see any changes or improvements!

Link to issue: https://github.com/vuejs/vue/issues/8862

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)