### PR TITLE
chore: remove computed cache:false option

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -220,7 +220,7 @@ export function defineComputed (
     sharedPropertyDefinition.set = noop
   } else {
     sharedPropertyDefinition.get = userDef.get
-      ? shouldCache && userDef.cache !== false
+      ? shouldCache
         ? createComputedGetter(key)
         : createGetterInvoker(userDef.get)
       : noop

--- a/test/unit/features/options/computed.spec.js
+++ b/test/unit/features/options/computed.spec.js
@@ -127,29 +127,6 @@ describe('Options computed', () => {
     expect(spy.calls.count()).toBe(1)
   })
 
-  it('cache: false', () => {
-    const spy = jasmine.createSpy('cached computed')
-    const vm = new Vue({
-      data: {
-        a: 1
-      },
-      computed: {
-        b: {
-          cache: false,
-          get () {
-            spy()
-            return this.a + 1
-          }
-        }
-      }
-    })
-    expect(spy.calls.count()).toBe(0)
-    vm.b
-    expect(spy.calls.count()).toBe(1)
-    vm.b
-    expect(spy.calls.count()).toBe(2)
-  })
-
   it('as component', done => {
     const Comp = Vue.extend({
       template: `<div>{{ b }} {{ c }}</div>`,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

As mentioned a while ago in another PR this option is deprecated in 2.x. If the maintainers have reservations against merging this PR then I think that at least we should provide a warning when _cache:false_ is used.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: remove deprecated feature

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Caching invalidation of computed properties will stop working in applications that use this feature. But as explained in the [migration guide](https://vuejs.org/v2/guide/migration.html#cache-false-deprecated) these applications should use normal methods instead, which should have the same result. 

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
