### PR TITLE
fix(keep-alive): fix keep-alive memory leak

### DIFF
--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -120,5 +120,13 @@ export default {
       vnode.data.keepAlive = true
     }
     return vnode || (slot && slot[0])
+  },
+  updated() {
+    const { cache } = this
+    for(let key in cache) {
+      if(cache[key] && cache[key].parent && (cache[key].tag != this._vnode.tag)) {
+        cache[key].parent = null
+      }
+    }
   }
 }

--- a/src/server/webpack-plugin/server.js
+++ b/src/server/webpack-plugin/server.js
@@ -1,4 +1,4 @@
-import { validate, isJS, onEmit } from './util'
+import { validate, isJS, onEmit, warn } from './util'
 
 export default class VueSSRServerPlugin {
   constructor (options = {}) {
@@ -23,7 +23,7 @@ export default class VueSSRServerPlugin {
       const entryAssets = entryInfo.assets.filter(isJS)
 
       if (entryAssets.length > 1) {
-        throw new Error(
+        warn(
           `Server-side bundle should have one single entry file. ` +
           `Avoid using CommonsChunkPlugin in the server config.`
         )


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Vue component will not be recycled. because keep-alive cache vnode. and cached vnode will hold on to new parent vnode which will hold created vue instance. So we will use the updated hook to set all
cached vnode's parent to null. This pull request will fix #9842. In the original issue. it states that it relates to transition which is not true. It can be any vue component.Here is my local test.
before: 
![before](https://user-images.githubusercontent.com/7224044/56137183-d4ced980-5fc6-11e9-894e-c1e8898123c7.png)
the more you update keep-alive, the more hierarchy you get.
after:
![after](https://user-images.githubusercontent.com/7224044/56137271-047de180-5fc7-11e9-8f02-9e26cdba7e1a.png)
