### PR TITLE
perf: improve scoped slots change detection accuracy

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -119,6 +119,7 @@ declare type ASTElement = {
   transitionMode?: string | null;
   slotName?: ?string;
   slotTarget?: ?string;
+  slotTargetDynamic?: boolean;
   slotScope?: ?string;
   scopedSlots?: { [name: string]: ASTElement };
 

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -354,11 +354,12 @@ function genScopedSlots (
   slots: { [key: string]: ASTElement },
   state: CodegenState
 ): string {
+  const hasDynamicKeys = Object.keys(slots).some(key => slots[key].slotTargetDynamic)
   return `scopedSlots:_u([${
     Object.keys(slots).map(key => {
       return genScopedSlot(key, slots[key], state)
     }).join(',')
-  }])`
+  }]${hasDynamicKeys ? `,true` : ``})`
 }
 
 function genScopedSlot (

--- a/src/core/instance/render-helpers/resolve-slots.js
+++ b/src/core/instance/render-helpers/resolve-slots.js
@@ -51,13 +51,14 @@ function isWhitespace (node: VNode): boolean {
 
 export function resolveScopedSlots (
   fns: ScopedSlotsData, // see flow/vnode
+  hasDynamicKeys?: boolean,
   res?: Object
-): { [key: string]: Function } {
-  res = res || {}
+): { [key: string]: Function, $stable: boolean } {
+  res = res || { $stable: !hasDynamicKeys }
   for (let i = 0; i < fns.length; i++) {
     const slot = fns[i]
     if (Array.isArray(slot)) {
-      resolveScopedSlots(slot, res)
+      resolveScopedSlots(slot, hasDynamicKeys, res)
     } else {
       res[slot.key] = slot.fn
     }

--- a/src/core/vdom/helpers/normalize-scoped-slots.js
+++ b/src/core/vdom/helpers/normalize-scoped-slots.js
@@ -14,7 +14,7 @@ export function normalizeScopedSlots (
   } else {
     res = {}
     for (const key in slots) {
-      if (slots[key]) {
+      if (slots[key] && key[0] !== '$') {
         res[key] = normalizeScopedSlot(slots[key])
       }
     }
@@ -26,6 +26,7 @@ export function normalizeScopedSlots (
     }
   }
   res._normalized = true
+  res.$stable = slots && slots.$stable
   return res
 }
 

--- a/test/unit/features/component/component-scoped-slot.spec.js
+++ b/test/unit/features/component/component-scoped-slot.spec.js
@@ -633,131 +633,69 @@ describe('Component scoped slot', () => {
   })
 
   // 2.6 new slot syntax
-  if (process.env.NEW_SLOT_SYNTAX) {
-    describe('v-slot syntax', () => {
-      const Foo = {
-        render(h) {
-          return h('div', [
-            this.$scopedSlots.default && this.$scopedSlots.default('from foo default'),
-            this.$scopedSlots.one && this.$scopedSlots.one('from foo one'),
-            this.$scopedSlots.two && this.$scopedSlots.two('from foo two')
-          ])
-        }
+  describe('v-slot syntax', () => {
+    const Foo = {
+      render(h) {
+        return h('div', [
+          this.$scopedSlots.default && this.$scopedSlots.default('from foo default'),
+          this.$scopedSlots.one && this.$scopedSlots.one('from foo one'),
+          this.$scopedSlots.two && this.$scopedSlots.two('from foo two')
+        ])
       }
+    }
 
-      const Bar = {
-        render(h) {
-          return this.$scopedSlots.default && this.$scopedSlots.default('from bar')
-        }
+    const Bar = {
+      render(h) {
+        return this.$scopedSlots.default && this.$scopedSlots.default('from bar')
       }
+    }
 
-      const Baz = {
-        render(h) {
-          return this.$scopedSlots.default && this.$scopedSlots.default('from baz')
-        }
+    const Baz = {
+      render(h) {
+        return this.$scopedSlots.default && this.$scopedSlots.default('from baz')
       }
+    }
 
-      const toNamed = (syntax, name) => syntax[0] === '#'
-        ? `#${name}` // shorthand
-        : `${syntax}:${name}` // full syntax
+    const toNamed = (syntax, name) => syntax[0] === '#'
+      ? `#${name}` // shorthand
+      : `${syntax}:${name}` // full syntax
 
