### PR TITLE
[feature] allow template to be function in vue-server-renderer

### DIFF
--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -81,12 +81,12 @@ export function createRenderer ({
         return false
       }, cb)
       try {
-        render(component, write, context, err => {
+        render(component, write, context, async (err) => {
           if (context && context.rendered) {
             context.rendered(context)
           }
           if (template) {
-            result = templateRenderer.render(result, context)
+            result = await templateRenderer.render(result, context)
           }
           if (err) {
             cb(err)

--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -23,7 +23,7 @@ export type RenderOptions = {
   directives?: Object;
   isUnaryTag?: Function;
   cache?: RenderCache;
-  template?: string;
+  template?: string | Function;
   inject?: boolean;
   basedir?: string;
   shouldPreload?: Function;
@@ -81,12 +81,13 @@ export function createRenderer ({
         return false
       }, cb)
       try {
-        render(component, write, context, async (err) => {
+        render(component, write, context, err => {
           if (context && context.rendered) {
             context.rendered(context)
           }
           if (template) {
-            result = await templateRenderer.render(result, context)
+            new Promise(resolve => resolve(templateRenderer.render(result, context)))
+              .then(res => cb(res))
           }
           if (err) {
             cb(err)

--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -23,7 +23,7 @@ export type RenderOptions = {
   directives?: Object;
   isUnaryTag?: Function;
   cache?: RenderCache;
-  template?: string | (content: string, context: object) => string;
+  template?: string | (content: string, context: any) => string;
   inject?: boolean;
   basedir?: string;
   shouldPreload?: Function;

--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -23,7 +23,7 @@ export type RenderOptions = {
   directives?: Object;
   isUnaryTag?: Function;
   cache?: RenderCache;
-  template?: string | Function;
+  template?: string | (content: string, context: object) => string;
   inject?: boolean;
   basedir?: string;
   shouldPreload?: Function;
@@ -131,6 +131,8 @@ export function createRenderer ({
           })
         }
         return renderStream
+      } else if (typeof template === 'function') {
+        throw new Error(`function template is only supported in renderToString.`)
       } else {
         const templateStream = templateRenderer.createStream(context)
         renderStream.on('error', err => {

--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -86,7 +86,7 @@ export function createRenderer ({
             context.rendered(context)
           }
           if (template) {
-            result = templateRenderer.renderSync(result, context)
+            result = templateRenderer.render(result, context)
           }
           if (err) {
             cb(err)

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -11,7 +11,7 @@ import type { ParsedTemplate } from './parse-template'
 import type { AsyncFileMapper } from './create-async-file-mapper'
 
 type TemplateRendererOptions = {
-  template: ?string;
+  template?: string | Function;
   inject?: boolean;
   clientManifest?: ClientManifest;
   shouldPreload?: (file: string, type: string) => boolean;
@@ -93,7 +93,7 @@ export default class TemplateRenderer {
   }
 
   // render synchronously given rendered app content and render context
-  async render (content: string, context: ?Object) {
+  render (content: string, context: ?Object) {
     const template = this.parsedTemplate
     if (!template) {
       throw new Error('render cannot be called without a template.')

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -55,9 +55,13 @@ export default class TemplateRenderer {
     this.inject = options.inject !== false
     // if no template option is provided, the renderer is created
     // as a utility object for rendering assets like preload links and scripts.
-    this.parsedTemplate = options.template
-      ? parseTemplate(options.template)
-      : null
+    
+    let template = options.template
+  
+    this.parsedTemplate = template
+      ? typeof template === 'function'
+        ? template : parseTemplate(template)
+      : null;
 
     // function used to serialize initial state JSON
     this.serialize = options.serializer || (state => {
@@ -89,12 +93,16 @@ export default class TemplateRenderer {
   }
 
   // render synchronously given rendered app content and render context
-  renderSync (content: string, context: ?Object) {
+  async render (content: string, context: ?Object) {
     const template = this.parsedTemplate
     if (!template) {
-      throw new Error('renderSync cannot be called without a template.')
+      throw new Error('render cannot be called without a template.')
     }
     context = context || {}
+
+    //if the template is a function, just call the template and return
+    if(typeof template === 'function') return template(content, context)
+
     if (this.inject) {
       return (
         template.head(context) +

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -11,7 +11,7 @@ import type { ParsedTemplate } from './parse-template'
 import type { AsyncFileMapper } from './create-async-file-mapper'
 
 type TemplateRendererOptions = {
-  template?: string | Function;
+  template?: string | (content: string, context: any) => string;
   inject?: boolean;
   clientManifest?: ClientManifest;
   shouldPreload?: (file: string, type: string) => boolean;
@@ -42,7 +42,7 @@ type Resource = {
 export default class TemplateRenderer {
   options: TemplateRendererOptions;
   inject: boolean;
-  parsedTemplate: ParsedTemplate | null;
+  parsedTemplate: ParsedTemplate | Function | null;
   publicPath: string;
   clientManifest: ClientManifest;
   preloadFiles: Array<Resource>;
@@ -58,9 +58,9 @@ export default class TemplateRenderer {
     
     const { template } = options
     this.parsedTemplate = template
-      ? typeof template === 'function'
-        ? template
-        : parseTemplate(options.template)
+      ? typeof template === 'string'
+        ? parseTemplate(template)
+        : template
       : null
 
     // function used to serialize initial state JSON

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -56,12 +56,12 @@ export default class TemplateRenderer {
     // if no template option is provided, the renderer is created
     // as a utility object for rendering assets like preload links and scripts.
     
-    let template = options.template
-  
+    const { template } = options
     this.parsedTemplate = template
       ? typeof template === 'function'
-        ? template : parseTemplate(template)
-      : null;
+        ? template
+        : parseTemplate(options.template)
+      : null
 
     // function used to serialize initial state JSON
     this.serialize = options.serializer || (state => {
@@ -93,15 +93,16 @@ export default class TemplateRenderer {
   }
 
   // render synchronously given rendered app content and render context
-  render (content: string, context: ?Object) {
+  render (content: string, context: ?Object): string | Promise<string> {
     const template = this.parsedTemplate
     if (!template) {
       throw new Error('render cannot be called without a template.')
     }
     context = context || {}
 
-    //if the template is a function, just call the template and return
-    if(typeof template === 'function') return template(content, context)
+    if (typeof template === 'function') {
+      return template(content, context)
+    }
 
     if (this.inject) {
       return (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

@yyx990803 I've found a solution to #9205 

It's a very simple addition, to the `vue-server-renderer` package that has tonnes of use-cases and actually makes the `vue-server-renderer` much easier to use, as it provides a template function to the bundle renderer template compiler.

This isn't a breaking change and doesn't really need any tests, as it is a user-provided function

It would be amazing if this could be added in **2.6**, so I could use it in my package

### Use cases
1. Allows head management within `single file components` (see #9205)
2. Allows async functions within the `template` option
3. Makes the `vue-server-renderer` templater much easier to use, and allows users to use javascript interpolations. For example: `<!--vue-ssr-outlet-->` becomes `${result}`

#### Bonus
I'm creating a serverside rendering templating engine for **Vue** that will use this feature. It includes:
- A super simple head management system that exists entirely within the `<template>`, like native html
- full server-side rendering with Webpack
- CommonJS based, so users can easily implement it into koa/express projects
- templating using slots
- runtime compilation of Vue files (which are cached)

The package is aimed for users who want to start using Vue but want to keep express/koa routing which will make building serverside applications much easier for users, and will increase Vue adoption in the process