### PR TITLE
feat(model): add .eager modifier

### DIFF
--- a/src/platforms/web/compiler/directives/model.js
+++ b/src/platforms/web/compiler/directives/model.js
@@ -146,8 +146,8 @@ function genDefaultModel (
     }
   }
 
-  const { lazy, number, trim } = modifiers || {}
-  const needCompositionGuard = !lazy && type !== 'range'
+  const { lazy, number, trim, eager } = modifiers || {}
+  const needCompositionGuard = !lazy && type !== 'range' && !eager
   const event = lazy
     ? 'change'
     : type === 'range'

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -218,6 +218,26 @@ describe('Directive v-model text', () => {
     done()
   })
 
+  it('.eager modifier', () => {
+    const vm = new Vue({
+      data: {
+        test: 'foo'
+      },
+      template: '<input v-model.eager="test">'
+    }).$mount()
+    const input = vm.$el
+    triggerEvent(input, 'compositionstart')
+    input.value = 'baz'
+    // input before composition unlock should call set
+    triggerEvent(input, 'input')
+    expect(vm.test).toBe('baz')
+    // after composition unlock it should work
+    triggerEvent(input, 'compositionend')
+    input.value = 'bar'
+    triggerEvent(input, 'input')
+    expect(vm.test).toBe('bar')
+  })
+
   it('warn invalid tag', () => {
     new Vue({
       data: {


### PR DESCRIPTION
Add an `.eager` modifier to v-model that ignore `composing` value on the input and eagerly modify the value while the user is still composing a value. #9299 #9777

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
