### PR TITLE
fix #9571, rendering async components after initial context was destroyed

### DIFF
--- a/src/core/vdom/helpers/resolve-async-component.js
+++ b/src/core/vdom/helpers/resolve-async-component.js
@@ -66,7 +66,7 @@ export function resolveAsyncComponent (
     const owners = factory.owners = [owner]
     let sync = true
  
-    ;(owner: any).$on('hook:destroyed', () => remove(owners, owner))
+    if (owner) owner.$on('hook:destroyed', () => remove(owners, owner))
 
     const forceRender = (renderCompleted: boolean) => {
       for (let i = 0, l = owners.length; i < l; i++) {

--- a/src/core/vdom/helpers/resolve-async-component.js
+++ b/src/core/vdom/helpers/resolve-async-component.js
@@ -8,7 +8,8 @@ import {
   isTrue,
   isObject,
   hasSymbol,
-  isPromise
+  isPromise,
+  remove
 } from 'core/util/index'
 
 import { createEmptyVNode } from 'core/vdom/vnode'
@@ -64,13 +65,8 @@ export function resolveAsyncComponent (
   if (!isDef(factory.owners)) {
     const owners = factory.owners = [owner]
     let sync = true
-
-    const removeOwner = (destroyedOwner) => {
-      const index = owners.indexOf(destroyedOwner)
-      if (index > -1) owners.splice(index, 1)
-    }
-
-    if (owner) owner.$on('hook:destroyed', () => removeOwner(owner))
+ 
+    ;(owner: any).$on('hook:destroyed', () => remove(owners, owner))
 
     const forceRender = (renderCompleted: boolean) => {
       for (let i = 0, l = owners.length; i < l; i++) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
- [ ] Maybe (I'm not sure)

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I have not heavily tested this in a lot of circumstances. The async part of it almost broke my brain ^^ But tests are passing, so... ¯\_(ツ)_/¯