### PR TITLE
fix(compiler): Remove the waring for valid v-slot value

### DIFF
--- a/src/compiler/error-detector.js
+++ b/src/compiler/error-detector.js
@@ -31,6 +31,7 @@ function checkNode (node: ASTNode, warn: Function) {
   if (node.type === 1) {
     for (const name in node.attrsMap) {
       if (dirRE.test(name)) {
+        if (name === 'v-slot') break;
         const value = node.attrsMap[name]
         if (value) {
           const range = node.rawAttrsMap[name]

--- a/src/compiler/error-detector.js
+++ b/src/compiler/error-detector.js
@@ -31,12 +31,13 @@ function checkNode (node: ASTNode, warn: Function) {
   if (node.type === 1) {
     for (const name in node.attrsMap) {
       if (dirRE.test(name)) {
-        if (name === 'v-slot') break;
         const value = node.attrsMap[name]
         if (value) {
           const range = node.rawAttrsMap[name]
           if (name === 'v-for') {
             checkFor(node, `v-for="${value}"`, warn, range)
+          } else if (name === 'v-slot' || name[0] === '#') {
+            checkFunctionParameterExpression(value, `${name}="${value}"`, warn, range)
           } else if (onRE.test(name)) {
             checkEvent(value, `${name}="${value}"`, warn, range)
           } else {
@@ -110,5 +111,18 @@ function checkExpression (exp: string, text: string, warn: Function, range?: Ran
         range
       )
     }
+  }
+}
+
+function checkFunctionParameterExpression (exp: string, text: string, warn: Function, range?: Range) {
+  try {
+    new Function(exp, '')
+  } catch (e) {
+    warn(
+      `invalid function parameter expression: ${e.message} in\n\n` +
+      `    ${exp}\n\n` +
+      `  Raw expression: ${text.trim()}\n`,
+      range
+    )
   }
 }

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -23,8 +23,8 @@ import {
 
 export const onRE = /^@|^v-on:/
 export const dirRE = process.env.VBIND_PROP_SHORTHAND
-  ? /^v-|^@|^:|^\./
-  : /^v-|^@|^:/
+  ? /^v-|^@|^:|^\.|^#/
+  : /^v-|^@|^:|^#/
 export const forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
 export const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
 const stripParensRE = /^\(|\)$/g

--- a/test/unit/features/component/component-scoped-slot.spec.js
+++ b/test/unit/features/component/component-scoped-slot.spec.js
@@ -760,12 +760,20 @@ describe('Component scoped slot', () => {
         expect(`Unexpected mixed usage of different slot syntaxes`).toHaveBeenWarned()
       })
 
+      it('should warn invalid parameter expression', () => {
+        new Vue({
+          template: `<foo ${syntax}="1"></foo>`,
+          components: { Foo }
+        }).$mount();
+        expect('invalid function parameter expression').toHaveBeenWarned()
+      })
+
       it('should allow destructuring props with default value', () => {
         new Vue({
           template: `<foo ${syntax}="{ foo = { bar: '1' } }"></foo>`,
-          components: { Foo, Bar }
+          components: { Foo }
         }).$mount();
-        expect('Invalid shorthand property initializer').not.toHaveBeenWarned()
+        expect('invalid function parameter expression').not.toHaveBeenWarned()
       })
     }
 

--- a/test/unit/features/component/component-scoped-slot.spec.js
+++ b/test/unit/features/component/component-scoped-slot.spec.js
@@ -759,6 +759,14 @@ describe('Component scoped slot', () => {
         }).$mount()
         expect(`Unexpected mixed usage of different slot syntaxes`).toHaveBeenWarned()
       })
+
+      it('should allow destructuring props with default value', () => {
+        new Vue({
+          template: `<foo ${syntax}="{ foo = { bar: '1' } }"></foo>`,
+          components: { Foo, Bar }
+        }).$mount();
+        expect('Invalid shorthand property initializer').not.toHaveBeenWarned()
+      })
     }
 
     // run tests for both full syntax and shorthand


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

The Vue doc says that one can use destructuring props with fallback value as v-slot's value.
![image](https://user-images.githubusercontent.com/9816225/56653472-4cd08a00-66c0-11e9-8393-0f668e86b136.png)

Actually, this will cause a warning.
![image](https://user-images.githubusercontent.com/9816225/56653722-e26c1980-66c0-11e9-9c8f-f49dcf173c60.png)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