-      function runSuite(syntax) {
-        it('default slot', () => {
-          const vm = new Vue({
-            template: `<foo ${syntax}="foo">{{ foo }}<div>{{ foo }}</div></foo>`,
-            components: { Foo }
-          }).$mount()
-          expect(vm.$el.innerHTML).toBe(`from foo default<div>from foo default</div>`)
-        })
+    function runSuite(syntax) {
+      it('default slot', () => {
+        const vm = new Vue({
+          template: `<foo ${syntax}="foo">{{ foo }}<div>{{ foo }}</div></foo>`,
+          components: { Foo }
+        }).$mount()
+        expect(vm.$el.innerHTML).toBe(`from foo default<div>from foo default</div>`)
+      })
 
-        it('nested default slots', () => {
-          const vm = new Vue({
-            template: `
-              <foo ${syntax}="foo">
-                <bar ${syntax}="bar">
-                  <baz ${syntax}="baz">
-                    {{ foo }} | {{ bar }} | {{ baz }}
-                  </baz>
-                </bar>
-              </foo>
-            `,
-            components: { Foo, Bar, Baz }
-          }).$mount()
-          expect(vm.$el.innerHTML.trim()).toBe(`from foo default | from bar | from baz`)
-        })
+      it('nested default slots', () => {
+        const vm = new Vue({
+          template: `
+            <foo ${syntax}="foo">
+              <bar ${syntax}="bar">
+                <baz ${syntax}="baz">
+                  {{ foo }} | {{ bar }} | {{ baz }}
+                </baz>
+              </bar>
+            </foo>
+          `,
+          components: { Foo, Bar, Baz }
+        }).$mount()
+        expect(vm.$el.innerHTML.trim()).toBe(`from foo default | from bar | from baz`)
+      })
 
-        it('named slots', () => {
-          const vm = new Vue({
-            template: `
-              <foo>
-                <template ${toNamed(syntax, 'default')}="foo">
-                  {{ foo }}
-                </template>
-                <template ${toNamed(syntax, 'one')}="one">
-                  {{ one }}
-                </template>
-                <template ${toNamed(syntax, 'two')}="two">
-                  {{ two }}
-                </template>
-              </foo>
-            `,
-            components: { Foo }
-          }).$mount()
-          expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo default from foo one from foo two`)
-        })
-
-        it('nested + named + default slots', () => {
-          const vm = new Vue({
-            template: `
-              <foo>
-                <template ${toNamed(syntax, 'one')}="one">
-                  <bar ${syntax}="bar">
-                    {{ one }} {{ bar }}
-                  </bar>
-                </template>
-                <template ${toNamed(syntax, 'two')}="two">
-                  <baz ${syntax}="baz">
-                    {{ two }} {{ baz }}
-                  </baz>
-                </template>
-              </foo>
-            `,
-            components: { Foo, Bar, Baz }
-          }).$mount()
-          expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo one from bar from foo two from baz`)
-        })
-
-        it('should warn v-slot usage on non-component elements', () => {
-          const vm = new Vue({
-            template: `<div ${syntax}="foo"/>`
-          }).$mount()
-          expect(`v-slot can only be used on components or <template>`).toHaveBeenWarned()
-        })
-
-        it('should warn mixed usage', () => {
-          const vm = new Vue({
-            template: `<foo><bar slot="one" slot-scope="bar" ${syntax}="bar"></bar></foo>`,
-            components: { Foo, Bar }
-          }).$mount()
-          expect(`Unexpected mixed usage of different slot syntaxes`).toHaveBeenWarned()
-        })
-      }
-
-      // run tests for both full syntax and shorthand
-      runSuite('v-slot')
-      runSuite('#default')
-
-      it('shorthand named slots', () => {
+      it('named slots', () => {
         const vm = new Vue({
           template: `
             <foo>
-              <template #default="foo">
+              <template ${toNamed(syntax, 'default')}="foo">
                 {{ foo }}
               </template>
-              <template #one="one">
+              <template ${toNamed(syntax, 'one')}="one">
                 {{ one }}
               </template>
-              <template #two="two">
+              <template ${toNamed(syntax, 'two')}="two">
                 {{ two }}
               </template>
             </foo>
@@ -767,62 +705,165 @@ describe('Component scoped slot', () => {
         expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo default from foo one from foo two`)
       })
 
-      it('should warn mixed root-default and named slots', () => {
+      it('nested + named + default slots', () => {
         const vm = new Vue({
           template: `
-            <foo #default="foo">
-              {{ foo }}
-              <template #one="one">
-                {{ one }}
+            <foo>
+              <template ${toNamed(syntax, 'one')}="one">
+                <bar ${syntax}="bar">
+                  {{ one }} {{ bar }}
+                </bar>
+              </template>
+              <template ${toNamed(syntax, 'two')}="two">
+                <baz ${syntax}="baz">
+                  {{ two }} {{ baz }}
+                </baz>
               </template>
             </foo>
           `,
-          components: { Foo }
+          components: { Foo, Bar, Baz }
         }).$mount()
-        expect(`default slot should also use <template>`).toHaveBeenWarned()
+        expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo one from bar from foo two from baz`)
       })
 
-      it('shorthand without scope variable', () => {
+      it('should warn v-slot usage on non-component elements', () => {
         const vm = new Vue({
-          template: `
-            <foo>
-              <template #one>one</template>
-              <template #two>two</template>
-            </foo>
-          `,
-          components: { Foo }
+          template: `<div ${syntax}="foo"/>`
         }).$mount()
-        expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`onetwo`)
+        expect(`v-slot can only be used on components or <template>`).toHaveBeenWarned()
       })
 
-      it('shorthand named slots on root', () => {
+      it('should warn mixed usage', () => {
         const vm = new Vue({
-          template: `
-            <foo #one="one">
+          template: `<foo><bar slot="one" slot-scope="bar" ${syntax}="bar"></bar></foo>`,
+          components: { Foo, Bar }
+        }).$mount()
+        expect(`Unexpected mixed usage of different slot syntaxes`).toHaveBeenWarned()
+      })
+    }
+
+    // run tests for both full syntax and shorthand
+    runSuite('v-slot')
+    runSuite('#default')
+
+    it('shorthand named slots', () => {
+      const vm = new Vue({
+        template: `
+          <foo>
+            <template #default="foo">
+              {{ foo }}
+            </template>
+            <template #one="one">
               {{ one }}
-            </foo>
-          `,
-          components: { Foo }
-        }).$mount()
-        expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo one`)
-      })
-
-      it('dynamic slot name', () => {
-        const vm = new Vue({
-          data: {
-            a: 'one',
-            b: 'two'
-          },
-          template: `
-            <foo>
-              <template #[a]="one">{{ one }} </template>
-              <template v-slot:[b]="two">{{ two }}</template>
-            </foo>
-          `,
-          components: { Foo }
-        }).$mount()
-        expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo one from foo two`)
-      })
+            </template>
+            <template #two="two">
+              {{ two }}
+            </template>
+          </foo>
+        `,
+        components: { Foo }
+      }).$mount()
+      expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo default from foo one from foo two`)
     })
