### PR TITLE
bail out of event blocking for Adobe CEP bug (fix #10366)

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { isObject } from 'shared/util'
+
 // can we use __proto__?
 export const hasProto = '__proto__' in {}
 
@@ -16,7 +18,7 @@ export const isIOS = (UA && /iphone|ipad|ipod|ios/.test(UA)) || (weexPlatform ==
 export const isChrome = UA && /chrome\/\d+/.test(UA) && !isEdge
 export const isPhantomJS = UA && /phantomjs/.test(UA)
 export const isFF = UA && UA.match(/firefox\/(\d+)/)
-export const isCEP = inBrowser && window.__adobe_cep__ !== undefined
+export const isCEP = inBrowser && isObject(window.__adobe_cep__)
 
 // Firefox has a "watch" function on Object.prototype...
 export const nativeWatch = ({}).watch

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -16,6 +16,7 @@ export const isIOS = (UA && /iphone|ipad|ipod|ios/.test(UA)) || (weexPlatform ==
 export const isChrome = UA && /chrome\/\d+/.test(UA) && !isEdge
 export const isPhantomJS = UA && /phantomjs/.test(UA)
 export const isFF = UA && UA.match(/firefox\/(\d+)/)
+export const isCEP = inBrowser && window.__adobe_cep__ !== undefined
 
 // Firefox has a "watch" function on Object.prototype...
 export const nativeWatch = ({}).watch

--- a/src/platforms/web/runtime/modules/events.js
+++ b/src/platforms/web/runtime/modules/events.js
@@ -47,10 +47,12 @@ const useMicrotaskFix = isUsingMicroTask && !(isFF && Number(isFF[1]) <= 53)
 // #10366: CEP <= 9.3.x has a buggy Event.timeStamp implementation. While the
 // issue is restricted to macOS, the fix is OS-agnostic to keep behavioral
 // differences to a minimum.
-const isCEP93orEarlier = isCEP && ((maxBadMajor, maxBadMinor) => {
+const isCEP93orEarlier = isCEP &&
+      (typeof window.__adobe_cep__.getCurrentApiVersion !== 'function' ||
+      ((maxBadMajor, maxBadMinor) => {
   const version = JSON.parse(window.__adobe_cep__.getCurrentApiVersion())
   return version.major <= maxBadMajor && version.minor <= maxBadMinor
-})(9, 3)
+})(9, 3))
 
 function add (
   name: string,


### PR DESCRIPTION
fix #10366

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Some [Adobe CEP](https://github.com/Adobe-CEP) [environments](https://github.com/Adobe-CEP/CEP-Resources/blob/master/CEP_9.x/Documentation/CEP%209.0%20HTML%20Extension%20Cookbook.md#applications-integrated-with-cep) have a broken `Event.timeStamp` implementation that breaks event blocking logic. The issue specifically affects host applications running on macOS with CEP version 9.3 and below. This workaround is OS-agnostic so as to maintain identical behavior across platforms. More details can be found in issue #10366.