### PR TITLE
fix(keep-alive): bug prune oldest entry

### DIFF
--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -113,7 +113,7 @@ export default {
         keys.push(key)
         // prune oldest entry
         if (this.max && keys.length > parseInt(this.max)) {
-          pruneCacheEntry(cache, keys[0], keys, this._vnode)
+          pruneCacheEntry(cache, keys[0], keys, vnode)
         }
       }
 


### PR DESCRIPTION
prune oldest entry

The same component(keep-alive) is created many times when max is set
（keepalive render方法中，this._vnode仍为上一次的组件，并不是当前的）

detailed description of the bug
Live demo :
![v3b08-htlqv](https://user-images.githubusercontent.com/11729993/56123347-e1433a00-5fa6-11e9-949f-5f3c7fed5ad8.gif)
![image](https://user-images.githubusercontent.com/11729993/56123378-ee602900-5fa6-11e9-9439-82e9dc6f0225.png)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
