### PR TITLE
chore: add `repository.directory` field to each `package.json`

### DIFF
--- a/packages/vue-server-renderer/package.json
+++ b/packages/vue-server-renderer/package.json
@@ -6,7 +6,8 @@
   "types": "types/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue.git"
+    "url": "git+https://github.com/vuejs/vue.git",
+    "directory": "packages/vue-server-renderer"
   },
   "keywords": [
     "vue",

--- a/packages/vue-template-compiler/package.json
+++ b/packages/vue-template-compiler/package.json
@@ -9,7 +9,8 @@
   "types": "types/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue.git"
+    "url": "git+https://github.com/vuejs/vue.git",
+    "directory": "packages/vue-template-compiler"
   },
   "keywords": [
     "vue",

--- a/packages/weex-template-compiler/package.json
+++ b/packages/weex-template-compiler/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue.git"
+    "url": "git+https://github.com/vuejs/vue.git",
+    "directory": "packages/weex-template-compiler"
   },
   "keywords": [
     "vue",

--- a/packages/weex-vue-framework/package.json
+++ b/packages/weex-vue-framework/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue.git"
+    "url": "git+https://github.com/vuejs/vue.git",
+    "directory": "packages/weex-vue-framework"
   },
   "keywords": [
     "vue",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

I created a similar PR in `vue-cli` repo, so I will just copy&paste my comment here:
> This field allows you specify path of each package in a monorepo thanks to this npm RFC. Main benefit of providing this field is a more accurate link to the package's source code from its npmjs.com page.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
