### PR TITLE
types: changed Vue.set and Vue.delete typings to use keyof

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -91,9 +91,9 @@ export interface VueConstructor<V extends Vue = Vue> {
 
   nextTick(callback: () => void, context?: any[]): void;
   nextTick(): Promise<void>
-  set<T>(object: object, key: string | number, value: T): T;
+  set<U extends {}, K extends keyof U>(object: U, key: K, value: U[K]): U[K];
   set<T>(array: T[], key: number, value: T): T;
-  delete(object: object, key: string | number): void;
+  delete<U extends {}>(object: U, key: keyof U): void;
   delete<T>(array: T[], key: number): void;
 
   directive(


### PR DESCRIPTION
Changed `Vue.set()` and `Vue.delete()` typings to prevent accidental index mismatch

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
TypeScript typings

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

This PR can break apps that use Vue.set/Vue.delete with incorrect types, but I wouldn't consider it to be a breaking change since the builds were already (unknowingly) broken before.
However, keys of type "string" may stop working without casting to a proper key type.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

While using `Vue.set()`, it was possible to update a non-existing field on an object, or pass an object of incorrect type as value and break everything.
I've changed `Vue.set()` and `Vue.delete()` declarations to better match their intent: now it can only be used with correct types.

Before:
```typescript
let obj = { height: 100 }
Vue.set(obj, "heigth", 50) // typo in the field name is ignored, obj becomes { height: 100, heigth: 50 }
console.log(obj.height) // still prints "100"
```
After:
```typescript
let obj = { height: 100 }
Vue.set(obj, "heigth", 50) // tsc error
```

Before:
```typescript
let obj: { width?: number } = { }
Vue.set(obj, "width", "0px") // field type is ignored, obj becomes { width: "0px" } while still typed as { width?: number }
if (typeof obj.width !== "undefined")
  obj.width.toFixed(10) // throws
```

After:
```typescript
let obj: { width?: number } = { }
Vue.set(obj, "width", "0px") // tsc error
```

I think that we can also remove the `Vue.set()`/`Vue.delete()` declarations with arrays, since `keyof` works on arrays as well.
This will become:
```typescript
export interface VueConstructor<V extends Vue = Vue> {
  // ...
  set<U, K extends keyof U>(objectOrArray: U, key: K, value: U[K]): U[K];
  delete<U>(objectOrArray: U, key: keyof U): void;
  // ...
}
```