-  }
+
+    it('should warn mixed root-default and named slots', () => {
+      const vm = new Vue({
+        template: `
+          <foo #default="foo">
+            {{ foo }}
+            <template #one="one">
+              {{ one }}
+            </template>
+          </foo>
+        `,
+        components: { Foo }
+      }).$mount()
+      expect(`default slot should also use <template>`).toHaveBeenWarned()
+    })
+
+    it('shorthand without scope variable', () => {
+      const vm = new Vue({
+        template: `
+          <foo>
+            <template #one>one</template>
+            <template #two>two</template>
+          </foo>
+        `,
+        components: { Foo }
+      }).$mount()
+      expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`onetwo`)
+    })
+
+    it('shorthand named slots on root', () => {
+      const vm = new Vue({
+        template: `
+          <foo #one="one">
+            {{ one }}
+          </foo>
+        `,
+        components: { Foo }
+      }).$mount()
+      expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`from foo one`)
+    })
+
+    it('dynamic slot name', done => {
+      const vm = new Vue({
+        data: {
+          a: 'one',
+          b: 'two'
+        },
+        template: `
+          <foo>
+            <template #[a]="one">a {{ one }} </template>
+            <template v-slot:[b]="two">b {{ two }} </template>
+          </foo>
+        `,
+        components: { Foo }
+      }).$mount()
+      expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`a from foo one b from foo two`)
+      vm.a = 'two'
+      vm.b = 'one'
+      waitForUpdate(() => {
+        expect(vm.$el.innerHTML.replace(/\s+/g, ' ')).toMatch(`b from foo one a from foo two `)
+      }).then(done)
+    })
+  })
+
+  // 2.6 scoped slot perf optimization
+  it('should have accurate tracking for scoped slots', done => {
+    const parentUpdate = jasmine.createSpy()
+    const childUpdate = jasmine.createSpy()
+    const vm = new Vue({
+      template: `
+        <div>{{ parentCount }}<foo #default>{{ childCount }}</foo></div>
+      `,
+      data: {
+        parentCount: 0,
+        childCount: 0
+      },
+      updated: parentUpdate,
+      components: {
+        foo: {
+          template: `<div><slot/></div>`,
+          updated: childUpdate
+        }
+      }
+    }).$mount()
+    expect(vm.$el.innerHTML).toMatch(`0<div>0</div>`)
+
+    vm.parentCount++
+    waitForUpdate(() => {
+      expect(vm.$el.innerHTML).toMatch(`1<div>0</div>`)
+      // should only trigger parent update
+      expect(parentUpdate.calls.count()).toBe(1)
+      expect(childUpdate.calls.count()).toBe(0)
+
+      vm.childCount++
+    }).then(() => {
+      expect(vm.$el.innerHTML).toMatch(`1<div>1</div>`)
+      // should only trigger child update
+      expect(parentUpdate.calls.count()).toBe(1)
+      expect(childUpdate.calls.count()).toBe(1)
+    }).then(done)
+  })
 })

