### PR TITLE
feat(types): expose ElementAttributesProperty for TSX

### DIFF
--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -1,0 +1,25 @@
+import { VNodeData } from "./vnode";
+
+export type KnownAttrs = Pick<
+  VNodeData,
+  "class" | "staticClass" | "key" | "ref" | "slot"
+> & {
+  style?: VNodeData["style"] | string
+  id?: string
+  refInFor?: boolean
+  domPropsInnerHTML?: string
+};
+
+type OuterProps<Props, RequiredPropNames extends keyof Props> = {
+  [K in RequiredPropNames]: Props[K]
+} &
+  { [K in Exclude<keyof Props, RequiredPropNames>]?: Props[K] };
+
+/**
+ * `_attrs` is a special property for using Vue components as JSX elements.
+ * By passing `_attrs` to `JSX.ElementAttributesProperty`, your component's props are
+ * exposed as JSX elemnt properties.
+ */
+export type JSXElementAttributesProperty<Props, RequiredPropsNames extends keyof Props> = {
+  _attrs: KnownAttrs & OuterProps<Props, RequiredPropsNames>
+};

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -2,7 +2,7 @@ import { Vue, CreateElement, CombinedVueInstance } from "./vue";
 import { VNode, VNodeData, VNodeDirective, ScopedSlot } from "./vnode";
 
 type Constructor = {
-  new (...args: any[]): any;
+  new(...args: any[]): any;
 }
 
 // we don't support infer props in async component
@@ -60,9 +60,9 @@ export type ThisTypedComponentOptionsWithRecordProps<V extends Vue, Data, Method
   ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
   ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Props>>>;
 
-type DefaultData<V> =  object | ((this: V) => object);
+type DefaultData<V> = object | ((this: V) => object);
 type DefaultProps = Record<string, any>;
-type DefaultMethods<V> =  { [key: string]: (this: V, ...args: any[]) => any };
+type DefaultMethods<V> = { [key: string]: (this: V, ...args: any[]) => any };
 type DefaultComputed = { [key: string]: any };
 export interface ComponentOptions<
   V extends Vue,
@@ -143,6 +143,10 @@ export interface RenderContext<Props=DefaultProps> {
   scopedSlots: { [key: string]: ScopedSlot };
   injections: any
 }
+
+export type RequiredPropsNames<PropsDef> = {
+  [K in keyof PropsDef]: PropsDef[K] extends { required: true } ? K : never
+}[Extract<keyof PropsDef, string>];
 
 export type Prop<T> = { (): T } | { new(...args: any[]): T & object }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

# Descriptions
With current type definitions, it's extremely difficult for developers to pass props to children components when writing TSX since there's no exposed property that JSX can handle as element attributes properties.

![2019-01-27 22 45 39](https://user-images.githubusercontent.com/8381075/51801762-4e3b1380-2285-11e9-8262-18136c6afbe1.png)
 
This PullRequest achieves 2 things.
- Creates new property `_attrs` to the `ExtendedVue` type so it can be used inside `JSX.ElementAttributesProperty`.(Examples are below)
- Transform non-required props into optional properties of `props` interface.

## Example

Given these 2 children components...

```js
// PrimaryButton.tsx
import Vue from 'vue'

export default Vue.extend({
  name: 'Primary Button',
  props: {
    label: {
      type: String,
      required: true as true
    },
    color: String
  },
  computed: {
    style(): string {
      return `color: ${this.color || 'blue'};`
    }
  },
  render() {
    return <button style={this.style}>{this.label}</button>
  }
})
```

```js
// SecondaryButton.tsx
import Vue from 'vue'

export default Vue.extend({
  name: 'Secondary Button',
  props: ['color', 'label'],
  computed: {
    style(): string {
      return `color: ${this.color || 'blue'};`
    }
  },
  render() {
    return <button style={this.style}>{this.label}</button>
  }
})
```

and prepare `shims-tsx.d.ts` like this

```js
// shims-tsx.d.ts
import Vue, { VNode } from 'vue'

declare global {
  namespace JSX {
    interface Element extends VNode {}
    interface ElementClass extends Vue {}
    interface ElementAttributesProperty {
      _attrs: any
    }
    interface IntrinsicElements {
      [elem: string]: any
    }
  }
}
```

Property completion works as expected.

![2019-01-27 22 55 58](https://user-images.githubusercontent.com/8381075/51801907-2e0c5400-2287-11e9-95db-6d99dfa59ddb.png)

Type error warned as expected.

![2019-01-27 22 56 15](https://user-images.githubusercontent.com/8381075/51801908-2e0c5400-2287-11e9-8953-9f0357920edb.png)

and no more errors with correct props declaration 👍 

![2019-01-27 23 00 09](https://user-images.githubusercontent.com/8381075/51801914-52683080-2287-11e9-8b29-31700b54c77f.png)
