### PR TITLE
fix(examples/select2): Prevents the change event from firi…

### DIFF
--- a/examples/select2/index.html
+++ b/examples/select2/index.html
@@ -49,7 +49,7 @@
           // init select2
           .select2({ data: this.options })
           // emit event on change.
-          .on('change', function () {
+          .on('select2:select', function () {
             vm.$emit('input', this.value)
           })
       },


### PR DESCRIPTION
…ng twice when a selection is ad

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
It its current state, the Select2 example component will emit the change callback twice when a selection is added/removed from the dropdown. By watching for the `select2:select` event as opposed to the `change` event, it will prevent `vm.$emit('input', this.value)` or any other callback from firing twice.