### PR TITLE
fix(mergeData): skip recursive call if values are identical

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -55,7 +55,11 @@ function mergeData (to: Object, from: ?Object): Object {
     fromVal = from[key]
     if (!hasOwn(to, key)) {
       set(to, key, fromVal)
-    } else if (isPlainObject(toVal) && isPlainObject(fromVal)) {
+    } else if (
+      toVal !== fromVal &&
+      isPlainObject(toVal) &&
+      isPlainObject(fromVal)
+    ) {
       mergeData(toVal, fromVal)
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
Fixes https://github.com/vuetifyjs/vuetify/issues/5633

I've been unable to reproduce this in isolation, but have run into it several times in the past. This check should also reduce unnecessary calls to `mergeData`, I noticed thousands of instances of identical objects being merged that didn't cause errors. 
