### PR TITLE
 fix(v-model): Clear composing flag on blur. Fixes #8945

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -41,8 +41,8 @@ const directive = {
         // this also fixes the issue where some browsers e.g. iOS Chrome
         // fires "change" instead of "input" on autocomplete.
         el.addEventListener('change', onCompositionEnd)
-        // If user moves focus before composition ends, clear the composing flag
-        // See #
+        // If user moves focus before composition ends, clear the composing flag.
+        // See #8945
         el.addEventListener('blur', onBlur)
         /* istanbul ignore if */
         if (isIE9) {

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -41,6 +41,9 @@ const directive = {
         // this also fixes the issue where some browsers e.g. iOS Chrome
         // fires "change" instead of "input" on autocomplete.
         el.addEventListener('change', onCompositionEnd)
+        // If user moves focus before composition ends, clear the composing flag
+        // See #
+        el.addEventListener('blur', onBlur)
         /* istanbul ignore if */
         if (isIE9) {
           el.vmodel = true
@@ -136,6 +139,12 @@ function onCompositionEnd (e) {
   if (!e.target.composing) return
   e.target.composing = false
   trigger(e.target, 'input')
+}
+
+function onBlur (e) {
+  // clear compostion flag on blur if set
+  if (!e.target.composing) return
+  e.target.composing = false
 }
 
 function trigger (el, type) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In some instances, the `.composing` flag can be left set as `true` if the user moves focus while they are in the middle of composition. See issue #8945

This fix adds a `blur` handler that sets the `e.target.composing` to `false` if it is still set to `true` when the blur happens.