### PR TITLE
fix(#9511): avoid promise catch multiple times

### DIFF
--- a/src/core/util/error.js
+++ b/src/core/util/error.js
@@ -36,7 +36,9 @@ export function invokeWithErrorHandling (
   try {
     res = args ? handler.apply(context, args) : handler.call(context)
     if (res && !res._isVue && isPromise(res)) {
-      res.catch(e => handleError(e, vm, info + ` (Promise/async)`))
+      // issue #9511
+      // reassign to res to avoid catch triggering multiple times when nested calls
+      res = res.catch(e => handleError(e, vm, info + ` (Promise/async)`))
     }
   } catch (e) {
     handleError(e, vm, info)

--- a/test/unit/modules/util/invoke-with-error-handling.spec.js
+++ b/test/unit/modules/util/invoke-with-error-handling.spec.js
@@ -1,0 +1,23 @@
+import Vue from 'vue'
+import { invokeWithErrorHandling } from 'core/util/error'
+
+describe('invokeWithErrorHandling', () => {
+  if (typeof Promise !== 'undefined') {
+    it('nested calls do not trigger multiple errorHandler calls', done => {
+      let times = 0
+
+      Vue.config.errorHandler = function () {
+        times++
+      }
+
+      invokeWithErrorHandling(() => {
+        return invokeWithErrorHandling(() => {
+          return Promise.reject(new Error('fake error'))
+        })
+      }).catch(() => {
+        expect(times).toBe(1)
+        done()
+      })
+    })
+  }
+})

--- a/test/unit/modules/util/invoke-with-error-handling.spec.js
+++ b/test/unit/modules/util/invoke-with-error-handling.spec.js
@@ -3,7 +3,7 @@ import { invokeWithErrorHandling } from 'core/util/error'
 
 describe('invokeWithErrorHandling', () => {
   if (typeof Promise !== 'undefined') {
-    it('nested calls do not trigger multiple errorHandler calls', done => {
+    it('should errorHandler call once when nested calls return rejected promise', done => {
       let times = 0
 
       Vue.config.errorHandler = function () {
@@ -14,7 +14,7 @@ describe('invokeWithErrorHandling', () => {
         return invokeWithErrorHandling(() => {
           return Promise.reject(new Error('fake error'))
         })
-      }).catch(() => {
+      }).then(() => {
         expect(times).toBe(1)
         done()
       })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
fixed #9511 

In some cases, invokeWithErrorHandling will have nested calls, and Promise will independently catch multiple times, resulting in multiple calls to handleError.

Look at a sample code：

``` javascript
var p = Promise.reject('some err');

p.catch(() => console.log('1'));  // p = p.catch(...)
p.catch(() => console.log('2'));
```
The above code will output 1 and 2, but if you reassign the first catch call to p, it will not output 2.