### PR TITLE
fix(ts types): Issue # 8983 Fixing $once type declaration on vue.d.ts file. $once …

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -53,7 +53,7 @@ export interface Vue {
     options?: WatchOptions
   ): (() => void);
   $on(event: string | string[], callback: Function): this;
-  $once(event: string, callback: Function): this;
+  $once(event: string | string[], callback: Function): this;
   $off(event?: string | string[], callback?: Function): this;
   $emit(event: string, ...args: any[]): this;
   $nextTick(callback: (this: this) => void): void;


### PR DESCRIPTION
Issue #8983 
$once should accept an event or array

Fixing $once type declaration on vue.d.ts file. $once should accept an event or array of events as
first parameter

fix #8983

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
