### PR TITLE
fix(v-pre): do not alter attributes (fix #10087)

### DIFF
--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -39,7 +39,7 @@ function updateAttrs (oldVnode: VNodeWithData, vnode: VNodeWithData) {
     cur = attrs[key]
     old = oldAttrs[key]
     if (old !== cur) {
-      setAttr(elm, key, cur)
+      setAttr(elm, key, cur, vnode.data.pre)
     }
   }
   // #4391: in IE9, setting type can reset value for input[type=radio]
@@ -59,8 +59,10 @@ function updateAttrs (oldVnode: VNodeWithData, vnode: VNodeWithData) {
   }
 }
 
-function setAttr (el: Element, key: string, value: any) {
+function setAttr (el: Element, key: string, value: any, isInPre: any) {
   if (el.tagName.indexOf('-') > -1) {
+    baseSetAttr(el, key, value)
+  } else if(isInPre) {
     baseSetAttr(el, key, value)
   } else if (isBooleanAttr(key)) {
     // set attribute for blank value

--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -60,9 +60,7 @@ function updateAttrs (oldVnode: VNodeWithData, vnode: VNodeWithData) {
 }
 
 function setAttr (el: Element, key: string, value: any, isInPre: any) {
-  if (el.tagName.indexOf('-') > -1) {
-    baseSetAttr(el, key, value)
-  } else if(isInPre) {
+  if (el.tagName.indexOf('-') > -1 || isInPre) {
     baseSetAttr(el, key, value)
   } else if (isBooleanAttr(key)) {
     // set attribute for blank value

--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -60,7 +60,7 @@ function updateAttrs (oldVnode: VNodeWithData, vnode: VNodeWithData) {
 }
 
 function setAttr (el: Element, key: string, value: any, isInPre: any) {
-  if (el.tagName.indexOf('-') > -1 || isInPre) {
+  if (isInPre || el.tagName.indexOf('-') > -1) {
     baseSetAttr(el, key, value)
   } else if (isBooleanAttr(key)) {
     // set attribute for blank value

--- a/test/unit/features/directives/pre.spec.js
+++ b/test/unit/features/directives/pre.spec.js
@@ -45,10 +45,8 @@ describe('Directive v-pre', function () {
 
   // #10087
   it('should not compile attributes', function () {
-    Vue.component('vtest', { template: ` <div>Hello World</div>` })
     const vm = new Vue({
-      template: '<div v-pre><vtest open="hello"></vtest></div>',
-      replace: true
+      template: '<div v-pre><p open="hello">A Test</p></div>'
     })
     vm.$mount()
     expect(vm.$el.firstChild.getAttribute('open')).toBe('hello')

--- a/test/unit/features/directives/pre.spec.js
+++ b/test/unit/features/directives/pre.spec.js
@@ -42,4 +42,15 @@ describe('Directive v-pre', function () {
     vm.$mount()
     expect(vm.$el.firstChild.tagName).toBe('VTEST')
   })
+
+  // #10087
+  it('should not compile attributes', function () {
+    Vue.component('vtest', { template: ` <div>Hello World</div>` })
+    const vm = new Vue({
+      template: '<div v-pre><vtest open="hello"></vtest></div>',
+      replace: true
+    })
+    vm.$mount()
+    expect(vm.$el.firstChild.getAttribute('open')).toBe('hello')
+  })
 })


### PR DESCRIPTION
Fix #10087

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When attributes under a v-pre match the list in `isBooleanAttr`, the value is replaced. This goes against the purpose of v-pre which is to leave all elements as-is.

An example of this bug can be found at https://jsfiddle.net/fp1omdaw/1/ as well as further details under #10087