### PR TITLE
WIP: types: propagate this in computed properties

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -27,8 +27,8 @@ export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never
  * Since there isn't a way to query for the return type of a function, we allow TypeScript
  * to infer from the shape of `Accessors<Computed>` and work backwards.
  */
-export type Accessors<T> = {
-  [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>
+export type Accessors<T, V = any> = {
+  [K in keyof T]: ((this: V) => T[K]) | ComputedOptions<T[K]>
 }
 
 type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data)
@@ -62,7 +62,7 @@ export interface ComponentOptions<
   data?: Data;
   props?: PropsDef;
   propsData?: object;
-  computed?: Accessors<Computed>;
+  computed?: Accessors<Computed, V>;
   methods?: Methods;
   watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | string>;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR fixes this in computed properties

> Error:(15, 19) TS2339: Property 'bar' does not exist on type '{ foo(): any; }'.

```ts
import Vue from 'vue'

Vue.extend({
  computed: {
    foo () {
      return this.bar()
    }
  },
  methods: {
    bar () {
      return null
    }
  }
})
```
