### PR TITLE
fix(types): support accessing inject as string array (#8969)

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -43,34 +43,37 @@ export type Accessors<T> = {
   [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>
 }
 
-type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data)
+type DataDef<Data, Props, Injected, V> = Data | ((this: Readonly<Props> & Readonly<Injected> & V) => Data)
 /**
  * This type should be used when an array of strings is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithArrayProps<V extends Vue, Data, Methods, Computed, PropNames extends string> =
+export type ThisTypedComponentOptionsWithArrayProps<V extends Vue, Data, Methods, Computed, PropNames extends string, InjectNames extends string>  =
   object &
-  ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>> &
-  ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Record<PropNames, any>>>>;
+  ComponentOptions<V, DataDef<Data, Record<PropNames, any>, Record<InjectNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>, InjectNames[],Record<InjectNames, any> > &
+  ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Record<PropNames, any>>, Readonly<Record<InjectNames, any>>>>  ;
 
 /**
  * This type should be used when an object mapped to `PropOptions` is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithRecordProps<V extends Vue, Data, Methods, Computed, Props> =
+export type ThisTypedComponentOptionsWithRecordProps<V extends Vue, Data, Methods, Computed, Props, InjectNames extends string> =
   object &
-  ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
-  ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Props>>>;
+  ComponentOptions<V, DataDef<Data, Props, Record<InjectNames, any>, V>, Methods, Computed, RecordPropsDefinition<Props>, Props, InjectNames[], Record<InjectNames, any>> &
+  ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Props>, Readonly<Record<InjectNames, any>>>>;
 
 type DefaultData<V> =  object | ((this: V) => object);
 type DefaultProps = Record<string, any>;
 type DefaultMethods<V> =  { [key: string]: (this: V, ...args: any[]) => any };
 type DefaultComputed = { [key: string]: any };
+type DefaultInjected = { [key: string]: any };
 export interface ComponentOptions<
   V extends Vue,
   Data=DefaultData<V>,
   Methods=DefaultMethods<V>,
   Computed=DefaultComputed,
   PropsDef=PropsDefinition<DefaultProps>,
-  Props=DefaultProps> {
+  Props=DefaultProps,
+  InjectDef=InjectDefinition<DefaultInjected>,
+  Injected=DefaultInjected> {
   data?: Data;
   props?: PropsDef;
   propsData?: object;
@@ -104,7 +107,8 @@ export interface ComponentOptions<
   filters?: { [key: string]: Function };
 
   provide?: object | (() => object);
-  inject?: InjectOptions;
+  // TODO: support object definition on Inject
+  inject?: InjectDef | DefaultInjected;
 
   model?: {
     prop?: string;
@@ -200,7 +204,13 @@ export interface DirectiveOptions {
 }
 
 export type InjectKey = string | symbol;
+export type InjectTypeOptions<T = any> = {
+  from?: InjectKey, default?: T | null | undefined
+}
 
-export type InjectOptions = {
-  [key: string]: InjectKey | { from?: InjectKey, default?: any }
+export type InjectOptions<T = any> = {
+  [key: string]: InjectKey | InjectTypeOptions<T>
 } | string[];
+
+export type ArrayInjectDefinition<T> = (keyof T)[];
+export type InjectDefinition<T> = ArrayInjectDefinition<T> | InjectOptions<T>;

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -238,3 +238,29 @@ const ComponentWithStyleInVNodeData = Vue.extend({
     ]);
   }
 });
+
+
+const InjectedWithArrayPropsComponent = Vue.extend({
+  props: ['test'],
+  inject: ['service'],
+  data() {
+    return {
+      test: this.test,
+      message: this.service.name,
+    }
+  }
+});
+
+const InjectedWithObjectPropsComponent = Vue.extend({
+  props: {
+    test: {type: String}
+  },
+  inject: ['service'],
+  data() {
+    return {
+      test: this.test,
+      message: this.service.name,
+    }
+  }
+});
+

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -61,8 +61,8 @@ export interface Vue {
   $createElement: CreateElement;
 }
 
-export type CombinedVueInstance<Instance extends Vue, Data, Methods, Computed, Props> =  Data & Methods & Computed & Props & Instance;
-export type ExtendedVue<Instance extends Vue, Data, Methods, Computed, Props> = VueConstructor<CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue>;
+export type CombinedVueInstance<Instance extends Vue, Data, Methods, Computed, Props, Injected> =  Data & Methods & Computed & Props & Instance & Injected;
+export type ExtendedVue<Instance extends Vue, Data, Methods, Computed, Props, Injected> = VueConstructor<CombinedVueInstance<Instance, Data, Methods, Computed, Props, Injected> & Vue>;
 
 export interface VueConfiguration {
   silent: boolean;
@@ -78,16 +78,16 @@ export interface VueConfiguration {
 }
 
 export interface VueConstructor<V extends Vue = Vue> {
-  new <Data = object, Methods = object, Computed = object, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>>;
+  new <Data = object, Methods = object, Computed = object, PropNames extends string = never, InjectNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames, InjectNames>): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>, Record<InjectNames, any>>;
   // ideally, the return type should just contain Props, not Record<keyof Props, any>. But TS requires to have Base constructors with the same return type.
-  new <Data = object, Methods = object, Computed = object, Props = object>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>>;
-  new (options?: ComponentOptions<V>): CombinedVueInstance<V, object, object, object, Record<keyof object, any>>;
+  new <Data = object, Methods = object, Computed = object, Props = object, InjectNames extends string = never>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props, InjectNames>): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>, Record<keyof InjectNames, any>>;
+  new (options?: ComponentOptions<V>): CombinedVueInstance<V, object, object, object, Record<keyof object, any>, Record<keyof object, any>>;
 
-  extend<Data, Methods, Computed, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
-  extend<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
-  extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
-  extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
-  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+  extend<Data, Methods, Computed, PropNames extends string = never, InjectNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames, InjectNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>, Record<InjectNames, any>>;
+  extend<Data, Methods, Computed, Props, InjectNames extends string = never>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props, InjectNames>): ExtendedVue<V, Data, Methods, Computed, Props, InjectNames>;
+  extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>, {}>;
+  extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props, {}>;
+  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}, {}>;
 
   nextTick<T>(callback: (this: T) => void, context?: T): void;
   nextTick(): Promise<void>
@@ -104,12 +104,12 @@ export interface VueConstructor<V extends Vue = Vue> {
 
   component(id: string): VueConstructor;
   component<VC extends VueConstructor>(id: string, constructor: VC): VC;
-  component<Data, Methods, Computed, Props>(id: string, definition: AsyncComponent<Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
-  component<Data, Methods, Computed, PropNames extends string = never>(id: string, definition?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
-  component<Data, Methods, Computed, Props>(id: string, definition?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
-  component<PropNames extends string>(id: string, definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
-  component<Props>(id: string, definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
-  component(id: string, definition?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+  component<Data, Methods, Computed, Props>(id: string, definition: AsyncComponent<Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props, {}>;
+  component<Data, Methods, Computed, PropNames extends string = never, InjectNames extends string = never>(id: string, definition?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames, InjectNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>, InjectNames>;
+  component<Data, Methods, Computed, Props, InjectNames extends string = never>(id: string, definition?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props, InjectNames>): ExtendedVue<V, Data, Methods, Computed, Props, InjectNames>;
+  component<PropNames extends string>(id: string, definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>, any>;
+  component<Props>(id: string, definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props, any>;
+  component(id: string, definition?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}, {}>;
 
   use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): VueConstructor<V>;
   use(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): VueConstructor<V>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
Improve typescript typing

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Using the object style still doesn't work as expected, since I based the implementation to have kinda the same behaviour as Props, it would be needed to create a two more `extend` methods to duplicate `ThisTypedComponentOptionsWithRecordProps` \ `ThisTypedComponentOptionsWithArrayProps`.
