### PR TITLE
fix(lifecycle): beforeUpdated should not be called if component is de…

### DIFF
--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -196,7 +196,7 @@ export function mountComponent (
   // component's mounted hook), which relies on vm._watcher being already defined
   new Watcher(vm, updateComponent, noop, {
     before () {
-      if (vm._isMounted) {
+      if (vm._isMounted && !vm._isDestroyed) {
         callHook(vm, 'beforeUpdate')
       }
     }

--- a/test/unit/features/options/lifecycle.spec.js
+++ b/test/unit/features/options/lifecycle.spec.js
@@ -186,7 +186,7 @@ describe('Options lifecycle hooks', () => {
       vm.todos[0].done = true
       waitForUpdate(() => {
         expect(destroyed).toHaveBeenCalled()
-        expect(beforeUpdated).not.toHaveBeenCalled()
+        expect(beforeUpdate).not.toHaveBeenCalled()
       }).then(done)
     })
   })

--- a/test/unit/features/options/lifecycle.spec.js
+++ b/test/unit/features/options/lifecycle.spec.js
@@ -155,14 +155,14 @@ describe('Options lifecycle hooks', () => {
 
     // #8076
     it('should not be called after destroy', done => {
-      const beforeUpdated = jasmine.createSpy('beforeUpdated')
+      const beforeUpdate = jasmine.createSpy('beforeUpdate')
       const destroyed = jasmine.createSpy('destroyed')
 
       Vue.component('todo', {
         template: '<div>{{todo.done}}</div>',
         props: ['todo'],
         destroyed,
-        beforeUpdated
+        beforeUpdate
       })
 
       const vm = new Vue({


### PR DESCRIPTION
…stroyed, fix #8076

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This properly fixes #8076 since PR #8381 did not cover beforeUpdate.