### PR TITLE
feat: add warning when .native modifier is used on native HTML elements

### DIFF
--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -98,6 +98,12 @@ export function _createElement (
     ns = (context.$vnode && context.$vnode.ns) || config.getTagNamespace(tag)
     if (config.isReservedTag(tag)) {
       // platform built-in elements
+      if (process.env.NODE_ENV !== 'production' && isDef(data) && isDef(data.nativeOn)) {
+        warn(
+          `The .native modifier for v-on is only valid on components.`,
+          context
+        )
+      }
       vnode = new VNode(
         config.parsePlatformTagName(tag), data, children,
         undefined, undefined, context

--- a/src/core/vdom/create-element.js
+++ b/src/core/vdom/create-element.js
@@ -100,7 +100,7 @@ export function _createElement (
       // platform built-in elements
       if (process.env.NODE_ENV !== 'production' && isDef(data) && isDef(data.nativeOn)) {
         warn(
-          `The .native modifier for v-on is only valid on components.`,
+          `The .native modifier for v-on is only valid on components but it was used on <${tag}>.`,
           context
         )
       }

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -470,7 +470,7 @@ describe('Directive v-on', () => {
     })
 
     triggerEvent(vm.$el, 'click')
-    expect(`The .native modifier for v-on is only valid on components but it was used on <${tag}>.`).toHaveBeenWarned()
+    expect(`The .native modifier for v-on is only valid on components but it was used on <button>.`).toHaveBeenWarned()
     expect(spy.calls.count()).toBe(0)
   })
 

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -460,6 +460,20 @@ describe('Directive v-on', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  it('should be able to ignore native modifier on native HTML element', () => {
+    vm = new Vue({
+      el,
+      template: `
+        <button @click.native="foo"></button>
+      `,
+      methods: { foo: spy },
+    })
+
+    triggerEvent(vm.$el, 'click')
+    expect(`You should not use the '.native' modifier on a native HTML element`).toHaveBeenWarned()
+    expect(spy.calls.count()).toBe(1)
+  })
+
   it('.once modifier should work with child components', () => {
     vm = new Vue({
       el,

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -460,7 +460,7 @@ describe('Directive v-on', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  it('should be able to ignore native modifier on native HTML element', () => {
+  it('should throw a warning is native modifier is used on native HTML element', () => {
     vm = new Vue({
       el,
       template: `
@@ -470,8 +470,8 @@ describe('Directive v-on', () => {
     })
 
     triggerEvent(vm.$el, 'click')
-    expect(`You should not use the '.native' modifier on a native HTML element`).toHaveBeenWarned()
-    expect(spy.calls.count()).toBe(1)
+    expect(`The .native modifier for v-on is only valid on components.`).toHaveBeenWarned()
+    expect(spy.calls.count()).toBe(0)
   })
 
   it('.once modifier should work with child components', () => {

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -460,7 +460,7 @@ describe('Directive v-on', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  it('should throw a warning is native modifier is used on native HTML element', () => {
+  it('should throw a warning if native modifier is used on native HTML element', () => {
     vm = new Vue({
       el,
       template: `

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -470,7 +470,7 @@ describe('Directive v-on', () => {
     })
 
     triggerEvent(vm.$el, 'click')
-    expect(`The .native modifier for v-on is only valid on components.`).toHaveBeenWarned()
+    expect(`The .native modifier for v-on is only valid on components but it was used on <${tag}>.`).toHaveBeenWarned()
     expect(spy.calls.count()).toBe(0)
   })
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Currently if we have a `.native` modifier applied to event handler on native HTML element, it will break the handler (you can find the minimal reproduction [here](https://codesandbox.io/s/m718j536yp)).

We had a discussion about it with @chrisvfritz and it was decided it would be a good solution to add a console warning for this case. This way we can warn people they are using `.native` incorrectly: it should be used only on components not on elements.

An ideal solution would be also making `.native` work on elements while throwing a warning but it might be a subject for another PR.