### PR TITLE
refactor: introduce isProduction to judge env

### DIFF
--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -2,8 +2,8 @@
 
 import { genHandlers } from './events'
 import baseDirectives from '../directives/index'
-import { camelize, no, extend } from 'shared/util'
 import { baseWarn, pluckModuleFunction } from '../helpers'
+import { camelize, no, extend, isProduction } from 'shared/util'
 
 type TransformFunction = (el: ASTElement, code: string) => string;
 type DataGenFunction = (el: ASTElement) => string;
@@ -129,7 +129,7 @@ function genOnce (el: ASTElement, state: CodegenState): string {
       parent = parent.parent
     }
     if (!key) {
-      process.env.NODE_ENV !== 'production' && state.warn(
+      !isProduction && state.warn(
         `v-once can only be used inside v-for that is keyed. `
       )
       return genElement(el, state)
@@ -192,7 +192,7 @@ export function genFor (
   const iterator1 = el.iterator1 ? `,${el.iterator1}` : ''
   const iterator2 = el.iterator2 ? `,${el.iterator2}` : ''
 
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!isProduction &&
     state.maybeComponent(el) &&
     el.tag !== 'slot' &&
     el.tag !== 'template' &&
@@ -330,7 +330,7 @@ function genDirectives (el: ASTElement, state: CodegenState): string | void {
 
 function genInlineTemplate (el: ASTElement, state: CodegenState): ?string {
   const ast = el.children[0]
-  if (process.env.NODE_ENV !== 'production' && (
+  if (!isProduction && (
     el.children.length !== 1 || ast.type !== 1
   )) {
     state.warn('Inline-template components must have exactly one child element.')

--- a/src/compiler/create-compiler.js
+++ b/src/compiler/create-compiler.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import { extend } from 'shared/util'
 import { detectErrors } from './error-detector'
+import { extend, isProduction } from 'shared/util'
 import { createCompileToFunctionFn } from './to-function'
 
 export function createCompilerCreator (baseCompile: Function): Function {
@@ -39,7 +39,7 @@ export function createCompilerCreator (baseCompile: Function): Function {
       }
 
       const compiled = baseCompile(template, finalOptions)
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProduction) {
         errors.push.apply(errors, detectErrors(compiled.ast))
       }
       compiled.errors = errors

--- a/src/compiler/directives/on.js
+++ b/src/compiler/directives/on.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import { warn } from 'core/util/index'
+import { warn, isProduction } from 'core/util/index'
 
 export default function on (el: ASTElement, dir: ASTDirective) {
-  if (process.env.NODE_ENV !== 'production' && dir.modifiers) {
+  if (!isProduction && dir.modifiers) {
     warn(`v-on without argument does not support modifiers.`)
   }
   el.wrapListeners = (code: string) => `_g(${code},${dir.value})`

--- a/src/compiler/helpers.js
+++ b/src/compiler/helpers.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import { emptyObject } from 'shared/util'
 import { parseFilters } from './parser/filter-parser'
+import { emptyObject, isProduction } from 'shared/util'
 
 export function baseWarn (msg: string) {
   console.error(`[Vue compiler]: ${msg}`)
@@ -56,7 +56,7 @@ export function addHandler (
   // warn prevent and passive modifier
   /* istanbul ignore if */
   if (
-    process.env.NODE_ENV !== 'production' && warn &&
+    !isProduction && warn &&
     modifiers.prevent && modifiers.passive
   ) {
     warn(

--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -9,8 +9,8 @@
  * http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
  */
 
-import { makeMap, no } from 'shared/util'
 import { isNonPhrasingTag } from 'web/compiler/util'
+import { makeMap, no, isProduction } from 'shared/util'
 
 // Regular Expressions for parsing tags and attributes
 const attribute = /^\s*([^\s"'<>\/=]+)(?:\s*(=)\s*(?:"([^"]*)"+|'([^']*)'+|([^\s"'=<>`]+)))?/
@@ -166,7 +166,7 @@ export function parseHTML (html, options) {
 
     if (html === last) {
       options.chars && options.chars(html)
-      if (process.env.NODE_ENV !== 'production' && !stack.length && options.warn) {
+      if (!isProduction && !stack.length && options.warn) {
         options.warn(`Mal-formatted tag at end of template: "${html}"`)
       }
       break
@@ -264,7 +264,7 @@ export function parseHTML (html, options) {
     if (pos >= 0) {
       // Close all the open elements, up the stack
       for (let i = stack.length - 1; i >= pos; i--) {
-        if (process.env.NODE_ENV !== 'production' &&
+        if (!isProduction &&
           (i > pos || !tagName) &&
           options.warn
         ) {

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -5,8 +5,8 @@ import { parseHTML } from './html-parser'
 import { parseText } from './text-parser'
 import { parseFilters } from './filter-parser'
 import { genAssignmentCode } from '../directives/model'
-import { extend, cached, no, camelize } from 'shared/util'
 import { isIE, isEdge, isServerRendering } from 'core/util/env'
+import { extend, cached, no, camelize, isProduction } from 'shared/util'
 
 import {
   addProp,
@@ -132,7 +132,7 @@ export function parse (
 
       if (isForbiddenTag(element) && !isServerRendering()) {
         element.forbidden = true
-        process.env.NODE_ENV !== 'production' && warn(
+        !isProduction && warn(
           'Templates should only be responsible for mapping the state to the ' +
           'UI. Avoid placing tags with side-effects in your templates, such as ' +
           `<${tag}>` + ', as they will not be parsed.'
@@ -165,7 +165,7 @@ export function parse (
       }
 
       function checkRootConstraints (el) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!isProduction) {
           if (el.tag === 'slot' || el.tag === 'template') {
             warnOnce(
               `Cannot use <${el.tag}> as component root element because it may ` +
@@ -193,7 +193,7 @@ export function parse (
             exp: element.elseif,
             block: element
           })
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!isProduction) {
           warnOnce(
             `Component template should contain exactly one root element. ` +
             `If you are using v-if on multiple elements, ` +
@@ -236,7 +236,7 @@ export function parse (
 
     chars (text: string) {
       if (!currentParent) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!isProduction) {
           if (text === template) {
             warnOnce(
               'Component template requires a root element, rather than just text.'
@@ -331,7 +331,7 @@ export function processElement (element: ASTElement, options: CompilerOptions) {
 function processKey (el) {
   const exp = getBindingAttr(el, 'key')
   if (exp) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       if (el.tag === 'template') {
         warn(`<template> cannot be keyed. Place the key on real elements instead.`)
       }
@@ -364,7 +364,7 @@ export function processFor (el: ASTElement) {
     const res = parseFor(exp)
     if (res) {
       extend(el, res)
-    } else if (process.env.NODE_ENV !== 'production') {
+    } else if (!isProduction) {
       warn(
         `Invalid v-for expression: ${exp}`
       )
@@ -424,7 +424,7 @@ function processIfConditions (el, parent) {
       exp: el.elseif,
       block: el
     })
-  } else if (process.env.NODE_ENV !== 'production') {
+  } else if (!isProduction) {
     warn(
       `v-${el.elseif ? ('else-if="' + el.elseif + '"') : 'else'} ` +
       `used on element <${el.tag}> without corresponding v-if.`
@@ -438,7 +438,7 @@ function findPrevElement (children: Array<any>): ASTElement | void {
     if (children[i].type === 1) {
       return children[i]
     } else {
-      if (process.env.NODE_ENV !== 'production' && children[i].text !== ' ') {
+      if (!isProduction && children[i].text !== ' ') {
         warn(
           `text "${children[i].text.trim()}" between v-if and v-else(-if) ` +
           `will be ignored.`
@@ -466,7 +466,7 @@ function processOnce (el) {
 function processSlot (el) {
   if (el.tag === 'slot') {
     el.slotName = getBindingAttr(el, 'name')
-    if (process.env.NODE_ENV !== 'production' && el.key) {
+    if (!isProduction && el.key) {
       warn(
         `\`key\` does not work on <slot> because slots are abstract outlets ` +
         `and can possibly expand into multiple elements. ` +
@@ -478,7 +478,7 @@ function processSlot (el) {
     if (el.tag === 'template') {
       slotScope = getAndRemoveAttr(el, 'scope')
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && slotScope) {
+      if (!isProduction && slotScope) {
         warn(
           `the "scope" attribute for scoped slots have been deprecated and ` +
           `replaced by "slot-scope" since 2.5. The new "slot-scope" attribute ` +
@@ -490,7 +490,7 @@ function processSlot (el) {
       el.slotScope = slotScope || getAndRemoveAttr(el, 'slot-scope')
     } else if ((slotScope = getAndRemoveAttr(el, 'slot-scope'))) {
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && el.attrsMap['v-for']) {
+      if (!isProduction && el.attrsMap['v-for']) {
         warn(
           `Ambiguous combined usage of slot-scope and v-for on <${el.tag}> ` +
           `(v-for takes higher priority). Use a wrapper <template> for the ` +
@@ -541,7 +541,7 @@ function processAttrs (el) {
         value = parseFilters(value)
         isProp = false
         if (
-          process.env.NODE_ENV !== 'production' &&
+          !isProduction &&
           value.trim().length === 0
         ) {
           warn(
@@ -584,13 +584,13 @@ function processAttrs (el) {
           name = name.slice(0, -(arg.length + 1))
         }
         addDirective(el, name, rawName, value, arg, modifiers)
-        if (process.env.NODE_ENV !== 'production' && name === 'model') {
+        if (!isProduction && name === 'model') {
           checkForAliasModel(el, value)
         }
       }
     } else {
       // literal attribute
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProduction) {
         const res = parseText(value, delimiters)
         if (res) {
           warn(
@@ -637,7 +637,7 @@ function makeAttrsMap (attrs: Array<Object>): Object {
   const map = {}
   for (let i = 0, l = attrs.length; i < l; i++) {
     if (
-      process.env.NODE_ENV !== 'production' &&
+      !isProduction &&
       map[attrs[i].name] && !isIE && !isEdge
     ) {
       warn('duplicate attribute: ' + attrs[i].name)

--- a/src/compiler/to-function.js
+++ b/src/compiler/to-function.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import { noop, extend } from 'shared/util'
 import { warn as baseWarn, tip } from 'core/util/debug'
+import { noop, extend, isProduction } from 'shared/util'
 
 type CompiledFunctionResult = {
   render: Function;
@@ -30,7 +30,7 @@ export function createCompileToFunctionFn (compile: Function): Function {
     delete options.warn
 
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       // detect possible CSP restriction
       try {
         new Function('return 1')
@@ -59,7 +59,7 @@ export function createCompileToFunctionFn (compile: Function): Function {
     const compiled = compile(template, options)
 
     // check compilation errors/tips
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       if (compiled.errors && compiled.errors.length) {
         warn(
           `Error compiling template:\n\n${template}\n\n` +
@@ -84,7 +84,7 @@ export function createCompileToFunctionFn (compile: Function): Function {
     // this should only happen if there is a bug in the compiler itself.
     // mostly for codegen development use
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       if ((!compiled.errors || !compiled.errors.length) && fnGenErrors.length) {
         warn(
           `Failed to generate render function:\n\n` +

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -3,7 +3,8 @@
 import {
   no,
   noop,
-  identity
+  identity,
+  isProduction
 } from 'shared/util'
 
 import { LIFECYCLE_HOOKS } from 'shared/constants'
@@ -50,12 +51,12 @@ export default ({
   /**
    * Show production mode tip message on boot?
    */
-  productionTip: process.env.NODE_ENV !== 'production',
+  productionTip: !isProduction,
 
   /**
    * Whether to enable devtools
    */
-  devtools: process.env.NODE_ENV !== 'production',
+  devtools: !isProduction,
 
   /**
    * Whether to record perf

--- a/src/core/global-api/assets.js
+++ b/src/core/global-api/assets.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { ASSET_TYPES } from 'shared/constants'
-import { isPlainObject, validateComponentName } from '../util/index'
+import { isPlainObject, validateComponentName, isProduction } from '../util/index'
 
 export function initAssetRegisters (Vue: GlobalAPI) {
   /**
@@ -16,7 +16,7 @@ export function initAssetRegisters (Vue: GlobalAPI) {
         return this.options[type + 's'][id]
       } else {
         /* istanbul ignore if */
-        if (process.env.NODE_ENV !== 'production' && type === 'component') {
+        if (!isProduction && type === 'component') {
           validateComponentName(id)
         }
         if (type === 'component' && isPlainObject(definition)) {

--- a/src/core/global-api/extend.js
+++ b/src/core/global-api/extend.js
@@ -2,7 +2,7 @@
 
 import { ASSET_TYPES } from 'shared/constants'
 import { defineComputed, proxy } from '../instance/state'
-import { extend, mergeOptions, validateComponentName } from '../util/index'
+import { extend, mergeOptions, validateComponentName, isProduction } from '../util/index'
 
 export function initExtend (Vue: GlobalAPI) {
   /**
@@ -26,7 +26,7 @@ export function initExtend (Vue: GlobalAPI) {
     }
 
     const name = extendOptions.name || Super.options.name
-    if (process.env.NODE_ENV !== 'production' && name) {
+    if (!isProduction && name) {
       validateComponentName(name)
     }
 

--- a/src/core/global-api/index.js
+++ b/src/core/global-api/index.js
@@ -14,14 +14,15 @@ import {
   extend,
   nextTick,
   mergeOptions,
-  defineReactive
+  defineReactive,
+  isProduction
 } from '../util/index'
 
 export function initGlobalAPI (Vue: GlobalAPI) {
   // config
   const configDef = {}
   configDef.get = () => config
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     configDef.set = () => {
       warn(
         'Do not replace the Vue.config object, set individual fields instead.'

--- a/src/core/instance/events.js
+++ b/src/core/instance/events.js
@@ -5,6 +5,7 @@ import {
   toArray,
   hyphenate,
   handleError,
+  isProduction,
   formatComponentName
 } from '../util/index'
 import { updateListeners } from '../vdom/helpers/index'
@@ -117,7 +118,7 @@ export function eventsMixin (Vue: Class<Component>) {
 
   Vue.prototype.$emit = function (event: string): Component {
     const vm: Component = this
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       const lowerCaseEvent = event.toLowerCase()
       if (lowerCaseEvent !== event && vm._events[lowerCaseEvent]) {
         tip(

--- a/src/core/instance/index.js
+++ b/src/core/instance/index.js
@@ -1,3 +1,5 @@
+import { isProduction } from 'shared/util'
+
 import { initMixin } from './init'
 import { stateMixin } from './state'
 import { renderMixin } from './render'
@@ -6,7 +8,7 @@ import { lifecycleMixin } from './lifecycle'
 import { warn } from '../util/index'
 
 function Vue (options) {
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!isProduction &&
     !(this instanceof Vue)
   ) {
     warn('Vue is a constructor and should be called with the `new` keyword')

--- a/src/core/instance/init.js
+++ b/src/core/instance/init.js
@@ -8,7 +8,7 @@ import { initEvents } from './events'
 import { mark, measure } from '../util/perf'
 import { initLifecycle, callHook } from './lifecycle'
 import { initProvide, initInjections } from './inject'
-import { extend, mergeOptions, formatComponentName } from '../util/index'
+import { extend, mergeOptions, formatComponentName, isProduction } from '../util/index'
 
 let uid = 0
 
@@ -20,7 +20,7 @@ export function initMixin (Vue: Class<Component>) {
 
     let startTag, endTag
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+    if (!isProduction && config.performance && mark) {
       startTag = `vue-perf-start:${vm._uid}`
       endTag = `vue-perf-end:${vm._uid}`
       mark(startTag)
@@ -42,7 +42,7 @@ export function initMixin (Vue: Class<Component>) {
       )
     }
     /* istanbul ignore else */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       initProxy(vm)
     } else {
       vm._renderProxy = vm
@@ -59,7 +59,7 @@ export function initMixin (Vue: Class<Component>) {
     callHook(vm, 'created')
 
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+    if (!isProduction && config.performance && mark) {
       vm._name = formatComponentName(vm, false)
       mark(endTag)
       measure(`vue ${vm._name} init`, startTag, endTag)

--- a/src/core/instance/inject.js
+++ b/src/core/instance/inject.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-import { hasOwn } from 'shared/util'
-import { warn, hasSymbol } from '../util/index'
 import { defineReactive, toggleObserving } from '../observer/index'
+import { warn, hasOwn, hasSymbol, isProduction } from '../util/index'
 
 export function initProvide (vm: Component) {
   const provide = vm.$options.provide
@@ -19,7 +18,7 @@ export function initInjections (vm: Component) {
     toggleObserving(false)
     Object.keys(result).forEach(key => {
       /* istanbul ignore else */
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProduction) {
         defineReactive(vm, key, result[key], () => {
           warn(
             `Avoid mutating an injected value directly since the changes will be ` +
@@ -64,7 +63,7 @@ export function resolveInject (inject: any, vm: Component): ?Object {
           result[key] = typeof provideDefault === 'function'
             ? provideDefault.call(vm)
             : provideDefault
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!isProduction) {
           warn(`Injection "${key}" not found`, vm)
         }
       }

--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -15,7 +15,8 @@ import {
   remove,
   handleError,
   emptyObject,
-  validateProp
+  validateProp,
+  isProduction
 } from '../util/index'
 
 export let activeInstance: any = null
@@ -146,7 +147,7 @@ export function mountComponent (
   vm.$el = el
   if (!vm.$options.render) {
     vm.$options.render = createEmptyVNode
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       /* istanbul ignore if */
       if ((vm.$options.template && vm.$options.template.charAt(0) !== '#') ||
         vm.$options.el || el) {
@@ -168,7 +169,7 @@ export function mountComponent (
 
   let updateComponent
   /* istanbul ignore if */
-  if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+  if (!isProduction && config.performance && mark) {
     updateComponent = () => {
       const name = vm._name
       const id = vm._uid
@@ -219,7 +220,7 @@ export function updateChildComponent (
   parentVnode: MountedComponentVNode,
   renderChildren: ?Array<VNode>
 ) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     isUpdatingChildComponent = true
   }
 
@@ -273,7 +274,7 @@ export function updateChildComponent (
     vm.$forceUpdate()
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     isUpdatingChildComponent = false
   }
 }

--- a/src/core/instance/proxy.js
+++ b/src/core/instance/proxy.js
@@ -1,11 +1,11 @@
 /* not type checking this file because flow doesn't play well with Proxy */
 
 import config from 'core/config'
-import { warn, makeMap, isNative } from '../util/index'
+import { warn, makeMap, isNative, isProduction } from '../util/index'
 
 let initProxy
 
-if (process.env.NODE_ENV !== 'production') {
+if (!isProduction) {
   const allowedGlobals = makeMap(
     'Infinity,undefined,NaN,isFinite,isNaN,' +
     'parseFloat,parseInt,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,' +

--- a/src/core/instance/render-helpers/bind-object-listeners.js
+++ b/src/core/instance/render-helpers/bind-object-listeners.js
@@ -1,11 +1,12 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { warn, extend, isPlainObject } from 'core/util/index'
 
 export function bindObjectListeners (data: any, value: any): VNodeData {
   if (value) {
     if (!isPlainObject(value)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         'v-on without argument expects an Object value',
         this
       )

--- a/src/core/instance/render-helpers/bind-object-props.js
+++ b/src/core/instance/render-helpers/bind-object-props.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import config from 'core/config'
+import { isProduction } from 'shared/util'
 
 import {
   warn,
@@ -22,7 +23,7 @@ export function bindObjectProps (
 ): VNodeData {
   if (value) {
     if (!isObject(value)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         'v-bind without argument expects an Object or Array value',
         this
       )

--- a/src/core/instance/render-helpers/render-slot.js
+++ b/src/core/instance/render-helpers/render-slot.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { extend, warn, isObject } from 'core/util/index'
 
 /**
@@ -16,7 +17,7 @@ export function renderSlot (
   if (scopedSlotFn) { // scoped slot
     props = props || {}
     if (bindObject) {
-      if (process.env.NODE_ENV !== 'production' && !isObject(bindObject)) {
+      if (!isProduction && !isObject(bindObject)) {
         warn(
           'slot v-bind without argument expects an Object',
           this

--- a/src/core/instance/render.js
+++ b/src/core/instance/render.js
@@ -5,6 +5,7 @@ import {
   nextTick,
   emptyObject,
   handleError,
+  isProduction,
   defineReactive
 } from '../util/index'
 
@@ -37,7 +38,7 @@ export function initRender (vm: Component) {
   const parentData = parentVnode && parentVnode.data
 
   /* istanbul ignore else */
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     defineReactive(vm, '$attrs', parentData && parentData.attrs || emptyObject, () => {
       !isUpdatingChildComponent && warn(`$attrs is readonly.`, vm)
     }, true)
@@ -78,7 +79,7 @@ export function renderMixin (Vue: Class<Component>) {
       // return error render result,
       // or previous vnode to prevent render error causing blank component
       /* istanbul ignore else */
-      if (process.env.NODE_ENV !== 'production' && vm.$options.renderError) {
+      if (!isProduction && vm.$options.renderError) {
         try {
           vnode = vm.$options.renderError.call(vm._renderProxy, vm.$createElement, e)
         } catch (e) {
@@ -91,7 +92,7 @@ export function renderMixin (Vue: Class<Component>) {
     }
     // return empty vnode in case the render function errored out
     if (!(vnode instanceof VNode)) {
-      if (process.env.NODE_ENV !== 'production' && Array.isArray(vnode)) {
+      if (!isProduction && Array.isArray(vnode)) {
         warn(
           'Multiple root nodes returned from render function. Render function ' +
           'should return a single root node.',

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -23,6 +23,7 @@ import {
   handleError,
   nativeWatch,
   validateProp,
+  isProduction,
   isPlainObject,
   isServerRendering,
   isReservedAttribute
@@ -76,7 +77,7 @@ function initProps (vm: Component, propsOptions: Object) {
     keys.push(key)
     const value = validateProp(key, propsOptions, propsData, vm)
     /* istanbul ignore else */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       const hyphenatedKey = hyphenate(key)
       if (isReservedAttribute(hyphenatedKey) ||
           config.isReservedAttr(hyphenatedKey)) {
@@ -116,7 +117,7 @@ function initData (vm: Component) {
     : data || {}
   if (!isPlainObject(data)) {
     data = {}
-    process.env.NODE_ENV !== 'production' && warn(
+    !isProduction && warn(
       'data functions should return an object:\n' +
       'https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
       vm
@@ -129,7 +130,7 @@ function initData (vm: Component) {
   let i = keys.length
   while (i--) {
     const key = keys[i]
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       if (methods && hasOwn(methods, key)) {
         warn(
           `Method "${key}" has already been defined as a data property.`,
@@ -138,7 +139,7 @@ function initData (vm: Component) {
       }
     }
     if (props && hasOwn(props, key)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         `The data property "${key}" is already declared as a prop. ` +
         `Use prop default value instead.`,
         vm
@@ -175,7 +176,7 @@ function initComputed (vm: Component, computed: Object) {
   for (const key in computed) {
     const userDef = computed[key]
     const getter = typeof userDef === 'function' ? userDef : userDef.get
-    if (process.env.NODE_ENV !== 'production' && getter == null) {
+    if (!isProduction && getter == null) {
       warn(
         `Getter is missing for computed property "${key}".`,
         vm
@@ -197,7 +198,7 @@ function initComputed (vm: Component, computed: Object) {
     // at instantiation here.
     if (!(key in vm)) {
       defineComputed(vm, key, userDef)
-    } else if (process.env.NODE_ENV !== 'production') {
+    } else if (!isProduction) {
       if (key in vm.$data) {
         warn(`The computed property "${key}" is already defined in data.`, vm)
       } else if (vm.$options.props && key in vm.$options.props) {
@@ -226,7 +227,7 @@ export function defineComputed (
       : noop
     sharedPropertyDefinition.set = userDef.set || noop
   }
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!isProduction &&
       sharedPropertyDefinition.set === noop) {
     sharedPropertyDefinition.set = function () {
       warn(
@@ -262,7 +263,7 @@ function createGetterInvoker(fn) {
 function initMethods (vm: Component, methods: Object) {
   const props = vm.$options.props
   for (const key in methods) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       if (typeof methods[key] !== 'function') {
         warn(
           `Method "${key}" has type "${typeof methods[key]}" in the component definition. ` +
@@ -324,7 +325,7 @@ export function stateMixin (Vue: Class<Component>) {
   dataDef.get = function () { return this._data }
   const propsDef = {}
   propsDef.get = function () { return this._props }
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     dataDef.set = function () {
       warn(
         'Avoid replacing instance root $data. ' +

--- a/src/core/observer/dep.js
+++ b/src/core/observer/dep.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import type Watcher from './watcher'
 import { remove } from '../util/index'
 import config from '../config'
@@ -37,7 +39,7 @@ export default class Dep {
   notify () {
     // stabilize the subscriber list first
     const subs = this.subs.slice()
-    if (process.env.NODE_ENV !== 'production' && !config.async) {
+    if (!isProduction && !config.async) {
       // subs aren't sorted in scheduler if not running async
       // we need to sort them now to make sure they fire in correct
       // order

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -3,6 +3,7 @@
 import Dep from './dep'
 import VNode from '../vdom/vnode'
 import { arrayMethods } from './array'
+import { isProduction } from 'shared/util'
 import {
   def,
   warn,
@@ -177,7 +178,7 @@ export function defineReactive (
         return
       }
       /* eslint-enable no-self-compare */
-      if (process.env.NODE_ENV !== 'production' && customSetter) {
+      if (!isProduction && customSetter) {
         customSetter()
       }
       // #7981: for accessor properties without setter
@@ -199,7 +200,7 @@ export function defineReactive (
  * already exist.
  */
 export function set (target: Array<any> | Object, key: any, val: any): any {
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!isProduction &&
     (isUndef(target) || isPrimitive(target))
   ) {
     warn(`Cannot set reactive property on undefined, null, or primitive value: ${(target: any)}`)
@@ -215,7 +216,7 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
   }
   const ob = (target: any).__ob__
   if (target._isVue || (ob && ob.vmCount)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !isProduction && warn(
       'Avoid adding reactive properties to a Vue instance or its root $data ' +
       'at runtime - declare it upfront in the data option.'
     )
@@ -234,7 +235,7 @@ export function set (target: Array<any> | Object, key: any, val: any): any {
  * Delete a property and trigger change if necessary.
  */
 export function del (target: Array<any> | Object, key: any) {
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!isProduction &&
     (isUndef(target) || isPrimitive(target))
   ) {
     warn(`Cannot delete reactive property on undefined, null, or primitive value: ${(target: any)}`)
@@ -245,7 +246,7 @@ export function del (target: Array<any> | Object, key: any) {
   }
   const ob = (target: any).__ob__
   if (target._isVue || (ob && ob.vmCount)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !isProduction && warn(
       'Avoid deleting properties on a Vue instance or its root $data ' +
       '- just set it to null.'
     )

--- a/src/core/observer/scheduler.js
+++ b/src/core/observer/scheduler.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import type Watcher from './watcher'
 import config from '../config'
 import { callHook, activateChildComponent } from '../instance/lifecycle'
@@ -26,7 +28,7 @@ let index = 0
 function resetSchedulerState () {
   index = queue.length = activatedChildren.length = 0
   has = {}
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     circular = {}
   }
   waiting = flushing = false
@@ -60,7 +62,7 @@ function flushSchedulerQueue () {
     has[id] = null
     watcher.run()
     // in dev build, check and stop circular updates.
-    if (process.env.NODE_ENV !== 'production' && has[id] != null) {
+    if (!isProduction && has[id] != null) {
       circular[id] = (circular[id] || 0) + 1
       if (circular[id] > MAX_UPDATE_COUNT) {
         warn(
@@ -146,7 +148,7 @@ export function queueWatcher (watcher: Watcher) {
     if (!waiting) {
       waiting = true
 
-      if (process.env.NODE_ENV !== 'production' && !config.async) {
+      if (!isProduction && !config.async) {
         flushSchedulerQueue()
         return
       }

--- a/src/core/observer/watcher.js
+++ b/src/core/observer/watcher.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import {
   warn,
   remove,
@@ -72,7 +74,7 @@ export default class Watcher {
     this.newDeps = []
     this.depIds = new Set()
     this.newDepIds = new Set()
-    this.expression = process.env.NODE_ENV !== 'production'
+    this.expression = !isProduction
       ? expOrFn.toString()
       : ''
     // parse expression for getter
@@ -82,7 +84,7 @@ export default class Watcher {
       this.getter = parsePath(expOrFn)
       if (!this.getter) {
         this.getter = noop
-        process.env.NODE_ENV !== 'production' && warn(
+        !isProduction && warn(
           `Failed watching path: "${expOrFn}" ` +
           'Watcher only accepts simple dot-delimited paths. ' +
           'For full control, use a function instead.',

--- a/src/core/util/debug.js
+++ b/src/core/util/debug.js
@@ -1,14 +1,14 @@
 /* @flow */
 
 import config from '../config'
-import { noop } from 'shared/util'
+import { noop, isProduction } from 'shared/util'
 
 export let warn = noop
 export let tip = noop
 export let generateComponentTrace = (noop: any) // work around flow check
 export let formatComponentName = (noop: any)
 
-if (process.env.NODE_ENV !== 'production') {
+if (!isProduction) {
   const hasConsole = typeof console !== 'undefined'
   const classifyRE = /(?:^|[-_])(\w)/g
   const classify = str => str

--- a/src/core/util/error.js
+++ b/src/core/util/error.js
@@ -3,6 +3,7 @@
 import config from '../config'
 import { warn } from './debug'
 import { inBrowser, inWeex } from './env'
+import { isProduction } from 'shared/util'
 
 export function handleError (err: Error, vm: any, info: string) {
   if (vm) {
@@ -36,7 +37,7 @@ function globalHandleError (err, vm, info) {
 }
 
 function logError (err, vm, info) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     warn(`Error in ${info}: "${err.toString()}"`, vm)
   }
   /* istanbul ignore else */

--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -17,7 +17,8 @@ import {
   toRawType,
   capitalize,
   isBuiltInTag,
-  isPlainObject
+  isPlainObject,
+  isProduction
 } from 'shared/util'
 
 /**
@@ -30,7 +31,7 @@ const strats = config.optionMergeStrategies
 /**
  * Options with restrictions
  */
-if (process.env.NODE_ENV !== 'production') {
+if (!isProduction) {
   strats.el = strats.propsData = function (parent, child, vm, key) {
     if (!vm) {
       warn(
@@ -118,7 +119,7 @@ strats.data = function (
 ): ?Function {
   if (!vm) {
     if (childVal && typeof childVal !== 'function') {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         'The "data" option should be a function ' +
         'that returns a per-instance value in component ' +
         'definitions.',
@@ -168,7 +169,7 @@ function mergeAssets (
 ): Object {
   const res = Object.create(parentVal || null)
   if (childVal) {
-    process.env.NODE_ENV !== 'production' && assertObjectType(key, childVal, vm)
+    !isProduction && assertObjectType(key, childVal, vm)
     return extend(res, childVal)
   } else {
     return res
@@ -196,7 +197,7 @@ strats.watch = function (
   if (childVal === nativeWatch) childVal = undefined
   /* istanbul ignore if */
   if (!childVal) return Object.create(parentVal || null)
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     assertObjectType(key, childVal, vm)
   }
   if (!parentVal) return childVal
@@ -227,7 +228,7 @@ strats.computed = function (
   vm?: Component,
   key: string
 ): ?Object {
-  if (childVal && process.env.NODE_ENV !== 'production') {
+  if (childVal && !isProduction) {
     assertObjectType(key, childVal, vm)
   }
   if (!parentVal) return childVal
@@ -288,7 +289,7 @@ function normalizeProps (options: Object, vm: ?Component) {
       if (typeof val === 'string') {
         name = camelize(val)
         res[name] = { type: null }
-      } else if (process.env.NODE_ENV !== 'production') {
+      } else if (!isProduction) {
         warn('props must be strings when using array syntax.')
       }
     }
@@ -300,7 +301,7 @@ function normalizeProps (options: Object, vm: ?Component) {
         ? val
         : { type: val }
     }
-  } else if (process.env.NODE_ENV !== 'production') {
+  } else if (!isProduction) {
     warn(
       `Invalid value for option "props": expected an Array or an Object, ` +
       `but got ${toRawType(props)}.`,
@@ -328,7 +329,7 @@ function normalizeInject (options: Object, vm: ?Component) {
         ? extend({ from: key }, val)
         : { from: val }
     }
-  } else if (process.env.NODE_ENV !== 'production') {
+  } else if (!isProduction) {
     warn(
       `Invalid value for option "inject": expected an Array or an Object, ` +
       `but got ${toRawType(inject)}.`,
@@ -371,7 +372,7 @@ export function mergeOptions (
   child: Object,
   vm?: Component
 ): Object {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     checkComponents(child)
   }
 
@@ -382,7 +383,7 @@ export function mergeOptions (
   normalizeProps(child, vm)
   normalizeInject(child, vm)
   normalizeDirectives(child)
-  
+
   // Apply extends and mixins on the child options,
   // but only if it is a raw options object that isn't
   // the result of another mergeOptions call.
@@ -439,7 +440,7 @@ export function resolveAsset (
   if (hasOwn(assets, PascalCaseId)) return assets[PascalCaseId]
   // fallback to prototype chain
   const res = assets[id] || assets[camelizedId] || assets[PascalCaseId]
-  if (process.env.NODE_ENV !== 'production' && warnMissing && !res) {
+  if (!isProduction && warnMissing && !res) {
     warn(
       'Failed to resolve ' + type.slice(0, -1) + ': ' + id,
       options

--- a/src/core/util/perf.js
+++ b/src/core/util/perf.js
@@ -1,9 +1,10 @@
 import { inBrowser } from './env'
+import { isProduction } from 'shared/util'
 
 export let mark
 export let measure
 
-if (process.env.NODE_ENV !== 'production') {
+if (!isProduction) {
   const perf = inBrowser && window.performance
   /* istanbul ignore if */
   if (

--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -8,7 +8,8 @@ import {
   toRawType,
   hyphenate,
   capitalize,
-  isPlainObject
+  isPlainObject,
+  isProduction
 } from 'shared/util'
 
 type PropOptions = {
@@ -52,7 +53,7 @@ export function validateProp (
     toggleObserving(prevShouldObserve)
   }
   if (
-    process.env.NODE_ENV !== 'production' &&
+    !isProduction &&
     // skip validation for weex recycle-list child component props
     !(__WEEX__ && isObject(value) && ('@binding' in value))
   ) {
@@ -71,7 +72,7 @@ function getPropDefaultValue (vm: ?Component, prop: PropOptions, key: string): a
   }
   const def = prop.default
   // warn against non-factory defaults for Object & Array
-  if (process.env.NODE_ENV !== 'production' && isObject(def)) {
+  if (!isProduction && isObject(def)) {
     warn(
       'Invalid default value for prop "' + key + '": ' +
       'Props with type Object/Array must use a factory function ' +

--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import VNode from './vnode'
 import { resolveConstructorOptions } from 'core/instance/init'
 import { queueActivatedComponent } from 'core/observer/scheduler'
@@ -119,7 +121,7 @@ export function createComponent (
   // if at this stage it's not a constructor or an async component factory,
   // reject.
   if (typeof Ctor !== 'function') {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       warn(`Invalid Component definition: ${String(Ctor)}`, context)
     }
     return

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import config from '../config'
 import VNode, { createEmptyVNode } from './vnode'
 import { createComponent } from './create-component'
@@ -52,7 +54,7 @@ export function _createElement (
   normalizationType?: number
 ): VNode | Array<VNode> {
   if (isDef(data) && isDef((data: any).__ob__)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !isProduction && warn(
       `Avoid using observed data object as vnode data: ${JSON.stringify(data)}\n` +
       'Always create fresh vnode data objects in each render!',
       context
@@ -68,7 +70,7 @@ export function _createElement (
     return createEmptyVNode()
   }
   // warn against non-primitive key
-  if (process.env.NODE_ENV !== 'production' &&
+  if (!isProduction &&
     isDef(data) && isDef(data.key) && !isPrimitive(data.key)
   ) {
     if (!__WEEX__ || !('@binding' in data.key)) {

--- a/src/core/vdom/create-functional-component.js
+++ b/src/core/vdom/create-functional-component.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import VNode, { cloneVNode } from './vnode'
 import { createElement } from './create-element'
 import { resolveInject } from '../instance/inject'
@@ -123,7 +125,7 @@ function cloneAndMarkFunctionalResult (vnode, data, contextVm, options, renderCo
   const clone = cloneVNode(vnode)
   clone.fnContext = contextVm
   clone.fnOptions = options
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     (clone.devtoolsMeta = clone.devtoolsMeta || {}).renderContext = renderContext
   }
   if (data.slot) {

--- a/src/core/vdom/helpers/extract-props.js
+++ b/src/core/vdom/helpers/extract-props.js
@@ -8,6 +8,7 @@ import {
   hyphenate,
   formatComponentName
 } from 'core/util/index'
+import { isProduction } from 'shared/util'
 
 export function extractPropsFromVNodeData (
   data: VNodeData,
@@ -26,7 +27,7 @@ export function extractPropsFromVNodeData (
   if (isDef(attrs) || isDef(props)) {
     for (const key in propOptions) {
       const altKey = hyphenate(key)
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProduction) {
         const keyInLowerCase = key.toLowerCase()
         if (
           key !== keyInLowerCase &&

--- a/src/core/vdom/helpers/resolve-async-component.js
+++ b/src/core/vdom/helpers/resolve-async-component.js
@@ -10,6 +10,7 @@ import {
   hasSymbol
 } from 'core/util/index'
 
+import { isProduction } from 'shared/util'
 import { createEmptyVNode } from 'core/vdom/vnode'
 
 function ensureCtor (comp: any, base) {
@@ -82,7 +83,7 @@ export function resolveAsyncComponent (
     })
 
     const reject = once(reason => {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         `Failed to resolve async component: ${String(factory)}` +
         (reason ? `\nReason: ${reason}` : '')
       )
@@ -125,7 +126,7 @@ export function resolveAsyncComponent (
           setTimeout(() => {
             if (isUndef(factory.resolved)) {
               reject(
-                process.env.NODE_ENV !== 'production'
+                !isProduction
                   ? `timeout (${res.timeout}ms)`
                   : null
               )

--- a/src/core/vdom/helpers/update-listeners.js
+++ b/src/core/vdom/helpers/update-listeners.js
@@ -6,7 +6,8 @@ import {
   cached,
   isUndef,
   isTrue,
-  isPlainObject
+  isPlainObject,
+  isProduction
 } from 'shared/util'
 
 const normalizeEvent = cached((name: string): {
@@ -67,7 +68,7 @@ export function updateListeners (
       event.params = def.params
     }
     if (isUndef(cur)) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         `Invalid handler for event "${event.name}": got ` + String(cur),
         vm
       )

--- a/src/core/vdom/patch.js
+++ b/src/core/vdom/patch.js
@@ -10,6 +10,8 @@
  * of making flow understand it is not worth it.
  */
 
+import { isProduction } from 'shared/util'
+
 import VNode, { cloneVNode } from './vnode'
 import config from '../config'
 import { SSR_ATTR } from 'shared/constants'
@@ -149,7 +151,7 @@ export function createPatchFunction (backend) {
     const children = vnode.children
     const tag = vnode.tag
     if (isDef(tag)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProduction) {
         if (data && data.pre) {
           creatingElmInVPre++
         }
@@ -195,7 +197,7 @@ export function createPatchFunction (backend) {
         insert(parentElm, vnode.elm, refElm)
       }
 
-      if (process.env.NODE_ENV !== 'production' && data && data.pre) {
+      if (!isProduction && data && data.pre) {
         creatingElmInVPre--
       }
     } else if (isTrue(vnode.isComment)) {
@@ -283,7 +285,7 @@ export function createPatchFunction (backend) {
 
   function createChildren (vnode, children, insertedVnodeQueue) {
     if (Array.isArray(children)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProduction) {
         checkDuplicateKeys(children)
       }
       for (let i = 0; i < children.length; ++i) {
@@ -417,7 +419,7 @@ export function createPatchFunction (backend) {
     // during leaving transitions
     const canMove = !removeOnly
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       checkDuplicateKeys(newCh)
     }
 
@@ -555,7 +557,7 @@ export function createPatchFunction (backend) {
       if (isDef(oldCh) && isDef(ch)) {
         if (oldCh !== ch) updateChildren(elm, oldCh, ch, insertedVnodeQueue, removeOnly)
       } else if (isDef(ch)) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!isProduction) {
           checkDuplicateKeys(ch)
         }
         if (isDef(oldVnode.text)) nodeOps.setTextContent(elm, '')
@@ -604,7 +606,7 @@ export function createPatchFunction (backend) {
       return true
     }
     // assert node match
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       if (!assertNodeMatch(elm, vnode, inVPre)) {
         return false
       }
@@ -627,7 +629,7 @@ export function createPatchFunction (backend) {
           if (isDef(i = data) && isDef(i = i.domProps) && isDef(i = i.innerHTML)) {
             if (i !== elm.innerHTML) {
               /* istanbul ignore if */
-              if (process.env.NODE_ENV !== 'production' &&
+              if (!isProduction &&
                 typeof console !== 'undefined' &&
                 !hydrationBailed
               ) {
@@ -653,7 +655,7 @@ export function createPatchFunction (backend) {
             // longer than the virtual children list.
             if (!childrenMatch || childNode) {
               /* istanbul ignore if */
-              if (process.env.NODE_ENV !== 'production' &&
+              if (!isProduction &&
                 typeof console !== 'undefined' &&
                 !hydrationBailed
               ) {
@@ -728,7 +730,7 @@ export function createPatchFunction (backend) {
             if (hydrate(oldVnode, vnode, insertedVnodeQueue)) {
               invokeInsertHook(vnode, insertedVnodeQueue, true)
               return oldVnode
-            } else if (process.env.NODE_ENV !== 'production') {
+            } else if (!isProduction) {
               warn(
                 'The client-side rendered virtual DOM tree is not matching ' +
                 'server-rendered content. This is likely caused by incorrect ' +

--- a/src/platforms/web/compiler/directives/model.js
+++ b/src/platforms/web/compiler/directives/model.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import config from 'core/config'
+import { isProduction } from 'shared/util'
 import { addHandler, addProp, getBindingAttr } from 'compiler/helpers'
 import { genComponentModel, genAssignmentCode } from 'compiler/directives/model'
 
@@ -22,7 +23,7 @@ export default function model (
   const tag = el.tag
   const type = el.attrsMap.type
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     // inputs with type="file" are read only and setting the input's
     // value will throw an error.
     if (tag === 'input' && type === 'file') {
@@ -49,7 +50,7 @@ export default function model (
     genComponentModel(el, value, modifiers)
     // component v-model doesn't need extra runtime
     return false
-  } else if (process.env.NODE_ENV !== 'production') {
+  } else if (!isProduction) {
     warn(
       `<${el.tag} v-model="${value}">: ` +
       `v-model is not supported on this element type. ` +
@@ -131,7 +132,7 @@ function genDefaultModel (
 
   // warn if v-bind:value conflicts with v-model
   // except for inputs with v-bind:type
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     const value = el.attrsMap['v-bind:value'] || el.attrsMap[':value']
     const typeBinding = el.attrsMap['v-bind:type'] || el.attrsMap[':type']
     if (value && !typeBinding) {

--- a/src/platforms/web/compiler/modules/class.js
+++ b/src/platforms/web/compiler/modules/class.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { parseText } from 'compiler/parser/text-parser'
 import {
   getAndRemoveAttr,
@@ -10,7 +11,7 @@ import {
 function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticClass = getAndRemoveAttr(el, 'class')
-  if (process.env.NODE_ENV !== 'production' && staticClass) {
+  if (!isProduction && staticClass) {
     const res = parseText(staticClass, options.delimiters)
     if (res) {
       warn(

--- a/src/platforms/web/compiler/modules/style.js
+++ b/src/platforms/web/compiler/modules/style.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { parseText } from 'compiler/parser/text-parser'
 import { parseStyleText } from 'web/util/style'
 import {
@@ -13,7 +14,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
   const staticStyle = getAndRemoveAttr(el, 'style')
   if (staticStyle) {
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProduction) {
       const res = parseText(staticStyle, options.delimiters)
       if (res) {
         warn(

--- a/src/platforms/web/entry-runtime-with-compiler.js
+++ b/src/platforms/web/entry-runtime-with-compiler.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
+
 import config from 'core/config'
 import { warn, cached } from 'core/util/index'
 import { mark, measure } from 'core/util/perf'
@@ -23,7 +25,7 @@ Vue.prototype.$mount = function (
 
   /* istanbul ignore if */
   if (el === document.body || el === document.documentElement) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !isProduction && warn(
       `Do not mount Vue to <html> or <body> - mount to normal elements instead.`
     )
     return this
@@ -38,7 +40,7 @@ Vue.prototype.$mount = function (
         if (template.charAt(0) === '#') {
           template = idToTemplate(template)
           /* istanbul ignore if */
-          if (process.env.NODE_ENV !== 'production' && !template) {
+          if (!isProduction && !template) {
             warn(
               `Template element not found or is empty: ${options.template}`,
               this
@@ -48,7 +50,7 @@ Vue.prototype.$mount = function (
       } else if (template.nodeType) {
         template = template.innerHTML
       } else {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!isProduction) {
           warn('invalid template option:' + template, this)
         }
         return this
@@ -58,7 +60,7 @@ Vue.prototype.$mount = function (
     }
     if (template) {
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+      if (!isProduction && config.performance && mark) {
         mark('compile')
       }
 
@@ -72,7 +74,7 @@ Vue.prototype.$mount = function (
       options.staticRenderFns = staticRenderFns
 
       /* istanbul ignore if */
-      if (process.env.NODE_ENV !== 'production' && config.performance && mark) {
+      if (!isProduction && config.performance && mark) {
         mark('compile end')
         measure(`vue ${this._name} compile`, 'compile', 'compile end')
       }

--- a/src/platforms/web/runtime/components/transition-group.js
+++ b/src/platforms/web/runtime/components/transition-group.js
@@ -11,6 +11,7 @@
 // into the final desired state. This way in the second pass removed
 // nodes will remain where they should be.
 
+import { isProduction } from 'shared/util'
 import { warn, extend } from 'core/util/index'
 import { addClass, removeClass } from '../class-util'
 import { transitionProps, extractTransitionData } from './transition'
@@ -66,7 +67,7 @@ export default {
           children.push(c)
           map[c.key] = c
           ;(c.data || (c.data = {})).transition = transitionData
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!isProduction) {
           const opts: ?VNodeComponentOptions = c.componentOptions
           const name: string = opts ? (opts.Ctor.options.name || opts.tag || '') : c.tag
           warn(`<transition-group> children must be keyed: <${name}>`)

--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -4,7 +4,7 @@
 // supports transition mode (out-in / in-out)
 
 import { warn } from 'core/util/index'
-import { camelize, extend, isPrimitive } from 'shared/util'
+import { camelize, extend, isPrimitive, isProduction } from 'shared/util'
 import {
   mergeVNodeHook,
   isAsyncPlaceholder,
@@ -99,7 +99,7 @@ export default {
     }
 
     // warn multiple elements
-    if (process.env.NODE_ENV !== 'production' && children.length > 1) {
+    if (!isProduction && children.length > 1) {
       warn(
         '<transition> can only be used on a single element. Use ' +
         '<transition-group> for lists.',
@@ -110,7 +110,7 @@ export default {
     const mode: string = this.mode
 
     // warn invalid mode
-    if (process.env.NODE_ENV !== 'production' &&
+    if (!isProduction &&
       mode && mode !== 'in-out' && mode !== 'out-in'
     ) {
       warn(

--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -4,7 +4,7 @@
  */
 
 import { isTextInputType } from 'web/util/element'
-import { looseEqual, looseIndexOf } from 'shared/util'
+import { looseEqual, looseIndexOf, isProduction } from 'shared/util'
 import { mergeVNodeHook } from 'core/vdom/helpers/index'
 import { warn, isIE9, isIE, isEdge } from 'core/util/index'
 
@@ -86,7 +86,7 @@ function actuallySetSelected (el, binding, vm) {
   const value = binding.value
   const isMultiple = el.multiple
   if (isMultiple && !Array.isArray(value)) {
-    process.env.NODE_ENV !== 'production' && warn(
+    !isProduction && warn(
       `<select multiple v-model="${binding.expression}"> ` +
       `expects an Array value for its binding, but got ${
         Object.prototype.toString.call(value).slice(8, -1)

--- a/src/platforms/web/runtime/index.js
+++ b/src/platforms/web/runtime/index.js
@@ -2,7 +2,7 @@
 
 import Vue from 'core/index'
 import config from 'core/config'
-import { extend, noop } from 'shared/util'
+import { extend, noop, isProduction } from 'shared/util'
 import { mountComponent } from 'core/instance/lifecycle'
 import { devtools, inBrowser, isChrome } from 'core/util/index'
 
@@ -50,7 +50,7 @@ if (inBrowser) {
       if (devtools) {
         devtools.emit('init', Vue)
       } else if (
-        process.env.NODE_ENV !== 'production' &&
+        !isProduction &&
         process.env.NODE_ENV !== 'test' &&
         isChrome
       ) {
@@ -60,7 +60,7 @@ if (inBrowser) {
         )
       }
     }
-    if (process.env.NODE_ENV !== 'production' &&
+    if (!isProduction &&
       process.env.NODE_ENV !== 'test' &&
       config.productionTip !== false &&
       typeof console !== 'undefined'

--- a/src/platforms/web/runtime/modules/transition.js
+++ b/src/platforms/web/runtime/modules/transition.js
@@ -9,7 +9,8 @@ import {
   isDef,
   isUndef,
   isObject,
-  toNumber
+  toNumber,
+  isProduction
 } from 'shared/util'
 
 import {
@@ -105,7 +106,7 @@ export function enter (vnode: VNodeWithData, toggleDisplay: ?() => void) {
       : duration
   )
 
-  if (process.env.NODE_ENV !== 'production' && explicitEnterDuration != null) {
+  if (!isProduction && explicitEnterDuration != null) {
     checkDuration(explicitEnterDuration, 'enter', vnode)
   }
 
@@ -215,7 +216,7 @@ export function leave (vnode: VNodeWithData, rm: Function) {
       : duration
   )
 
-  if (process.env.NODE_ENV !== 'production' && isDef(explicitLeaveDuration)) {
+  if (!isProduction && isDef(explicitLeaveDuration)) {
     checkDuration(explicitLeaveDuration, 'leave', vnode)
   }
 

--- a/src/platforms/web/util/index.js
+++ b/src/platforms/web/util/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { warn } from 'core/util/index'
+import { isProduction } from 'shared/util'
 
 export * from './attrs'
 export * from './class'
@@ -13,7 +14,7 @@ export function query (el: string | Element): Element {
   if (typeof el === 'string') {
     const selected = document.querySelector(el)
     if (!selected) {
-      process.env.NODE_ENV !== 'production' && warn(
+      !isProduction && warn(
         'Cannot find element: ' + el
       )
       return document.createElement('div')

--- a/src/platforms/weex/compiler/modules/class.js
+++ b/src/platforms/weex/compiler/modules/class.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { parseText } from 'compiler/parser/text-parser'
 import {
   getAndRemoveAttr,
@@ -16,7 +17,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticClass = getAndRemoveAttr(el, 'class')
   const { dynamic, classResult } = parseStaticClass(staticClass, options)
-  if (process.env.NODE_ENV !== 'production' && dynamic && staticClass) {
+  if (!isProduction && dynamic && staticClass) {
     warn(
       `class="${staticClass}": ` +
       'Interpolation inside attributes has been deprecated. ' +

--- a/src/platforms/weex/compiler/modules/recycle-list/v-for.js
+++ b/src/platforms/weex/compiler/modules/recycle-list/v-for.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { parseFor } from 'compiler/parser/index'
 import { getAndRemoveAttr, addRawAttr } from 'compiler/helpers'
 
@@ -11,7 +12,7 @@ export function preTransformVFor (el: ASTElement, options: WeexCompilerOptions) 
 
   const res = parseFor(exp)
   if (!res) {
-    if (process.env.NODE_ENV !== 'production' && options.warn) {
+    if (!isProduction && options.warn) {
       options.warn(`Invalid v-for expression: ${exp}`)
     }
     return

--- a/src/platforms/weex/compiler/modules/recycle-list/v-if.js
+++ b/src/platforms/weex/compiler/modules/recycle-list/v-if.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { isProduction } from 'shared/util'
 import { addIfCondition } from 'compiler/parser/index'
 import { getAndRemoveAttr, addRawAttr } from 'compiler/helpers'
 
@@ -50,7 +51,7 @@ export function preTransformVIf (el: ASTElement, options: WeexCompilerOptions) {
         exp = elseifExp
           ? `!(${prevMatch}) && (${elseifExp})` // v-else-if
           : `!(${prevMatch})` // v-else
-      } else if (process.env.NODE_ENV !== 'production' && options.warn) {
+      } else if (!isProduction && options.warn) {
         options.warn(
           `v-${elseifExp ? ('else-if="' + elseifExp + '"') : 'else'} ` +
           `used on element <${el.tag}> without corresponding v-if.`

--- a/src/platforms/weex/compiler/modules/style.js
+++ b/src/platforms/weex/compiler/modules/style.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { cached, camelize, isPlainObject } from 'shared/util'
+import { cached, camelize, isPlainObject, isProduction } from 'shared/util'
 import { parseText } from 'compiler/parser/text-parser'
 import {
   getAndRemoveAttr,
@@ -19,7 +19,7 @@ function transformNode (el: ASTElement, options: CompilerOptions) {
   const warn = options.warn || baseWarn
   const staticStyle = getAndRemoveAttr(el, 'style')
   const { dynamic, styleResult } = parseStaticStyle(staticStyle, options)
-  if (process.env.NODE_ENV !== 'production' && dynamic) {
+  if (!isProduction && dynamic) {
     warn(
       `style="${String(staticStyle)}": ` +
       'Interpolation inside attributes has been deprecated. ' +

--- a/src/platforms/weex/runtime/components/transition-group.js
+++ b/src/platforms/weex/runtime/components/transition-group.js
@@ -1,3 +1,4 @@
+import { isProduction } from 'shared/util'
 import { warn, extend } from 'core/util/index'
 import { transitionProps, extractTransitionData } from './transition'
 
@@ -44,7 +45,7 @@ export default {
           children.push(c)
           map[c.key] = c
           ;(c.data || (c.data = {})).transition = transitionData
-        } else if (process.env.NODE_ENV !== 'production') {
+        } else if (!isProduction) {
           const opts = c.componentOptions
           const name = opts
             ? (opts.Ctor.options.name || opts.tag)

--- a/src/platforms/weex/runtime/modules/transition.js
+++ b/src/platforms/weex/runtime/modules/transition.js
@@ -1,5 +1,5 @@
 import { warn } from 'core/util/debug'
-import { extend, once, noop } from 'shared/util'
+import { extend, once, noop, isProduction } from 'shared/util'
 import { activeInstance } from 'core/instance/lifecycle'
 import { resolveTransition } from 'web/runtime/transition-util'
 
@@ -239,7 +239,7 @@ function getEnterTargetState (el, stylesheet, startClass, endClass, activeClass)
     for (const key in startState) {
       targetState[key] = el.style[key]
       if (
-        process.env.NODE_ENV !== 'production' &&
+        !isProduction &&
         targetState[key] == null &&
         (!activeState || activeState[key] == null) &&
         (!endState || endState[key] == null)

--- a/src/platforms/weex/runtime/recycle-list/virtual-component.js
+++ b/src/platforms/weex/runtime/recycle-list/virtual-component.js
@@ -2,6 +2,7 @@
 
 // https://github.com/Hanks10100/weex-native-directive/tree/master/component
 
+import { isProduction } from 'shared/util'
 import { mergeOptions, isPlainObject, noop } from 'core/util/index'
 import Watcher from 'core/observer/watcher'
 import { initProxy } from 'core/instance/proxy'
@@ -40,7 +41,7 @@ function initVirtualComponent (options: Object = {}) {
   }
 
   /* istanbul ignore else */
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProduction) {
     initProxy(vm)
   } else {
     vm._renderProxy = vm

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const serialize = require('serialize-javascript')
 
+import { isProduction } from 'shared/util'
 import { isJS, isCSS } from '../util'
 import TemplateStream from './template-stream'
 import { parseTemplate } from './parse-template'
@@ -195,7 +196,7 @@ export default class TemplateRenderer {
       windowKey = '__INITIAL_STATE__'
     } = options || {}
     const state = serialize(context[contextKey], { isJSON: true })
-    const autoRemove = process.env.NODE_ENV === 'production'
+    const autoRemove = isProduction
       ? ';(function(){var s;(s=document.currentScript||document.scripts[document.scripts.length-1]).parentNode.removeChild(s);}());'
       : ''
     return context[contextKey]

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -333,3 +333,8 @@ export function once (fn: Function): Function {
     }
   }
 }
+
+/**
+ * Check whether in production mode.
+ */
+export const isProduction = process.env.NODE_ENV === 'production'


### PR DESCRIPTION
Refactor: introduce `isProduction` to judge env for reusable.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
