### PR TITLE
fix:use mobx ，when Proxy  property is array not allowed modify __proto__

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -86,8 +86,12 @@ export class Observer {
  */
 function protoAugment (target, src: Object) {
   /* eslint-disable no-proto */
-  target.__proto__ = src
-  /* eslint-enable no-proto */
+  try {
+    target.__proto__ = src
+  } catch (error) {
+    warn(error)
+  }
+ /* eslint-enable no-proto */
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ✔️] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [✔️ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
when we use mobx,when the Proxy property is array,set __proto__ return false,then put the Proxy Object to vue data, the vue application will be crashed!  

**The PR fulfills these requirements:**

- [✔️ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
