### PR TITLE
feat(core): allow users to create a Vue-instance without the "new" ke…

### DIFF
--- a/src/core/instance/index.js
+++ b/src/core/instance/index.js
@@ -3,13 +3,12 @@ import { stateMixin } from './state'
 import { renderMixin } from './render'
 import { eventsMixin } from './events'
 import { lifecycleMixin } from './lifecycle'
-import { warn } from '../util/index'
 
 function Vue (options) {
   if (process.env.NODE_ENV !== 'production' &&
     !(this instanceof Vue)
   ) {
-    warn('Vue is a constructor and should be called with the `new` keyword')
+   return new Vue(options)
   }
   this._init(options)
 }

--- a/test/unit/features/instance/init.spec.js
+++ b/test/unit/features/instance/init.spec.js
@@ -1,11 +1,6 @@
 import Vue from 'vue'
 
 describe('Initialization', () => {
-  it('without new', () => {
-    try { Vue() } catch (e) {}
-    expect('Vue is a constructor and should be called with the `new` keyword').toHaveBeenWarned()
-  })
-
   it('with new', () => {
     expect(new Vue() instanceof Vue).toBe(true)
   })


### PR DESCRIPTION
Hi!

I believe that **not** enforcing the usage of the 'new' keyword when creating a vue-instance would be a tiny but good improvement for the code. All the tests are passing except for the one that goes against the purpose of of the code change, therefore i had to delete it.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
