### PR TITLE
refactor: use lastIndex provide by exec

### DIFF
--- a/packages/vue-server-renderer/basic.js
+++ b/packages/vue-server-renderer/basic.js
@@ -2686,7 +2686,7 @@
       var exp = parseFilters(match[1].trim());
       tokens.push(("_s(" + exp + ")"));
       rawTokens.push({ '@binding': exp });
-      lastIndex = index + match[0].length;
+      lastIndex = tagRE.lastIndex;
     }
     if (lastIndex < text.length) {
       rawTokens.push(tokenValue = text.slice(lastIndex));

--- a/packages/vue-server-renderer/build.dev.js
+++ b/packages/vue-server-renderer/build.dev.js
@@ -2781,7 +2781,7 @@ function parseText (
     var exp = parseFilters(match[1].trim());
     tokens.push(("_s(" + exp + ")"));
     rawTokens.push({ '@binding': exp });
-    lastIndex = index + match[0].length;
+    lastIndex = tagRE.lastIndex;
   }
   if (lastIndex < text.length) {
     rawTokens.push(tokenValue = text.slice(lastIndex));

--- a/packages/vue-template-compiler/browser.js
+++ b/packages/vue-template-compiler/browser.js
@@ -1889,7 +1889,7 @@
       var exp = parseFilters(match[1].trim());
       tokens.push(("_s(" + exp + ")"));
       rawTokens.push({ '@binding': exp });
-      lastIndex = index + match[0].length;
+      lastIndex = tagRE.lastIndex;
     }
     if (lastIndex < text.length) {
       rawTokens.push(tokenValue = text.slice(lastIndex));

--- a/packages/vue-template-compiler/build.js
+++ b/packages/vue-template-compiler/build.js
@@ -1854,7 +1854,7 @@ function parseText (
     var exp = parseFilters(match[1].trim());
     tokens.push(("_s(" + exp + ")"));
     rawTokens.push({ '@binding': exp });
-    lastIndex = index + match[0].length;
+    lastIndex = tagRE.lastIndex;
   }
   if (lastIndex < text.length) {
     rawTokens.push(tokenValue = text.slice(lastIndex));

--- a/packages/weex-template-compiler/build.js
+++ b/packages/weex-template-compiler/build.js
@@ -710,7 +710,7 @@ function parseText (
     var exp = parseFilters(match[1].trim());
     tokens.push(("_s(" + exp + ")"));
     rawTokens.push({ '@binding': exp });
-    lastIndex = index + match[0].length;
+    lastIndex = tagRE.lastIndex;
   }
   if (lastIndex < text.length) {
     rawTokens.push(tokenValue = text.slice(lastIndex));

--- a/src/compiler/parser/text-parser.js
+++ b/src/compiler/parser/text-parser.js
@@ -40,7 +40,7 @@ export function parseText (
     const exp = parseFilters(match[1].trim())
     tokens.push(`_s(${exp})`)
     rawTokens.push({ '@binding': exp })
-    lastIndex = index + match[0].length
+    lastIndex = tagRE.lastIndex
   }
   if (lastIndex < text.length) {
     rawTokens.push(tokenValue = text.slice(lastIndex))


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

> I received lots of changes after run `npm run build`, so I skip it

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

lastIndex will auto-update in `RegExp.prototype.exec`, We do not need update manually
- https://tc39.es/ecma262/#sec-regexpbuiltinexec

**Other information:**

```js
var a = /a/g
var lastIndex = a.lastIndex
var match = a.exec("baa")
match[0].length + match.index === a.lastIndex
```