### PR TITLE
feat(ssr): add ability to cleanup after request

### DIFF
--- a/src/server/bundle-renderer/create-bundle-renderer.js
+++ b/src/server/bundle-renderer/create-bundle-renderer.js
@@ -28,6 +28,10 @@ type RenderBundle = {
   modules?: { [filename: string]: Array<string> };
 };
 
+function getRenderArguments(app) {
+  return app && app._isVue ? { app, onComplete: null } : app
+}
+
 export function createBundleRendererCreator (
   createRenderer: (options?: RenderOptions) => Renderer
 ) {
@@ -100,12 +104,16 @@ export function createBundleRendererCreator (
         run(context).catch(err => {
           rewriteErrorTrace(err, maps)
           cb(err)
-        }).then(app => {
+        }).then(args => {
+          const { app, onRequestComplete } = getRenderArguments(args)
           if (app) {
             renderer.renderToString(app, context, (err, res) => {
               rewriteErrorTrace(err, maps)
+              onRequestComplete && onRequestComplete()
               cb(err, res)
             })
+          } else {
+            onRequestComplete && onRequestComplete()
           }
         })
 
@@ -121,7 +129,8 @@ export function createBundleRendererCreator (
           process.nextTick(() => {
             res.emit('error', err)
           })
-        }).then(app => {
+        }).then(args => {
+          const { app, onComplete } = getRenderArguments(args)
           if (app) {
             const renderStream = renderer.renderToStream(app, context)
 
@@ -140,7 +149,15 @@ export function createBundleRendererCreator (
               })
             }
 
+            if (onComplete) {
+              renderStream.on('end', () => {
+                onComplete()
+              })
+            }
+
             renderStream.pipe(res)
+          } else {
+            onComplete && onComplete()
           }
         })
 

--- a/test/ssr/fixtures/app-callback.js
+++ b/test/ssr/fixtures/app-callback.js
@@ -1,0 +1,13 @@
+import Vue from '../../../dist/vue.runtime.common.js'
+
+export default context => {
+  return new Promise(resolve => {
+    const app = new Vue({
+      render (h) {
+        return h('div', context.url)
+      }
+    })
+    const onComplete = () => { context.msg = 'hello' }
+    resolve({ app, onComplete })
+  })
+}

--- a/test/ssr/fixtures/split-callback.js
+++ b/test/ssr/fixtures/split-callback.js
@@ -1,0 +1,27 @@
+import Vue from '../../../dist/vue.runtime.common.js'
+
+// async component!
+const Foo = () => import('./async-foo')
+const Bar = () => import('./async-bar') // eslint-disable-line
+
+export default context => {
+  return new Promise(resolve => {
+    const vm = new Vue({
+      render (h) {
+        return h('div', [
+          context.url,
+          h(Foo)
+        ])
+      }
+    })
+
+    const onComplete = () => { context.msg = 'hello' }
+
+    // simulate router.onReady
+    Foo().then(comp => {
+      // resolve now to make the render sync
+      Foo.resolved = Vue.extend(comp.default)
+      resolve({ app: vm, onComplete })
+    })
+  })
+}

--- a/test/ssr/ssr-bundle-render.spec.js
+++ b/test/ssr/ssr-bundle-render.spec.js
@@ -66,6 +66,33 @@ function createAssertions (runInNewContext) {
     })
   })
 
+  it('renderToString with callback', done => {
+    createRenderer('app-callback.js', { runInNewContext }, renderer => {
+      const context = { url: '/test' }
+      renderer.renderToString(context, (err, res) => {
+        expect(res).toBe('<div data-server-rendered="true">/test</div>')
+        expect(context.msg).toBe('hello')
+        done()
+      })
+    })
+  })
+
+  it('renderToStream with callback', done => {
+    createRenderer('app-callback.js', { runInNewContext }, renderer => {
+      const context = { url: '/test' }
+      const stream = renderer.renderToStream(context)
+      let res = ''
+      stream.on('data', chunk => {
+        res += chunk.toString()
+      })
+      stream.on('end', () => {
+        expect(res).toBe('<div data-server-rendered="true">/test</div>')
+        expect(context.msg).toBe('hello')
+        done()
+      })
+    })
+  })
+
   it('renderToString catch error', done => {
     createRenderer('error.js', { runInNewContext }, renderer => {
       renderer.renderToString(err => {
@@ -295,6 +322,34 @@ function createAssertions (runInNewContext) {
     })
   })
 
+  it('renderToString with callback (bundle format with code split)', done => {
+    createRenderer('split-callback.js', { runInNewContext, asBundle: true }, renderer => {
+      const context = { url: '/test' }
+      renderer.renderToString(context, (err, res) => {
+        expect(err).toBeNull()
+        expect(res).toBe('<div data-server-rendered="true">/test<div>async test.woff2 test.png</div></div>')
+        expect(context.msg).toBe('hello')
+        done()
+      })
+    })
+  })
+
+  it('renderToStream with callback (bundle format with code split)', done => {
+    createRenderer('split-callback.js', { runInNewContext, asBundle: true }, renderer => {
+      const context = { url: '/test' }
+      const stream = renderer.renderToStream(context)
+      let res = ''
+      stream.on('data', chunk => {
+        res += chunk.toString()
+      })
+      stream.on('end', () => {
+        expect(res).toBe('<div data-server-rendered="true">/test<div>async test.woff2 test.png</div></div>')
+        expect(context.msg).toBe('hello')
+        done()
+      })
+    })
+  })
+
   it('renderToString catch error (bundle format with source map)', done => {
     createRenderer('error.js', { runInNewContext, asBundle: true }, renderer => {
       renderer.renderToString(err => {
@@ -318,6 +373,17 @@ function createAssertions (runInNewContext) {
 
   it('renderToString return Promise', done => {
     createRenderer('app.js', { runInNewContext }, renderer => {
+      const context = { url: '/test' }
+      renderer.renderToString(context).then(res => {
+        expect(res).toBe('<div data-server-rendered="true">/test</div>')
+        expect(context.msg).toBe('hello')
+        done()
+      })
+    })
+  })
+
+  it('renderToString return Promise (callback)', done => {
+    createRenderer('app-callback.js', { runInNewContext }, renderer => {
       const context = { url: '/test' }
       renderer.renderToString(context).then(res => {
         expect(res).toBe('<div data-server-rendered="true">/test</div>')


### PR DESCRIPTION
close #9463

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The point of this "feature" is to be able to do something to the `app` to mark it as "invalid" so that `vue-router` has a way to detect and cleanup objects it might have left hanging around in memory. This feature might be able to be used for other reasons, but it is probably truly a fix. Also, a change would need to be approved in `vue-router` as well for the memory leak there to even go away (see https://github.com/vuejs/vue-router/issues/2606), and that might get fixed by other means, so this might not be worth doing anything with if that doesn't also get approved.

Because we're is in control of when the app is created in SSR it didn't seem like there was any other sensible option but to give us control of when to clean it up, though maybe something can be done based on `runInNewContext`. Also, maybe a more explicit API would be better, e.g. some way to mark the app as "served", `$isServer && $isServed`.

Note I'm submitting this knowing that there is a good chance that this will be tossed, so feel free to do so if this is not what is wanted.