### PR TITLE
fix(webpack): production preload files

### DIFF
--- a/src/server/webpack-plugin/client.js
+++ b/src/server/webpack-plugin/client.js
@@ -45,6 +45,18 @@ export default class VueSSRClientPlugin {
           }
           const id = m.identifier.replace(/\s\w+$/, '') // remove appended hash
           const files = manifest.modules[hash(id)] = chunk.files.map(fileToIndex)
+
+          // In production mode, modules may be concatenated by scope hoisting
+          // Include ConcatenatedModule for not losing module-component mapping
+          if (Array.isArray(m.modules)) {
+            for (const concatenatedModule of m.modules) {
+              const id = hash(concatenatedModule.identifier.replace(/\s\w+$/, ''))
+              if (!manifest.modules[id]) {
+                manifest.modules[id] = files
+              }
+            }
+          }
+
           // find all asset modules associated with the same chunk
           assetModules.forEach(m => {
             if (m.chunks.some(id => id === cid)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In webpack production mode, some modules may be concatenated by scope hoisting via ModuleConcatenationPlugin, so these modules' mapping information will be lost.

For example: modules info for `qux.js`, `quux.js` and `quuz.js` are lost

```js
{
  "modules": [
    {
      "chunks": [...],
      "identifier": "foo.js",
    },
    {
      "chunks": [...],
      "identifier": "bar.js"
    },
    {
      "chunks": [...],
      "identifier": "baz.js",
      "modules": [
        {
          "identifier": "qux.js"
        },
        {
          "identifier": "quux.js"
        }
        {
          "identifier": "quuz.js"
        }
      ]
    }
  ]
}
```

This pr change is traversing the ConcatenatedModule and populate the modules info.