### PR TITLE
fix(scheduler): getNow detection can randomly fail (fix #9632)

### DIFF
--- a/src/core/observer/scheduler.js
+++ b/src/core/observer/scheduler.js
@@ -47,11 +47,13 @@ let getNow: () => number = Date.now
 // timestamp can either be hi-res (relative to page load) or low-res
 // (relative to UNIX epoch), so in order to compare time we have to use the
 // same timestamp type when saving the flush timestamp.
-if (inBrowser && getNow() > document.createEvent('Event').timeStamp) {
-  // if the low-res timestamp which is bigger than the event timestamp
-  // (which is evaluated AFTER) it means the event is using a hi-res timestamp,
-  // and we need to use the hi-res version for event listeners as well.
-  getNow = () => performance.now()
+if (inBrowser && window.performance && typeof performance.now === 'function') {
+  // if the event timestamp is bigger than the hi-res timestamp
+  // (which is evaluated AFTER) it means the event is using a lo-res timestamp,
+  // and we need to use the lo-res version for event listeners as well.
+  if (document.createEvent('Event').timeStamp <= performance.now()) {
+    getNow = () => performance.now()
+  }
 }
 
 /**

--- a/src/core/observer/scheduler.js
+++ b/src/core/observer/scheduler.js
@@ -47,13 +47,16 @@ let getNow: () => number = Date.now
 // timestamp can either be hi-res (relative to page load) or low-res
 // (relative to UNIX epoch), so in order to compare time we have to use the
 // same timestamp type when saving the flush timestamp.
-if (inBrowser && window.performance && typeof performance.now === 'function') {
+if (
+  inBrowser &&
+  window.performance &&
+  typeof performance.now === 'function' &&
+  getNow() > document.createEvent('Event').timeStamp
+) {
   // if the event timestamp is bigger than the hi-res timestamp
   // (which is evaluated AFTER) it means the event is using a lo-res timestamp,
   // and we need to use the lo-res version for event listeners as well.
-  if (document.createEvent('Event').timeStamp <= performance.now()) {
-    getNow = () => performance.now()
-  }
+  getNow = () => performance.now()
 }
 
 /**


### PR DESCRIPTION
The previous detection code compared time stamps based on Date.now()
which are not monotonic, so the check could fail due to clock skew or
adjustments.

This fix changes the check to compare against performance.now() if it is
supported, because it is monotonic (strictly increasing).

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

See the discussion in #9632 for additional info.

This needs to be backported to the 2.6 branch.