### PR TITLE
polish: improve robustness of inject option

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -338,6 +338,16 @@ function normalizeInject (options: Object, vm: ?Component) {
   const normalized = options.inject = {}
   if (Array.isArray(inject)) {
     for (let i = 0; i < inject.length; i++) {
+      if (typeof inject[i] !== 'string') {
+        if (process.env.NODE_ENV !== 'production') {
+          warn(
+            `Invalid value for option "inject": expected an Array of string, ` +
+              `but found ${toRawType(inject[i])}.`,
+            vm
+          );
+        }
+        continue;
+      }
       normalized[inject[i]] = { from: inject[i] }
     }
   } else if (isPlainObject(inject)) {

--- a/test/unit/features/options/inject.spec.js
+++ b/test/unit/features/options/inject.spec.js
@@ -673,4 +673,19 @@ describe('Options provide/inject', () => {
     })
     expect(`Injection "constructor" not found`).toHaveBeenWarned()
   })
+
+  it('should warn when inject with none-string Array', () => {
+    const obj = { a: 1 }
+    const vm = new Vue({
+      template: `<child/>`,
+      provide: {},
+      components: {
+        child: {
+          inject: [obj],
+          template: `<div>{{ 123 }}</div>`,
+        },
+      },
+    }).$mount()
+    expect(`Invalid value for option "inject": expected an Array of string`).toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
When a user provides a none-string object in inject array, it may fail at runtime because we try to make an implicit string conversion for the object in "Injection not found" warn. Objects like Symbol will fail at runtime because of such implicit conversion.

![image](https://user-images.githubusercontent.com/9816225/59480206-54c3d380-8e92-11e9-8b59-18aac8719bb2.png)

See the [reproduction](https://codepen.io/liximomo/pen/XLmZjX?editors=1012).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
