### PR TITLE
fix(types): allow string for watch handlers

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -177,7 +177,7 @@ export interface WatchOptions {
 }
 
 export interface WatchOptionsWithHandler<T> extends WatchOptions {
-  handler: WatchHandler<T>;
+  handler: WatchHandler<T> | string;
 }
 
 export interface DirectiveBinding extends Readonly<VNodeDirective> {

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -76,7 +76,7 @@ export interface ComponentOptions<
   propsData?: object;
   computed?: Accessors<Computed>;
   methods?: Methods;
-  watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | string>;
+  watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any>>;
 
   el?: Element | string;
   template?: string;

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -169,7 +169,7 @@ export interface ComputedOptions<T> {
   cache?: boolean;
 }
 
-export type WatchHandler<T> = (val: T, oldVal: T) => void;
+export type WatchHandler<T> = string | ((val: T, oldVal: T) => void);
 
 export interface WatchOptions {
   deep?: boolean;
@@ -177,7 +177,7 @@ export interface WatchOptions {
 }
 
 export interface WatchOptionsWithHandler<T> extends WatchOptions {
-  handler: WatchHandler<T> | string;
+  handler: WatchHandler<T>;
 }
 
 export interface DirectiveBinding extends Readonly<VNodeDirective> {

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -169,6 +169,10 @@ Vue.component('component', {
         this.a = val
       },
       deep: true
+    },
+    d: {
+      handler: 'someMethod',
+      immediate: true
     }
   },
   el: "#app",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Adds missing TypeScript type info allowing watcher handler to be of `string` type