### PR TITLE
Force ArrayConstructor to be a any[] typescript type (fix #9935)

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -144,7 +144,7 @@ export interface RenderContext<Props=DefaultProps> {
   injections: any
 }
 
-export type Prop<T> = { (): T } | { new(...args: any[]): T & object } | { new(...args: string[]): Function }
+export type Prop<T> = { (): T extends {}[] ? any[] : T } | { new(...args: any[]): T & object } | { new(...args: string[]): Function }
 
 export type PropType<T> = Prop<T> | Prop<T>[];
 

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -118,6 +118,25 @@ Vue.component('prop-with-primitive-default', {
   }
 });
 
+// Test issue with the Array prop type
+Vue.extend({
+  props: {
+    s: String,
+    a: {type: Array},
+    b: Boolean
+  },
+  created() {
+    console.log(this.a)
+    console.log(this.s)
+    console.log(this.b)
+  },
+  mounted() {
+    console.log(this.a)
+    console.log(this.s)
+    console.log(this.b)
+  }
+})
+
 Vue.component('component', {
   data() {
     this.$mount


### PR DESCRIPTION
## Issue

When using an Array prop in a Vue component with TypeScript, TypeScript breaks because the
JavaScript ArrayConstructor is transpiled to a {}[] typescript type that is for some reason more
general than any[]. Since the type is more general, the component is not using the correct component
overload function declaration. The idea here is to force the JavaScript ArrayConstructor to be
transpiled to any[] type to fix the issue.

fix #9935

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included