### PR TITLE
Warn on colon shorthand usage on directive (fix #10191)

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -30,6 +30,7 @@ export const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
 const stripParensRE = /^\(|\)$/g
 const dynamicArgRE = /^\[.*\]$/
 
+const colonDirRE = /^:v-/
 const argRE = /:(.*)$/
 export const bindRE = /^:|^\.|^v-bind:/
 const propBindRE = /^\./
@@ -761,6 +762,12 @@ function processAttrs (el) {
   for (i = 0, l = list.length; i < l; i++) {
     name = rawName = list[i].name
     value = list[i].value
+    // :v-if or similar
+    if (process.env.NODE_ENV !== 'production' && colonDirRE.test(name)) {
+      warn(
+        `A v-bind shorthand directive was used on another Vue directive. Did you want to write '${name.substr(1)}="${value}"'?`
+      )
+    }
     if (dirRE.test(name)) {
       // mark element as dynamic
       el.hasBindings = true

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -530,6 +530,11 @@ describe('parser', () => {
     expect(ast.props[0].value).toBe('msg')
   })
 
+  it('v-bind expression on directive', () => {
+    parse('<div :v-if="foo"></div>', baseOptions)
+    expect(`A v-bind shorthand directive was used on another Vue directive. Did you want to write 'v-if="foo"'?`).toHaveBeenWarned()
+  })
+
   it('empty v-bind expression', () => {
     parse('<div :empty-msg=""></div>', baseOptions)
     expect('The value for a v-bind expression cannot be empty. Found in "v-bind:empty-msg"').toHaveBeenWarned()


### PR DESCRIPTION
fix #10191

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included


**Other information:**

```html
<template>
  <div v-if="something">foo</div>  <!-- does not throw a warning -->
  <div :v-if="something">foo</div> <!-- throws a warning -->
</template>
```

There are several things I _decided_ that could be improved, so any advice or suggestion is greatly appreciated :)

- PR shows a warning for every bound attribute starting with `v-`. The reasoning is that "The v- prefix serves as a visual cue for identifying Vue-specific attributes in your templates." ([source](https://vuejs.org/v2/guide/syntax.html#Shorthands))
- Do we need more test cases?
- Is the warning message clear enough? If the attribute is not a valid Vue directive, should the message change?

Thanks!