### PR TITLE
fix(traverse): Prevent traversing Vue instances

### DIFF
--- a/src/core/observer/traverse.js
+++ b/src/core/observer/traverse.js
@@ -3,6 +3,8 @@
 import { _Set as Set, isObject } from '../util/index'
 import type { SimpleSet } from '../util/index'
 import VNode from '../vdom/vnode'
+import Vue from '../instance/index'
+
 
 const seenObjects = new Set()
 
@@ -19,7 +21,7 @@ export function traverse (val: any) {
 function _traverse (val: any, seen: SimpleSet) {
   let i, keys
   const isA = Array.isArray(val)
-  if ((!isA && !isObject(val)) || Object.isFrozen(val) || val instanceof VNode) {
+  if ((!isA && !isObject(val)) || Object.isFrozen(val) || val instanceof VNode || val instanceof Vue) {
     return
   }
   if (val.__ob__) {

--- a/test/unit/features/options/watch.spec.js
+++ b/test/unit/features/options/watch.spec.js
@@ -106,6 +106,29 @@ describe('Options watch', () => {
     }).then(done)
   })
 
+  it('with option: deep and with reference to a Vue instance', done => {
+    const vueInstance = new Vue();
+    const vm = new Vue({
+      data: { a: { b: vueInstance }},
+      watch: {
+        a: {
+          handler: spy,
+          deep: true
+        }
+      }
+    })
+    const oldA = vm.a
+    expect(spy).not.toHaveBeenCalled()
+    vm.a.b = 2
+    expect(spy).not.toHaveBeenCalled()
+    waitForUpdate(() => {
+      expect(spy).toHaveBeenCalledWith(vm.a, vm.a)
+      vm.a = { b: 3 }
+    }).then(() => {
+      expect(spy).toHaveBeenCalledWith(vm.a, oldA)
+    }).then(done)
+  })
+
   it('correctly merges multiple extends', done => {
     const spy2 = jasmine.createSpy('A')
     const spy3 = jasmine.createSpy('B')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This fixes a bug first discovered in Vuex where storing Vue instances in the Store generates a `RangeError: Maximum call stack size exceeded`.

Related: https://github.com/vuejs/vuex/issues/1587

> If there is another approach for this I'm happy to go that road and suggest an alternative fix or documentation improvement..
