### PR TITLE
bugfix: adds ts context this: V for ComponentOptions hooks

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -85,17 +85,17 @@ export interface ComponentOptions<
   renderError?(createElement: CreateElement, err: Error): VNode;
   staticRenderFns?: ((createElement: CreateElement) => VNode)[];
 
-  beforeCreate?(this: V): void;
-  created?(): void;
-  beforeDestroy?(): void;
-  destroyed?(): void;
-  beforeMount?(): void;
-  mounted?(): void;
-  beforeUpdate?(): void;
-  updated?(): void;
-  activated?(): void;
-  deactivated?(): void;
-  errorCaptured?(err: Error, vm: Vue, info: string): boolean | void;
+  beforeCreate?(): void;
+  created?(this: V): void;
+  beforeDestroy?(this: V): void;
+  destroyed?(this: V): void;
+  beforeMount?(this: V): void;
+  mounted?(this: V): void;
+  beforeUpdate?(this: V): void;
+  updated?(this: V): void;
+  activated?(this: V): void;
+  deactivated?(this: V): void;
+  errorCaptured?(this: V, err: Error, vm: Vue, info: string): boolean | void;
   serverPrefetch?(this: V): Promise<void>;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

```vue
<template>
  <div> ... </div>
</template>

<script lang="ts">
import { Component, Vue } from 'vue-property-decorator';

// NOTE: <MyComponent>
@Component<MyComponent>({
  created() {
    this.myFunction();  // Error: Property 'myFunction' does not exist on type 'Vue'
  },

  // NOTE: this: MyComponent
  beforeDestroy(this: MyComponent) {
    this.myFunction();  // success
  },
})
export default class MyComponent extends Vue {
  public myFunction() {
    // ...
  }
}
</script>
```