--- a/test/unit/modules/compiler/codegen.spec.js
+++ b/test/unit/modules/compiler/codegen.spec.js
@@ -229,6 +229,13 @@ describe('codegen', () => {
     )
   })
 
+  it('generate dynamic scoped slot', () => {
+    assertCodegen(
+      '<foo><template :slot="foo" slot-scope="bar">{{ bar }}</template></foo>',
+      `with(this){return _c('foo',{scopedSlots:_u([{key:foo,fn:function(bar){return [_v(_s(bar))]}}],true)})}`
+    )
+  })
+
   it('generate scoped slot with multiline v-if', () => {
     assertCodegen(
       '<foo><template v-if="\nshow\n" slot-scope="bar">{{ bar }}</template></foo>',


### PR DESCRIPTION
Ensure that state mutations that only affect parent scope only trigger parent update and does not affect child components with only scoped slots.

Implications:

- For optimal performance, scoped slots should always be preferred. (In v3 all slots are unified to work like scoped slots so that will be the default)

- In 2.6, any slots using the new `v-slot` syntax are compiled as scopedSlots internally. This doesn't affect the child if it's using template, since `<slot/>` can render both scoped and normal slots, but if the child is using render functions, it is recommended to always use `this.$scopedSlots`. It is safe to do so in 2.6 since all normal slots are proxied on `this.$scopedSlots` as well.

- Unfortunately, any child components with static slot content still need to be forced updated. This means the common use case of `<parent><child></child></parent>` doesn't benefit from this change, unless the default slot is explicitly forced into a scoped slot by using `<parent v-slot:default><child></child></parent>`. (We cannot directly force all slots into scoped slots as that would break existing render function code that expects the slot to be present on `this.$slots` instead of `this.$scopedSlots)