### PR TITLE
fix #10184: Recognize assigment in v-if and do not throw warning

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -59,7 +59,7 @@ declare type ModuleOptions = {
 };
 
 declare type ASTModifiers = { [key: string]: boolean };
-declare type ASTIfCondition = { exp: ?string; block: ASTElement };
+declare type ASTIfCondition = { exp: ?string; alias: ?string; block: ASTElement };
 declare type ASTIfConditions = Array<ASTIfCondition>;
 
 declare type ASTAttr = {

--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -59,7 +59,7 @@ declare type ModuleOptions = {
 };
 
 declare type ASTModifiers = { [key: string]: boolean };
-declare type ASTIfCondition = { exp: ?string; alias: ?string; block: ASTElement };
+declare type ASTIfCondition = { exp: ?string; alias?: string; block: ASTElement };
 declare type ASTIfConditions = Array<ASTIfCondition>;
 
 declare type ASTAttr = {

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -164,11 +164,21 @@ function genIfConditions (
 
   const condition = conditions.shift()
   if (condition.exp) {
-    return `(${condition.exp})?${
+    let ternaryExp = `(${condition.exp})?${
       genTernaryExp(condition.block)
     }:${
       genIfConditions(conditions, state, altGen, altEmpty)
-    }`
+    }`;
+    if (condition.alias) {
+      // When there is assignment in `condition.exp`
+
+      // Wrap an IIFE (Immediately Invoked Function Expression) so that the variable of `condition.alias` will be local, and therefore no warning will be thrown.
+      return `function(){var ${condition.alias}; return ${ternaryExp}}()`
+    }
+    else {
+      return ternaryExp
+    }
+
   } else {
     return `${genTernaryExp(condition.block)}`
   }

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -583,7 +583,7 @@ function findPrevElement (children: Array<any>): ASTElement | void {
 
 export function addIfCondition (el: ASTElement, condition: ASTIfCondition) {
   let m
-  if (m = condition.exp && condition.exp.match(assignmentInIfRE)){
+  if ((m = condition.exp && condition.exp.match(assignmentInIfRE))){
     condition.alias = m[1];
   }
   if (!el.ifConditions) {

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -26,6 +26,7 @@ export const dirRE = process.env.VBIND_PROP_SHORTHAND
   ? /^v-|^@|^:|^\.|^#/
   : /^v-|^@|^:|^#/
 export const forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
+export const assignmentInIfRE = /([a-zA-Z][a-zA-Z0-9_$]*)\s+(?:=)\s+([\s\S]*)/
 export const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
 const stripParensRE = /^\(|\)$/g
 const dynamicArgRE = /^\[.*\]$/
@@ -581,6 +582,10 @@ function findPrevElement (children: Array<any>): ASTElement | void {
 }
 
 export function addIfCondition (el: ASTElement, condition: ASTIfCondition) {
+  let m
+  if (m = condition.exp && condition.exp.match(assignmentInIfRE)){
+    condition.alias = m[1];
+  }
   if (!el.ifConditions) {
     el.ifConditions = []
   }


### PR DESCRIPTION
The [original issue #10184](https://github.com/vuejs/vue/issues/10184) is too long, and I've made some mistakes when writing it.

Here, I will rephrase the issue, and explain my solution.

## What problem?

### Demos

Here are two demo for comparison.

1. [Vanilla vue.js warns when assigment in v-if happens](https://codepen.io/grandsong/pen/xoLxvM)
2. [My modified vue.js doesn't warn when assigment in v-if happens](https://codepen.io/grandsong/pen/PrKwQj)

Remember to open Dev Tools and check the Console.

The code in question is `<span v-if="pet = person.pet">`.

### What happens in vanilla vue.js?

vue.js doesn't check the content of the expression of a `v-if`.

To it, `pet = person.pet` is just an arbitrary expression.

It desn't care whether assigment happens in a `v-if`.

All if conditions will be compiled as ternary statements.

In the example, the compiled codes will be like:

  	((pet = person.pet) ? `${person.name}'s pet's name is ${pet.name}.` : `${person.name} has no pet.`)

As a result, while the template is being rendered, at the beginning when the renderer meets this identifier `pet`, the **proxy** of vue instane (let's name it as `vm`) will automatically try to get `pet` as a property of the instance.

Of course it will fail. `vm.pet` has not been defined yet.
So, a **warning** will be thrown.

    [Vue warn]: Property or method "pet" is not defined on the instance but referenced during render.

Then, the renderer meets `= person.pet`, so it assigns the `pet` as a property of the vue instance, namely, `vm.pet = person.pet`.

After that, when it meets `pet` again in `pet.name`, it gets `pet` (namely, `vm.pet`) successfully.

If we would manually do the rendering in place of vue (without the help of the magical proxy and its get-handler), we will deal with codes like this:

    ((vm.pet = person.pet) ? `${person.name}'s pet's name is ${vm.pet.name}.` : `${person.name} has no pet.`)

A spoiler: `person` is different. It doesn't bother the proxy.

## Why do we need assigment in v-if?

Why do we need any shorthand (like `:` for `v-bind:`), or sugar syntax (`for in` instead of `for(var ..;..<..length;..++)`), etc?

Making life easier!

We can live with inconvenience. But we still ask for better life when we have chance.

#### The above demos

Without the assigment, the codes would become

    <span v-if="person.pet">{{person.name}}'s pet's name is {{person.pet.name}}.</span>

Well, looks completely tolerable...

But, what if the design is more complex?

    <span v-if="person.pet">
    	<span v-if="person.pet.hunger > 0">
    		{{person.name}}'s pet's {{person.pet.name}} needs to eat
    		<span> {{foodDict[person.pet.favFoodId]}}</span>
    		, which
    		<span v-if="foodQtyInStore[person.pet.favFoodId]"> you have {{foodQtyInStore[person.pet.favFoodId]}}.</span>
    		<span v-else class="color-warning"> is out of stock!<span>
    	</span>
    </span>

Compare it with

    <span v-if="pet = person.pet">
    	<span v-if="pet.hunger > 0">
    		{{person.name}}'s pet's {{pet.name}} needs to eat
    		<span> {{foodDict[pet.favFoodId].name}}</span>
    		, which
    		<span v-if="foodQty = foodQtyInStore[pet.favFoodId]"> you have {{foodQty}}.</span>
    		<span v-else class="color-warning"> is out of stock!<span>
    	</span>
    </span>


#### `slotScope`

And let's take another example - an example in the source of **vue.js itself**:

		function processSlotContent (el) {
		  let slotScope
		  if (el.tag === 'template') {
		    ...
		  } else if ((slotScope = getAndRemoveAttr(el, 'slot-scope'))) {
		    ...
		    el.slotScope = slotScope
		  }
		  ...
		}

(It purposely uses double brackets to fool lint-flow-types, which forbids assigment in if.)

Without the assigment, it would become

		function processSlotContent (el) {
		  let slotScope
		  if (el.tag === 'template') {
		    ...
		  } else if (getAndRemoveAttr(el, 'slot-scope')) {
		    ...
		    el.slotScope = getAndRemoveAttr(el, 'slot-scope')
		  }
		  ...
		}

I don't know if it is OK for `getAndRemoveAttr(el, 'slot-scope')` to be called twice.
Probably not.

Maybe we still have to use assigment, just not in if-condition.

		function processSlotContent (el) {
		  let slotScope
		  if (el.tag === 'template') {
		    ...
		  } else {
			  slotScope = getAndRemoveAttr(el, 'slot-scope')
				if (slotScope) {
			    ...
			    el.slotScope = slotScope
			  }
			}
		  ...
		}

#### `if let`

Another thing we can analogize to is the `if let` in Swift.

See [Optional Binding](https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html#ID333) if you haven't learnt it or don't quite recall.

Before I learnt this feature of Swift, I was very reluctant to assigment in if-condition.

Because it would remind me of my several stupid mistakes of `=` for `==` as well as my old time as a JS newbie.

I would rather write more codes (like the `slotScope` one) to avoid assigment in if-condition.

But Swift gave me a good lesson.
Smart people should embrace useful features when opportunity allows (designing a new language).

#### What about danger?

In pure JS, thanks to js linters, assigment in if-condition is not as dangerous as it used to be. Mistakes of `=` for `==` can be easily detected.

(That's why [#7631 warn when assignment in v-if in development mode](https://github.com/vuejs/vue/issues/7631) was closed by @posva.)

## Then, what's wrong with vue?

In vue, it is another story.

There is no way to easily create local variables yet.

So, even if I just want assignment outside v-if, I cannot assign at all.

(There is [a solution](https://github.com/posva/vue-local-scope) for `slot-scope`. But I seldom use slots.)

Whether we deserve such freedom is beyond this issue. Let's leave it and focus on assignment in `v-if`.

Please remember these fact:

- assignment in `v-if` **already** works

- the warning thrown is not very helpful

The warning is thrown, not because vue has a rule which forbids assignment in `v-if`, but because vue fails to recognize the identifier as a new one, which of course is not defined.

### And, bug?

And there can be possible conflict (I don't know if it can be called a bug/loophole):

If somehow the developer writes

		data() {
      return {
        b: false,
        pet: {
        	// some other pet
        	name: 'Tom'
      	},
        persons: [...]
      }
    }

Now, there is `vm.pet` (Tom) before the template is rendered.

So, when the renderer meets `v-if="pet = perons.pet"`, it will happily get it!
And then, `vm.pet` will be overwritten and Tom will no longer exist!


### Compare `v-for`

`v-for` naturally contains assignment.

Although not mentioned in the doc, vue actually even "[support destructuring assignment](https://github.com/vuejs/vue/issues/8780)". It is a little secret.

So, what goes on with `v-for`? Why identifiers in it doesn't lead to warnings?

The answer is simple: compiled codes for `v-for` are functions, so that the identifiers are local varibles within the functions.

That's why you dont' see `vm.person.name` in the "If we would manually do the rendering" code:

    ((vm.pet = person.pet) ? `${person.name}'s pet's name is ${vm.pet.name}.` : `${person.name} has no pet.`)

This inspired me when I was trying to make a solution.

## What solution?

Simple.

You can see that I added/modified only very few lines below.

Quick explanation:

1. In "parser/index.js", `assignmentInIfRE` is define.

2. In `function addIfCondition`, `assignmentInIfRE` is used to find the identifier, and store it as `condition.alias`.

3. In "codegen/index.js", save the original compiled result to `ternaryExp`.

4. If `condition.alias` exists, add a declaration of the identifier. Then, wrap the codes as an IIFE (Immediately Invoked Function Expression).

With IIFE, it works in a way very similar to the optional binding (`if let`) in Swift.

### BTW, Why `alias`?

The parser for `v-for` stores identifiers (i.e. `person`) as `alias` of the node.

I don't know what uses are of these aliases, but I like the choice of name.

## Hey, no test yet? How dare you!

Sorry.
I tried to follow the instruction but I failed to do the test.
Twice.

I run `yarn`, then I got stuck. It shows several "waiting..." **forever**.

I had to stop it manually, and a rerun was no luck either.

Anyway, I've already made a **working** modified vue.js, in **my Demo 2**.

So I guess it is highly likely for my simple solution to run well with this pull request, too.

Besides, there might be problems that I cannot anticipate.
Today it was the first time I've delved into the source of vue.

Real experts may be needed for polishing this feature.

---

## PULL REQUEST TEMPLATE
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
