### PR TITLE
style does not work with zIndex (fix #9382)

### DIFF
--- a/src/platforms/web/runtime/modules/style.js
+++ b/src/platforms/web/runtime/modules/style.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { getStyle, normalizeStyleBinding } from 'web/util/style'
-import { cached, camelize, extend, isDef, isUndef } from 'shared/util'
+import { cached, camelize, extend, isDef, isUndef, hyphenate } from 'shared/util'
 
 const cssVarRE = /^--/
 const importantRE = /\s*!important$/
@@ -10,7 +10,7 @@ const setProp = (el, name, val) => {
   if (cssVarRE.test(name)) {
     el.style.setProperty(name, val)
   } else if (importantRE.test(val)) {
-    el.style.setProperty(name, val.replace(importantRE, ''), 'important')
+    el.style.setProperty(hyphenate(name), val.replace(importantRE, ''), 'important')
   } else {
     const normalizedName = normalize(name)
     if (Array.isArray(val)) {

--- a/test/unit/features/directives/style.spec.js
+++ b/test/unit/features/directives/style.spec.js
@@ -101,6 +101,13 @@ describe('Directive v-bind:style', () => {
     }).then(done)
   })
 
+  it('camelCase with !important', done => {
+    vm.styles = { zIndex: '100 !important' }
+    waitForUpdate(() => {
+      expect(vm.$el.style.getPropertyPriority('z-index')).toBe('important')
+    }).then(done)
+  })
+
   it('object with multiple entries', done => {
     vm.$el.style.color = 'red'
     vm.styles = {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The [documentation](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty#Parameters) states that the first parameter for `setProperty` must be hyphenated.

closes #9382