### PR TITLE
feat(global-api): warn when plugin is invalid

### DIFF
--- a/src/core/global-api/use.js
+++ b/src/core/global-api/use.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { toArray } from '../util/index'
+import { toArray, warn } from '../util/index'
 
 export function initUse (Vue: GlobalAPI) {
   Vue.use = function (plugin: Function | Object) {
@@ -12,10 +12,14 @@ export function initUse (Vue: GlobalAPI) {
     // additional parameters
     const args = toArray(arguments, 1)
     args.unshift(this)
-    if (typeof plugin.install === 'function') {
+    if (plugin && typeof plugin.install === 'function') {
       plugin.install.apply(plugin, args)
     } else if (typeof plugin === 'function') {
       plugin.apply(null, args)
+    } else if (process.env.NODE_ENV !== 'production') {
+      warn(
+        'Plugin should be either function or object with install method.'
+      )
     }
     installedPlugins.push(plugin)
     return this

--- a/test/unit/features/global-api/use.spec.js
+++ b/test/unit/features/global-api/use.spec.js
@@ -54,4 +54,18 @@ describe('Global API: use', () => {
   it('chain call', () => {
     expect(Vue.use(() => {})).toBe(Vue)
   })
+
+  it('should warn if using invalid plugin', () => {
+    const Ctor1 = Vue.extend({})
+    Ctor1.use('hello')
+    expect('Plugin should be either function object with install method.').toHaveBeenWarned()
+
+    const Ctor2 = Vue.extend({})
+    Ctor2.use(undefined)
+    expect('Plugin should be either function object with install method.').toHaveBeenWarned()
+
+    const Ctor3 = Vue.extend({})
+    Ctor3.use(null)
+    expect('Plugin should be either function object with install method.').toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it):
user should be able to see issue with plugin

**Other information:**
