### PR TITLE
fix(compiler): fix nested v-slot not updating when used with v-if/v-else

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -698,6 +698,13 @@ function processSlotContent (el) {
         slotContainer.children = el.children.filter((c: any) => {
           if (!c.slotScope) {
             c.parent = slotContainer
+            if (c.ifConditions) {
+              // #10330
+              // update every element's parent when it is in the other condition branch
+              // so we can find correctly whether the element is inside another scoped slot when
+              // generating scoped slot's rendering code, and this will trigger force updating
+              c.ifConditions.forEach(({block}) => block.parent = slotContainer)
+            }
             return true
           }
         })

--- a/test/unit/features/component/component-scoped-slot.spec.js
+++ b/test/unit/features/component/component-scoped-slot.spec.js
@@ -1325,4 +1325,39 @@ describe('Component scoped slot', () => {
       expect(vm.$el.textContent).toMatch(`1`)
     }).then(done)
   })
+
+  // #10330
+  it('nested v-slot should be reactive when v-slot on component itself combined with v-if/v-else', done => {
+    const Container = {
+      template: `<div><slot v-bind="n" /></div>`,
+      props: ['n']
+    }
+
+    const Nested = {
+      template: `<div><slot v-bind="m" /></div>`,
+      props: ['m']
+    }
+
+    const vm = new Vue({
+      data: {
+        n: { value: 0 }, 
+        disabled: false
+      },
+      components: { Container, Nested },
+      template: `
+        <container v-slot="n" :n="n">
+          <div v-if="disabled">Disabled</div>
+          <nested v-else v-slot="m" :m="n">
+            {{n.value}} {{m.value}}
+          </nested>
+        </container>
+      `
+    }).$mount()
+
+    expect(vm.$el.textContent).toMatch(`0 0`)
+    vm.n.value++
+    waitForUpdate(() => {
+      expect(vm.$el.textContent).toMatch(`1 1`)
+    }).then(done)
+  })
 })


### PR DESCRIPTION
fix nested v-slot not updating when v-if/v-else used in the root element of the slot content, and it will close #10330 .

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
