### PR TITLE
refactor(style): use arrow functions for unit tests

### DIFF
--- a/test/unit/features/component/component-slot.spec.js
+++ b/test/unit/features/component/component-slot.spec.js
@@ -131,7 +131,7 @@ describe('Component slot', () => {
     expect(child.$el.innerHTML).toBe('<p>1</p> <div>foo</div> <p>2</p>')
   })
 
-  it('name should only match children', function () {
+  it('name should only match children', () => {
     mount({
       childTemplate: `
         <div>
@@ -243,7 +243,7 @@ describe('Component slot', () => {
     }).then(done)
   })
 
-  it('template slot', function () {
+  it('template slot', () => {
     const vm = new Vue({
       template: '<test><template slot="test">hello</template></test>',
       components: {

--- a/test/unit/features/directives/for.spec.js
+++ b/test/unit/features/directives/for.spec.js
@@ -431,7 +431,7 @@ describe('Directive v-for', () => {
     }).then(done)
   })
 
-  it('check priorities: v-if before v-for', function () {
+  it('check priorities: v-if before v-for', () => {
     const vm = new Vue({
       data: {
         items: [1, 2, 3]
@@ -441,7 +441,7 @@ describe('Directive v-for', () => {
     expect(vm.$el.textContent).toBe('12')
   })
 
-  it('check priorities: v-if after v-for', function () {
+  it('check priorities: v-if after v-for', () => {
     const vm = new Vue({
       data: {
         items: [1, 2, 3]

--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -198,7 +198,7 @@ describe('Directive v-model text', () => {
     })
   }
 
-  it('compositionevents', function (done) {
+  it('compositionevents', done => {
     const vm = new Vue({
       data: {
         test: 'foo'

--- a/test/unit/features/directives/pre.spec.js
+++ b/test/unit/features/directives/pre.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 
-describe('Directive v-pre', function () {
-  it('should not compile inner content', function () {
+describe('Directive v-pre', () => {
+  it('should not compile inner content', () => {
     const vm = new Vue({
       template: `<div>
         <div v-pre>{{ a }}</div>
@@ -20,7 +20,7 @@ describe('Directive v-pre', function () {
     expect(vm.$el.lastChild.innerHTML).toBe('<component is="div"></component>')
   })
 
-  it('should not compile on root node', function () {
+  it('should not compile on root node', () => {
     const vm = new Vue({
       template: '<div v-pre>{{ a }}</div>',
       replace: true,
@@ -33,7 +33,7 @@ describe('Directive v-pre', function () {
   })
 
   // #8286
-  it('should not compile custom component tags', function () {
+  it('should not compile custom component tags', () => {
     Vue.component('vtest', { template: ` <div>Hello World</div>` })
     const vm = new Vue({
       template: '<div v-pre><vtest></vtest></div>',

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -384,7 +384,7 @@ describe('Options props', () => {
     expect(vm.$refs.child.propC).toBe(false)
   })
 
-  it('should respect default value of a Boolean prop', function () {
+  it('should respect default value of a Boolean prop', () => {
     const vm = new Vue({
       template: '<test></test>',
       components: {
@@ -434,7 +434,7 @@ describe('Options props', () => {
     }).then(done)
   })
 
-  it('should not warn for non-required, absent prop', function () {
+  it('should not warn for non-required, absent prop', () => {
     new Vue({
       template: '<test></test>',
       components: {

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -672,7 +672,7 @@ describe('parser', () => {
     expect(spy2).toHaveBeenCalledWith('img')
   })
 
-  it('preserve whitespace in <pre> tag', function () {
+  it('preserve whitespace in <pre> tag', () => {
     const options = extend({}, baseOptions)
     const ast = parse('<pre><code>  \n<span>hi</span>\n  </code><span> </span></pre>', options)
     const code = ast.children[0]
@@ -687,7 +687,7 @@ describe('parser', () => {
   })
 
   // #5992
-  it('ignore the first newline in <pre> tag', function () {
+  it('ignore the first newline in <pre> tag', () => {
     const options = extend({}, baseOptions)
     const ast = parse('<div><pre>\nabc</pre>\ndef<pre>\n\nabc</pre></div>', options)
     const pre = ast.children[0]
@@ -845,7 +845,7 @@ describe('parser', () => {
     expect(ast.children[4].children[0].text).toBe('. Have fun! ')
   })
 
-  it(`preserve whitespace in <pre> tag with whitespace: 'condense'`, function () {
+  it(`preserve whitespace in <pre> tag with whitespace: 'condense'`, () => {
     const options = extend({}, condenseOptions)
     const ast = parse('<pre><code>  \n<span>hi</span>\n  </code><span> </span></pre>', options)
     const code = ast.children[0]
@@ -859,7 +859,7 @@ describe('parser', () => {
     expect(span.children[0].text).toBe(' ')
   })
 
-  it(`ignore the first newline in <pre> tag with whitespace: 'condense'`, function () {
+  it(`ignore the first newline in <pre> tag with whitespace: 'condense'`, () => {
     const options = extend({}, condenseOptions)
     const ast = parse('<div><pre>\nabc</pre>\ndef<pre>\n\nabc</pre></div>', options)
     const pre = ast.children[0]

--- a/test/unit/modules/observer/scheduler.spec.js
+++ b/test/unit/modules/observer/scheduler.spec.js
@@ -110,7 +110,7 @@ describe('Scheduler', () => {
     }).then(done)
   })
 
-  it('warn against infinite update loops', function (done) {
+  it('warn against infinite update loops', done => {
     let count = 0
     const job = {
       id: 1,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

The majority of unit tests uses arrow functions for _describe_ and _it_ callbacks. This PR fixes the few that don't for a more consistent style.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
