### PR TITLE
Allow empty slot-scope to render a scoped slot instead of a normal one

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -204,7 +204,7 @@ export function parse (
       if (currentParent && !element.forbidden) {
         if (element.elseif || element.else) {
           processIfConditions(element, currentParent)
-        } else if (element.slotScope) { // scoped slot
+        } else if (element.slotScope || element.slotScope === '') { // scoped slot
           currentParent.plain = false
           const name = element.slotTarget || '"default"'
           ;(currentParent.scopedSlots || (currentParent.scopedSlots = {}))[name] = element
@@ -466,7 +466,7 @@ function processSlot (el) {
     if (el.tag === 'template') {
       slotScope = getAndRemoveAttr(el, 'scope')
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && slotScope) {
+      if (process.env.NODE_ENV !== 'production' && (slotScope || slotScope === '')) {
         warn(
           `the "scope" attribute for scoped slots have been deprecated and ` +
           `replaced by "slot-scope" since 2.5. The new "slot-scope" attribute ` +
@@ -476,7 +476,10 @@ function processSlot (el) {
         )
       }
       el.slotScope = slotScope || getAndRemoveAttr(el, 'slot-scope')
-    } else if ((slotScope = getAndRemoveAttr(el, 'slot-scope'))) {
+    } else if (
+        (slotScope = getAndRemoveAttr(el, 'slot-scope')) ||
+        (slotScope = getAndRemoveAttr(el, 'slot-scope')) === ''
+      ) {
       /* istanbul ignore if */
       if (process.env.NODE_ENV !== 'production' && el.attrsMap['v-for']) {
         warn(

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -478,7 +478,7 @@ function processSlot (el) {
       el.slotScope = slotScope || getAndRemoveAttr(el, 'slot-scope')
     } else if (
         (slotScope = getAndRemoveAttr(el, 'slot-scope')) ||
-        (slotScope = getAndRemoveAttr(el, 'slot-scope')) === ''
+        slotScope === ''
       ) {
       /* istanbul ignore if */
       if (process.env.NODE_ENV !== 'production' && el.attrsMap['v-for']) {

--- a/test/unit/features/component/component-scoped-slot.spec.js
+++ b/test/unit/features/component/component-scoped-slot.spec.js
@@ -558,6 +558,70 @@ describe('Component scoped slot', () => {
     }).then(done)
   })
 
+  it('renders slot multiple times with empty slot-scope', done => {
+    const vm = new Vue({
+      template: `
+        <test ref="test">
+          <template slot-scope>
+            <span>Hi</span>
+          </template>
+        </test>
+      `,
+      components: {
+        test: {
+          template: `
+            <div>
+              <slot v-for="item in items"></slot>
+            </div>
+          `,
+          data() {
+            return {
+              items: [1, 2, 3]
+            }
+          }
+        }
+      }
+    }).$mount()
+
+    expect(vm.$el.innerHTML).toBe('<span>Hi</span><span>Hi</span><span>Hi</span>')
+    vm.$refs.test.items = [1, 2]
+    waitForUpdate(() => {
+    expect(vm.$el.innerHTML).toBe('<span>Hi</span><span>Hi</span>')
+    }).then(done)
+  })
+
+  it('renders slot multiple times with empty slot-scope (plain elements)', done => {
+    const vm = new Vue({
+      template: `
+        <test ref="test">
+          <div slot-scope>
+            <span>Hi</span>
+          </div>
+        </test>
+      `,
+      components: {
+        test: {
+          template: `
+            <div>
+              <slot v-for="item in items"></slot>
+            </div>
+          `,
+          data() {
+            return {
+              items: [1, 2, 3]
+            }
+          }
+        }
+      }
+    }).$mount()
+
+    expect(vm.$el.innerHTML).toBe('<div><span>Hi</span></div><div><span>Hi</span></div><div><span>Hi</span></div>')
+    vm.$refs.test.items = [1, 2]
+    waitForUpdate(() => {
+    expect(vm.$el.innerHTML).toBe('<div><span>Hi</span></div><div><span>Hi</span></div>')
+    }).then(done)
+  })
+
   // #6725
   it('scoped slot with v-if', done => {
     const vm = new Vue({

--- a/test/unit/modules/compiler/codegen.spec.js
+++ b/test/unit/modules/compiler/codegen.spec.js
@@ -197,6 +197,17 @@ describe('codegen', () => {
     )
   })
 
+  it('generate scoped slot with empty string', () => {
+    assertCodegen(
+      '<foo><template slot-scope>{{ bar }}</template></foo>',
+      `with(this){return _c('foo',{scopedSlots:_u([{key:"default",fn:function(){return [_v(_s(bar))]}}])})}`
+    )
+    assertCodegen(
+      '<foo><div slot-scope>{{ bar }}</div></foo>',
+      `with(this){return _c('foo',{scopedSlots:_u([{key:"default",fn:function(){return _c('div',{},[_v(_s(bar))])}}])})}`
+    )
+  })
+
   it('generate named scoped slot', () => {
     assertCodegen(
       '<foo><template slot="foo" slot-scope="bar">{{ bar }}</template></foo>',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Please check issue #8912 and #8496 
This PR allows rendering a single slot multiple times by passing an empty slot-scope which makes the slot be rendered as a scoped slot instead of a normal one.
