### PR TITLE
fix: binding of `muted` dom property for <audio>

### DIFF
--- a/src/platforms/web/util/attrs.js
+++ b/src/platforms/web/util/attrs.js
@@ -13,7 +13,8 @@ export const mustUseProp = (tag: string, type: ?string, attr: string): boolean =
     (attr === 'value' && acceptValue(tag)) && type !== 'button' ||
     (attr === 'selected' && tag === 'option') ||
     (attr === 'checked' && tag === 'input') ||
-    (attr === 'muted' && tag === 'video')
+    (attr === 'muted' && tag === 'video') ||
+    (attr === 'muted' && tag === 'audio')
   )
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Binding the DOM `muted` property to a Vue.js property is currently working only on `<video>` elements, but not on `<audio>` elements. Example: https://jsfiddle.net/jfLkynsg/

This trivial change fixes the binding for `<audio>`.