### PR TITLE
fix(ssr): change throw error  to warn to fix hot reload

### DIFF
--- a/src/server/webpack-plugin/server.js
+++ b/src/server/webpack-plugin/server.js
@@ -1,4 +1,4 @@
-import { validate, isJS, onEmit } from './util'
+import { validate, isJS, onEmit, warn } from './util'
 
 export default class VueSSRServerPlugin {
   constructor (options = {}) {
@@ -23,7 +23,7 @@ export default class VueSSRServerPlugin {
       const entryAssets = entryInfo.assets.filter(isJS)
 
       if (entryAssets.length > 1) {
-        throw new Error(
+        warn(
           `Server-side bundle should have one single entry file. ` +
           `Avoid using CommonsChunkPlugin in the server config.`
         )


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
related issue: https://github.com/webpack/webpack/issues/9514, when used with koa-webapck.
Hot reload stopped working with error ``Server-side bundle should have one single entry file.Avoid using CommonsChunkPlugin in the server config.``. It caused by hmr plugin dynamically adding hot update js file to entrypoint.