### PR TITLE
perf(deps): improve the order to teardown watcher from O(n*m) to O(n) (fix vuex#1383)

### DIFF
--- a/test/unit/modules/observer/dep.spec.js
+++ b/test/unit/modules/observer/dep.spec.js
@@ -7,26 +7,32 @@ describe('Dep', () => {
     dep = new Dep()
   })
 
+  function subsLength (dep) {
+    return Object.keys(dep.subs).length
+  }
+
   describe('instance', () => {
     it('should be created with correct properties', () => {
-      expect(dep.subs.length).toBe(0)
+      expect(subsLength(dep)).toBe(0)
       expect(new Dep().id).toBe(dep.id + 1)
     })
   })
 
   describe('addSub()', () => {
     it('should add sub', () => {
-      dep.addSub(null)
-      expect(dep.subs.length).toBe(1)
-      expect(dep.subs[0]).toBe(null)
+      const dummySub = { id: 1 }
+      dep.addSub(dummySub)
+      expect(subsLength(dep)).toBe(1)
+      expect(dep.subs[dummySub.id]).toBe(dummySub)
     })
   })
 
   describe('removeSub()', () => {
     it('should remove sub', () => {
-      dep.subs.push(null)
-      dep.removeSub(null)
-      expect(dep.subs.length).toBe(0)
+      const dummySub = { id: 1 }
+      dep.subs[dummySub.id] = dummySub
+      dep.removeSub(dummySub)
+      expect(subsLength(dep)).toBe(0)
     })
   })
 
@@ -55,9 +61,10 @@ describe('Dep', () => {
 
   describe('notify()', () => {
     it('should notify subs', () => {
-      dep.subs.push(jasmine.createSpyObj('SUB', ['update']))
+      const subId = 1
+      dep.subs[subId] = jasmine.createSpyObj('SUB', ['update'])
       dep.notify()
-      expect(dep.subs[0].update).toHaveBeenCalled()
+      expect(dep.subs[subId].update).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: performance improvement

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR fixes vuejs/vuex#1383.

Simplified reproduction / benchmark: https://github.com/ktsn/vue-deps-perf-demo
The demo will destroy 1000 components that has a computed property depends on an array with 1000 length. Then print its time.

On my machine, the result is like the following:
current: 3434ms
patched: 224ms

On the current reactive system implementation, when a computed property depends on an array, its children object will also be registered to computed property's watcher as dependency.

When the watcher is torndown, the watcher iterates its dependencies (size `n`). The dependencies remove the watcher from their watcher list (size `m`). So it will cost O(n*m).

So it would become slow if there are many computed properties and a large array.

This PR change the watcher list in `Dep` object to object map to make the order linear. The entire order of the watcher teardown will be O(n).

There may be more overhead on `delete` operator. I'm not sure how it affects actual application though.