### PR TITLE
Explicitly disable a transition by setting it to false (fix #9320)

### DIFF
--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -40,6 +40,15 @@ function getRealChild (vnode: ?VNode): ?VNode {
   }
 }
 
+function isAttrDisabled (k: string): boolean {
+  var data: Object = this;
+  const attr = data[camelize(k)]
+  return typeof attr == "undefined" ||
+         typeof attr !== "undefined" &&
+         (typeof attr === "boolean" && attr ||
+          typeof attr === "string" && attr == "false")
+}
+
 export function extractTransitionData (comp: Component): Object {
   const data = {}
   const options: ComponentOptions = comp.$options
@@ -49,9 +58,11 @@ export function extractTransitionData (comp: Component): Object {
   }
   // events.
   // extract listeners and pass them directly to the transition methods
-  const listeners: ?Object = options._parentListeners
-  for (const key in listeners) {
-    data[camelize(key)] = listeners[key]
+  const listeners: Object = options._parentListeners || {}
+  // remove the listeners that are explicitily disabled
+  const listenerKeys: Array<string> = Object.keys(listeners).filter(isAttrDisabled, data)
+  for (let i = 0; i < listenerKeys.length; i++) {
+    data[camelize(listenerKeys[i])] = listeners[listenerKeys[i]]
   }
   return data
 }

--- a/src/platforms/web/runtime/components/transition.js
+++ b/src/platforms/web/runtime/components/transition.js
@@ -40,13 +40,9 @@ function getRealChild (vnode: ?VNode): ?VNode {
   }
 }
 
-function isAttrDisabled (k: string): boolean {
-  var data: Object = this;
-  const attr = data[camelize(k)]
-  return typeof attr == "undefined" ||
-         typeof attr !== "undefined" &&
-         (typeof attr === "boolean" && attr ||
-          typeof attr === "string" && attr == "false")
+function activeAttr (k: string): boolean {
+  // assuming active if undefined
+  return this[camelize(k)] === undefined || this[camelize(k)] === true
 }
 
 export function extractTransitionData (comp: Component): Object {
@@ -60,7 +56,7 @@ export function extractTransitionData (comp: Component): Object {
   // extract listeners and pass them directly to the transition methods
   const listeners: Object = options._parentListeners || {}
   // remove the listeners that are explicitily disabled
-  const listenerKeys: Array<string> = Object.keys(listeners).filter(isAttrDisabled, data)
+  const listenerKeys: Array<string> = Object.keys(listeners).filter(activeAttr, data)
   for (let i = 0; i < listenerKeys.length; i++) {
     data[camelize(listenerKeys[i])] = listeners[listenerKeys[i]]
   }

--- a/test/unit/features/transition/transition.spec.js
+++ b/test/unit/features/transition/transition.spec.js
@@ -769,6 +769,30 @@ if (!isIE9) {
       }).then(done)
     })
 
+    it('appear: false', done => {
+      let next
+      const vm = new Vue({
+        template: `
+          <div>
+            <transition name="test" :appear="false" @appear="appear" >
+              <div v-if="ok" class="test">foo</div>
+            </transition>
+          </div>
+        `,
+        data: { ok: true },
+        methods: {
+          appear: (el, cb) => {
+            next = cb
+          }
+        }
+      }).$mount(el)
+
+      waitForUpdate(() => {
+        expect(vm.$el.children[0].className).toBe('test')
+        expect(next).toBeUndefined()
+      }).then(done)
+    })
+
     it('transition on SVG elements', done => {
       const vm = new Vue({
         template: `


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
With this change will be possible to set `appear` to `false` and disable it dynamically. fix #9320

### Appear set to false
![image](https://user-images.githubusercontent.com/4977614/51719568-16d42900-2031-11e9-9591-2a05321e4342.png)

### Appear defined but not set 
![image](https://user-images.githubusercontent.com/4977614/51719593-33706100-2031-11e9-85cb-230ea21333cb.png)

### Appear not defined
Notice that consider `appear` to be `False` when absent would require either a change for the corner case or a breaking change
![image](https://user-images.githubusercontent.com/4977614/51719626-53a02000-2031-11e9-9b47-2ffea06e9422.png)

