### PR TITLE
fix(types): avoid `this` in VueConstructor signature

### DIFF
--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "experimentalDecorators": true,
     "lib": [
       "dom",
       "es2015"

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -102,10 +102,10 @@ class Test extends Vue {
     this.compile("<div>{{ message }}</div>");
     this
       .use(() => {
-        
+
       })
       .use(() => {
-        
+
       })
       .mixin({})
       .mixin({});
@@ -193,3 +193,10 @@ Vue.extend({
     return h('canvas', {}, [a])
   }
 })
+
+declare function decorate<VC extends typeof Vue>(v: VC): VC;
+
+@decorate
+class Decorated extends Vue {
+  a = 123;
+}

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -111,9 +111,9 @@ export interface VueConstructor<V extends Vue = Vue> {
   component<Props>(id: string, definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
   component(id: string, definition?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
 
-  use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): this;
-  use(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): this;
-  mixin(mixin: VueConstructor | ComponentOptions<Vue>): this;
+  use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): VueConstructor<V>;
+  use(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): VueConstructor<V>;
+  mixin(mixin: VueConstructor | ComponentOptions<Vue>): VueConstructor<V>;
   compile(template: string): {
     render(createElement: typeof Vue.prototype.$createElement): VNode;
     staticRenderFns: (() => VNode)[];


### PR DESCRIPTION
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

Fix https://github.com/vuejs/vue-class-component/issues/294

Mixing `this`, `interface`, `extends` and `new` signature seems to be hairy in TypeScript. It is better to not rely on `this`.
