### PR TITLE
feat(v-model): add normalize modifier

### DIFF
--- a/packages/vue-server-renderer/build.dev.js
+++ b/packages/vue-server-renderer/build.dev.js
@@ -3416,6 +3416,7 @@ function genComponentModel (
   modifiers
 ) {
   var ref = modifiers || {};
+  var normalize = ref.normalize;
   var number = ref.number;
   var trim = ref.trim;
 
@@ -3425,6 +3426,12 @@ function genComponentModel (
     valueExpression =
       "(typeof " + baseValueExpression + " === 'string'" +
       "? " + baseValueExpression + ".trim()" +
+      ": " + baseValueExpression + ")";
+  }
+  if (normalize) {
+    valueExpression =
+      "(typeof " + baseValueExpression + " === 'string'" +
+      "? " + baseValueExpression + ".normalize()" +
       ": " + baseValueExpression + ")";
   }
   if (number) {

--- a/packages/vue-template-compiler/browser.js
+++ b/packages/vue-template-compiler/browser.js
@@ -2589,6 +2589,7 @@
     modifiers
   ) {
     var ref = modifiers || {};
+    var normalize = ref.normalize;
     var number = ref.number;
     var trim = ref.trim;
 
@@ -2598,6 +2599,12 @@
       valueExpression =
         "(typeof " + baseValueExpression + " === 'string'" +
         "? " + baseValueExpression + ".trim()" +
+        ": " + baseValueExpression + ")";
+    }
+    if (normalize) {
+      valueExpression =
+        "(typeof " + baseValueExpression + " === 'string'" +
+        "? " + baseValueExpression + ".normalize()" +
         ": " + baseValueExpression + ")";
     }
     if (number) {

--- a/packages/weex-template-compiler/build.js
+++ b/packages/weex-template-compiler/build.js
@@ -733,6 +733,7 @@ function genComponentModel (
   modifiers
 ) {
   var ref = modifiers || {};
+  var normalize = ref.normalize;
   var number = ref.number;
   var trim = ref.trim;
 
@@ -742,6 +743,12 @@ function genComponentModel (
     valueExpression =
       "(typeof " + baseValueExpression + " === 'string'" +
       "? " + baseValueExpression + ".trim()" +
+      ": " + baseValueExpression + ")";
+  }
+  if (normalize) {
+    valueExpression =
+      "(typeof " + baseValueExpression + " === 'string'" +
+      "? " + baseValueExpression + ".normalize()" +
       ": " + baseValueExpression + ")";
   }
   if (number) {

--- a/src/compiler/directives/model.js
+++ b/src/compiler/directives/model.js
@@ -8,7 +8,7 @@ export function genComponentModel (
   value: string,
   modifiers: ?ASTModifiers
 ): ?boolean {
-  const { number, trim } = modifiers || {}
+  const { normalize, number, trim } = modifiers || {}
 
   const baseValueExpression = '$$v'
   let valueExpression = baseValueExpression
@@ -16,6 +16,12 @@ export function genComponentModel (
     valueExpression =
       `(typeof ${baseValueExpression} === 'string'` +
       `? ${baseValueExpression}.trim()` +
+      `: ${baseValueExpression})`
+  }
+  if (normalize) {
+    valueExpression =
+      `(typeof ${baseValueExpression} === 'string'` +
+      `? ${baseValueExpression}.normalize()` +
       `: ${baseValueExpression})`
   }
   if (number) {

--- a/src/platforms/web/compiler/directives/model.js
+++ b/src/platforms/web/compiler/directives/model.js
@@ -146,7 +146,7 @@ function genDefaultModel (
     }
   }
 
-  const { lazy, number, trim } = modifiers || {}
+  const { lazy, normalize, number, trim } = modifiers || {}
   const needCompositionGuard = !lazy && type !== 'range'
   const event = lazy
     ? 'change'
@@ -157,6 +157,9 @@ function genDefaultModel (
   let valueExpression = '$event.target.value'
   if (trim) {
     valueExpression = `$event.target.value.trim()`
+  }
+  if (normalize) {
+    valueExpression += '.normalize()'
   }
   if (number) {
     valueExpression = `_n(${valueExpression})`

--- a/src/platforms/weex/compiler/directives/model.js
+++ b/src/platforms/weex/compiler/directives/model.js
@@ -19,10 +19,15 @@ function genDefaultModel (
   value: string,
   modifiers: ?ASTModifiers
 ): ?boolean {
-  const { lazy, trim, number } = modifiers || {}
+  const { lazy, normalize, number, trim } = modifiers || {}
   const event = lazy ? 'change' : 'input'
 
   let valueExpression = `$event.target.attr.value${trim ? '.trim()' : ''}`
+
+  if (normalize) {
+    valueExpression += '.normalize()'
+  }
+
   if (number) {
     valueExpression = `_n(${valueExpression})`
   }

--- a/test/unit/features/directives/model-component.spec.js
+++ b/test/unit/features/directives/model-component.spec.js
@@ -132,6 +132,23 @@ describe('Directive v-model component', () => {
     expect(vm.text).toBe(123)
   })
 
+  it('modifier: .normalize', () => {
+    const vm = new Vue({
+      template: `<div><my-input ref="input" v-model.normalize="text"></my-input></div>`,
+      data: { text: 'foo' },
+      components: {
+        'my-input': {
+          template: '<input>'
+        }
+      }
+    }).$mount()
+    expect(vm.text).toBe('foo')
+    vm.$refs.input.$emit('input', 'b\u0061\u0308r')
+    expect(vm.text).toBe('b\u00e4r')
+    vm.$refs.input.$emit('input', 'b\u0061\u0300r')
+    expect(vm.text).toBe('b\u00e0r')
+  })
+
   it('modifier: .trim', () => {
     const vm = new Vue({
       template: `<div><my-input ref="input" v-model.trim="text"></my-input></div>`,

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -80,6 +80,22 @@ describe('Directive v-model text', () => {
     expect(vm.test).toBe('what')
   })
 
+  it('.normalize modifier', () => {
+    const vm = new Vue({
+      data: {
+        test: 'foo'
+      },
+      template: '<input v-model.normalize="test">'
+    }).$mount()
+    expect(vm.test).toBe('foo')
+    vm.$el.value = 'b\u0061\u0308r'
+    triggerEvent(vm.$el, 'input')
+    expect(vm.test).toBe('b\u00e4r')
+    vm.$el.value = 'b\u0061\u0300r'
+    triggerEvent(vm.$el, 'input')
+    expect(vm.test).toBe('b\u00e0r')
+  })
+
   it('.number focus and typing', (done) => {
     const vm = new Vue({
       data: {

--- a/test/weex/compiler/v-model.spec.js
+++ b/test/weex/compiler/v-model.spec.js
@@ -28,6 +28,15 @@ describe('compile v-model', () => {
     expect(errors).toEqual([])
   })
 
+  it('should compile with normalize modifier for modelable native component', () => {
+    const { render, staticRenderFns, errors } = compile(`<div><input v-model.normalize="x" /></div>`)
+    expect(render).not.toBeUndefined()
+    expect(render).toMatch(strToRegExp(`attrs:{"value":(x)}`))
+    expect(render).toMatch(strToRegExp(`on:{"input":function($event){x=$event.target.attr.value.normalize()}}`))
+    expect(staticRenderFns).toEqual([])
+    expect(errors).toEqual([])
+  })
+
   it('should compile with trim & lazy modifier', () => {
     const { render, staticRenderFns, errors } = compile(`<div><input v-model.trim.lazy="x" /><input v-model.lazy.trim="y" /></div>`)
     expect(render).not.toBeUndefined()


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] All tests are passing (I'm not 100% sure; **please see note below**)
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature

**Other information:**
Using `String.normalize()` is desirable when dealing with user-facing text inputs, considering that unicode strings that look the same on screen can sometimes be encoded differently and thus bring a bunch of problems later on (i.e. when trying to find duplicate strings).

Moreover, having to add `String.normalize()` every time is pretty much just as annoying as having to add `String.trim()` every time, so by that rationale I believe that adding this modifier to `v-model` makes just as much sense as having `trim` in there (which I very much appreciate!).

**Notes:**
- Sorry for not filing an issue first! I decided to just go for it since it's a pretty small modification. Hopefully this explanation is enough, but I can always add an issue later if needed.
- I'm pretty sure that I added all relevant tests and they all seem to have passed. I did experience an issue trying to run the ChromeHeadless instance on my PC, however, although I'm not sure if that test suite applies to this PR anyway (if it does please let me know and I'll try to get it fixed asap).
- I'm using the default `NFC` form of unicode normalization. It might be worth considering adding the other forms as well (`NFD`,`NFKC`,`NFKD`).

More informaton on `String.normalize()` and its usefulness can be found in the following links:
- [Why you need to normalize unicode strings](https://withblue.ink/2019/03/11/why-you-need-to-normalize-unicode-strings.html)
- [String.normalize() ­— MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize)