### PR TITLE
feat(keep-alive): includes/excludes keep-alive based on key and name (fix #8028)

### DIFF
--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -9,16 +9,20 @@ function getComponentName (opts: ?VNodeComponentOptions): ?string {
   return opts && (opts.Ctor.options.name || opts.tag)
 }
 
-function matches (pattern: string | RegExp | Array<string>, name: string): boolean {
-  if (Array.isArray(pattern)) {
-    return pattern.indexOf(name) > -1
-  } else if (typeof pattern === 'string') {
-    return pattern.split(',').indexOf(name) > -1
-  } else if (isRegExp(pattern)) {
-    return pattern.test(name)
+function matches (pattern: string | RegExp | Array<string>, key: ?string, name: string): boolean {
+  function matchesValue(value: string) {
+    if (Array.isArray(pattern)) {
+      return pattern.indexOf(value) > -1
+    } else if (typeof pattern === 'string') {
+      return pattern.split(',').indexOf(value) > -1
+    } else if (isRegExp(pattern)) {
+      return pattern.test(value)
+    }
+    /* istanbul ignore next */
+    return false
   }
-  /* istanbul ignore next */
-  return false
+
+  return (key && matchesValue(key)) || matchesValue(name);
 }
 
 function pruneCache (keepAliveInstance: any, filter: Function) {
@@ -27,7 +31,7 @@ function pruneCache (keepAliveInstance: any, filter: Function) {
     const cachedNode: ?VNode = cache[key]
     if (cachedNode) {
       const name: ?string = getComponentName(cachedNode.componentOptions)
-      if (name && !filter(name)) {
+      if (name && !filter(key, name)) {
         pruneCacheEntry(cache, key, keys, _vnode)
       }
     }
@@ -73,10 +77,10 @@ export default {
 
   mounted () {
     this.$watch('include', val => {
-      pruneCache(this, name => matches(val, name))
+      pruneCache(this, (key, name) => matches(val, key, name))
     })
     this.$watch('exclude', val => {
-      pruneCache(this, name => !matches(val, name))
+      pruneCache(this, (key, name) => !matches(val, key, name))
     })
   },
 
@@ -87,22 +91,25 @@ export default {
     if (componentOptions) {
       // check pattern
       const name: ?string = getComponentName(componentOptions)
-      const { include, exclude } = this
-      if (
-        // not included
-        (include && (!name || !matches(include, name))) ||
-        // excluded
-        (exclude && name && matches(exclude, name))
-      ) {
-        return vnode
-      }
 
-      const { cache, keys } = this
       const key: ?string = vnode.key == null
         // same constructor may get registered as different local components
         // so cid alone is not enough (#3269)
         ? componentOptions.Ctor.cid + (componentOptions.tag ? `::${componentOptions.tag}` : '')
         : vnode.key
+
+      const { include, exclude } = this
+      if (
+        // not included
+        (include && (!name || !matches(include, key, name))) ||
+        // excluded
+        (exclude && name && matches(exclude, key, name))
+      ) {
+        return vnode
+      }
+
+      const { cache, keys } = this
+
       if (cache[key]) {
         vnode.componentInstance = cache[key].componentInstance
         // make current key freshest

--- a/test/unit/features/component/component-keep-alive.spec.js
+++ b/test/unit/features/component/component-keep-alive.spec.js
@@ -236,7 +236,7 @@ describe('Component keep-alive', () => {
     }).then(done)
   }
 
-  it('include (string)', done => {
+  it('include (string, name)', done => {
     const vm = new Vue({
       template: `
         <div v-if="ok">
@@ -254,7 +254,26 @@ describe('Component keep-alive', () => {
     sharedAssertions(vm, done)
   })
 
-  it('include (regex)', done => {
+  it('include (string, key)', done => {
+    const vm = new Vue({
+      template: `
+        <div v-if="ok">
+          <keep-alive include="one-key">
+            <component :key="view + '-key'" :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: {
+        view: 'one',
+        ok: true
+      },
+      components
+    }).$mount()
+    sharedAssertions(vm, done)
+  })
+
+
+  it('include (regex, name)', done => {
     const vm = new Vue({
       template: `
         <div v-if="ok">
@@ -272,7 +291,26 @@ describe('Component keep-alive', () => {
     sharedAssertions(vm, done)
   })
 
-  it('include (array)', done => {
+  it('include (regex, key)', done => {
+    const vm = new Vue({
+      template: `
+        <div v-if="ok">
+          <keep-alive :include="/^one-key$/">
+            <component :key="view + '-key'" :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: {
+        view: 'one',
+        ok: true
+      },
+      components
+    }).$mount()
+    sharedAssertions(vm, done)
+  })
+
+
+  it('include (array, name)', done => {
     const vm = new Vue({
       template: `
         <div v-if="ok">
@@ -290,7 +328,26 @@ describe('Component keep-alive', () => {
     sharedAssertions(vm, done)
   })
 
-  it('exclude (string)', done => {
+  it('include (array, key)', done => {
+    const vm = new Vue({
+      template: `
+        <div v-if="ok">
+          <keep-alive :include="['one']">
+            <component :key="view + '-key'" :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: {
+        view: 'one',
+        ok: true
+      },
+      components
+    }).$mount()
+    sharedAssertions(vm, done)
+  })
+
+
+  it('exclude (string, name)', done => {
     const vm = new Vue({
       template: `
         <div v-if="ok">
@@ -308,7 +365,26 @@ describe('Component keep-alive', () => {
     sharedAssertions(vm, done)
   })
 
-  it('exclude (regex)', done => {
+  it('exclude (string, key)', done => {
+    const vm = new Vue({
+      template: `
+        <div v-if="ok">
+          <keep-alive exclude="two-key">
+            <component :key="view + '-key'" :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: {
+        view: 'one',
+        ok: true
+      },
+      components
+    }).$mount()
+    sharedAssertions(vm, done)
+  })
+
+
+  it('exclude (regex, name)', done => {
     const vm = new Vue({
       template: `
         <div v-if="ok">
@@ -326,7 +402,25 @@ describe('Component keep-alive', () => {
     sharedAssertions(vm, done)
   })
 
-  it('exclude (array)', done => {
+  it('exclude (regex, key)', done => {
+    const vm = new Vue({
+      template: `
+        <div v-if="ok">
+          <keep-alive :exclude="/^two-key$/">
+            <component :key="view + '-key'" :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: {
+        view: 'one',
+        ok: true
+      },
+      components
+    }).$mount()
+    sharedAssertions(vm, done)
+  })
+
+  it('exclude (array, name)', done => {
     const vm = new Vue({
       template: `
         <div v-if="ok">
@@ -343,6 +437,25 @@ describe('Component keep-alive', () => {
     }).$mount()
     sharedAssertions(vm, done)
   })
+
+  it('exclude (array, key)', done => {
+    const vm = new Vue({
+      template: `
+        <div v-if="ok">
+          <keep-alive :exclude="['two-key']">
+            <component :key="view + '-key'" :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: {
+        view: 'one',
+        ok: true
+      },
+      components
+    }).$mount()
+    sharedAssertions(vm, done)
+  })
+
 
   it('include + exclude', done => {
     const vm = new Vue({


### PR DESCRIPTION
The keep-alive component will now also use the key of the component when checking the includes or excludes properties.

On this way you can cache specific instances of a component instead of caching all instances of that component.

fix #8028

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included