### PR TITLE
fix(#9198): fix merged twice bug when passing extended constructor to mixins

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -376,13 +376,13 @@ export function mergeOptions (
   }
 
   if (typeof child === 'function') {
-    child = child.options
+    child = child.extendOptions
   }
 
   normalizeProps(child, vm)
   normalizeInject(child, vm)
   normalizeDirectives(child)
-  
+
   // Apply extends and mixins on the child options,
   // but only if it is a raw options object that isn't
   // the result of another mergeOptions call.

--- a/test/unit/features/options/mixins.spec.js
+++ b/test/unit/features/options/mixins.spec.js
@@ -109,4 +109,32 @@ describe('Options mixins', () => {
     expect(vm.b).toBeDefined()
     expect(vm.$options.directives.c).toBeDefined()
   })
+
+  it('should not mix global mixined lifecycle hook twice', () => {
+    const spy = jasmine.createSpy('global mixed in lifecycle hook')
+    Vue.mixin({
+      created() {
+        spy()
+      }
+    })
+
+    const mixin1 = Vue.extend({
+      methods: {
+        a() {}
+      }
+    })
+
+    const mixin2 = Vue.extend({
+      mixins: [mixin1],
+    })
+
+    const Child = Vue.extend({
+      mixins: [mixin2],
+    })
+
+    const vm = new Child()
+
+    expect(typeof vm.$options.methods.a).toBe('function')
+    expect(spy.calls.count()).toBe(1)
+  })
 })


### PR DESCRIPTION
(#9198)

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
