### PR TITLE
fix: fix memory leak of watcher created in initComputed

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -242,7 +242,7 @@ function createComputedGetter (key) {
   return function computedGetter () {
     const watcher = this._computedWatchers && this._computedWatchers[key]
     if (watcher) {
-      if (watcher.dirty) {
+      if (watcher.active && watcher.dirty) {
         watcher.evaluate()
       }
       if (Dep.target) {


### PR DESCRIPTION
After vue instance get destroyed, the watcher created in `initComputed` can still collect deps, which
cause the watcher can't be GC.

See the [reproduction](https://codepen.io/liximomo/pen/PrwvPV).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
