### PR TITLE
lifecycle hooks, expose "this" typing to all of them

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -86,16 +86,16 @@ export interface ComponentOptions<
   staticRenderFns?: ((createElement: CreateElement) => VNode)[];
 
   beforeCreate?(this: V): void;
-  created?(): void;
-  beforeDestroy?(): void;
-  destroyed?(): void;
-  beforeMount?(): void;
-  mounted?(): void;
-  beforeUpdate?(): void;
-  updated?(): void;
-  activated?(): void;
-  deactivated?(): void;
-  errorCaptured?(err: Error, vm: Vue, info: string): boolean | void;
+  created?(this: V): void;
+  beforeDestroy?(this: V): void;
+  destroyed?(this: V): void;
+  beforeMount?(this: V): void;
+  mounted?(this: V): void;
+  beforeUpdate?(this: V): void;
+  updated?(this: V): void;
+  activated?(this: V): void;
+  deactivated?(this: V): void;
+  errorCaptured?(this: V, err: Error, vm: Vue, info: string): boolean | void;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };
   components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> };


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ X ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X ] No

**The PR fulfills these requirements:**

- [ X ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ X ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ X ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ X ] New/updated tests are included

**Other information:**
I am not sure why only `beforeCreate` has the "this" typing? Working on something that would benefit from all of the lifecycle hooks having the "this" typing, which is technically correct as well.

Did not see any actual type testing for this? So did not implement that.