### PR TITLE
feat(web): Integrate trusted types into Vue

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -33,6 +33,9 @@ export type Config = {
 
   // legacy
   _lifecycleHooks: Array<string>;
+
+  // trusted types (https://github.com/WICG/trusted-types)
+  trustedTypesPolicyName: string;
 };
 
 export default ({
@@ -126,5 +129,11 @@ export default ({
   /**
    * Exposed for legacy reasons
    */
-  _lifecycleHooks: LIFECYCLE_HOOKS
+  _lifecycleHooks: LIFECYCLE_HOOKS,
+
+  /**
+   * Trusted Types policy name which will be used by Vue. More
+   * info about Trusted Types on https://github.com/WICG/trusted-types.
+   */
+  trustedTypesPolicyName: 'vue'
 }: Config)

--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -2,7 +2,7 @@
 
 import { isDef, isUndef, extend, toNumber } from 'shared/util'
 import { isSVG } from 'web/util/index'
-import {convertToTrustedType} from 'web/security'
+import {maybeCreateDangerousSvgHTML} from 'web/security'
 
 let svgContainer
 
@@ -53,7 +53,7 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
     } else if (key === 'innerHTML' && isSVG(elm.tagName) && isUndef(elm.innerHTML)) {
       // IE doesn't support innerHTML for SVG elements
       svgContainer = svgContainer || document.createElement('div')
-      svgContainer.innerHTML = convertToTrustedType(`<svg>${cur}</svg>`)
+      svgContainer.innerHTML = maybeCreateDangerousSvgHTML(cur)
       const svg = svgContainer.firstChild
       while (elm.firstChild) {
         elm.removeChild(elm.firstChild)

--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -2,6 +2,7 @@
 
 import { isDef, isUndef, extend, toNumber } from 'shared/util'
 import { isSVG } from 'web/util/index'
+import {convertToTrustedType} from 'web/security'
 
 let svgContainer
 
@@ -20,6 +21,7 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
 
   for (key in oldProps) {
     if (!(key in props)) {
+      // TT_TODO: when (how) is this even called
       elm[key] = ''
     }
   }
@@ -51,7 +53,7 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
     } else if (key === 'innerHTML' && isSVG(elm.tagName) && isUndef(elm.innerHTML)) {
       // IE doesn't support innerHTML for SVG elements
       svgContainer = svgContainer || document.createElement('div')
-      svgContainer.innerHTML = `<svg>${cur}</svg>`
+      svgContainer.innerHTML = convertToTrustedType(`<svg>${cur}</svg>`)
       const svg = svgContainer.firstChild
       while (elm.firstChild) {
         elm.removeChild(elm.firstChild)

--- a/src/platforms/web/security.js
+++ b/src/platforms/web/security.js
@@ -8,24 +8,50 @@ type TrustedTypePolicy = {
 };
 
 let policy: ?TrustedTypePolicy
-// we need this function to clear the policy in tests
-Vue.prototype.$clearTrustedTypesPolicy = function() {
-  policy = undefined
-}
-
-export function maybeCreateDangerousSvgHTML(value: any): string {
-  // create policy lazily to simplify testing
+// create policy lazily to simplify testing
+function getOrCreatePolicy() {
   const tt = getTrustedTypes()
   if (tt && !policy) {
     policy = tt.createPolicy(Vue.config.trustedTypesPolicyName, {createHTML: (s) => s});
   }
 
-  if (!tt) return `<svg>${value}</svg>`;
-  else if (!isTrustedValue(value)) throw new Error('Expected svg innerHTML to be TrustedHTML!');
-  // flow complains 'policy' may be undefined
-  else return (policy: any).createHTML(`<svg>${value}</svg>`);
+  return policy
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // we need this function to clear the policy in tests
+  Vue.prototype.$clearTrustedTypesPolicy = function() {
+    policy = undefined
+  }
+}
+
+// TODO: remove once https://github.com/WICG/trusted-types/issues/36 is resolved.
+function isApplicationUsingTrustedTypes() {
+  // This check actually checks whether Trusted Types are enforced or not.
+  // However application might still use them in report only mode.
+  // This has also a side effect that CSP violation will be triggered.
+  try {
+    document.createElement('div').innerHTML = 'string';
+    return false;
+  } catch (e) {
+    return true;
+  }
+}
+
+export function maybeCreateDangerousSvgHTML(value: any): string {
+  const tt = getTrustedTypes()
+
+  if (!tt || !isApplicationUsingTrustedTypes()) return `<svg>${value}</svg>`;
+  else if (!isTrustedValue(value)) {
+    throw new Error('Expected svg innerHTML to be TrustedHTML!');
+  }
+  // flow complains that 'getOrCreatePolicy()' might return null.
+  else return (getOrCreatePolicy(): any).createHTML(`<svg>${value}</svg>`);
 }
 
 export function getTrustedShouldDecodeInnerHTML(href: boolean): string {
-  return href ? `<a href="\n"/>` : `<div a="\n"/>`
+  const html = href ? `<a href="\n"/>` : `<div a="\n"/>`;
+  const p = getOrCreatePolicy()
+  if (!p) return html;
+  else return p.createHTML(html);
 }

--- a/src/platforms/web/security.js
+++ b/src/platforms/web/security.js
@@ -25,27 +25,11 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
-// TODO: remove once https://github.com/WICG/trusted-types/issues/36 is resolved.
-function isApplicationUsingTrustedTypes() {
-  // This check actually checks whether Trusted Types are enforced or not.
-  // However application might still use them in report only mode.
-  // This has also a side effect that CSP violation will be triggered.
-  try {
-    document.createElement('div').innerHTML = 'string';
-    return false;
-  } catch (e) {
-    return true;
-  }
-}
-
 export function maybeCreateDangerousSvgHTML(value: any): string {
   const tt = getTrustedTypes()
 
-  if (!tt || !isApplicationUsingTrustedTypes()) return `<svg>${value}</svg>`;
-  else if (!isTrustedValue(value)) {
-    throw new Error('Expected svg innerHTML to be TrustedHTML!');
-  }
-  // flow complains that 'getOrCreatePolicy()' might return null.
+  if (!tt || !isTrustedValue(value)) return `<svg>${value}</svg>`;
+  // flow complains that 'getOrCreatePolicy()' might return null
   else return (getOrCreatePolicy(): any).createHTML(`<svg>${value}</svg>`);
 }
 

--- a/src/platforms/web/security.js
+++ b/src/platforms/web/security.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+type TrustedTypePolicy = {
+  // value returned is actually an object with toString method returning the wrapped value
+  createHTML: (value: any) => string;
+};
+
+let policy: TrustedTypePolicy
+export function convertToTrustedType(value: any) {
+  // create policy lazily to simplify testing
+  const tt = getTrustedTypes()
+  if (tt && !policy) {
+    policy = tt.createPolicy('vue', {createHTML: (s) => s});
+  }
+
+  if (!tt) return value;
+  else return policy.createHTML(value);
+}
+
+export function getTrustedTypes() {
+  // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
+  return window.trustedTypes || window.TrustedTypes;
+}

--- a/src/platforms/web/security.js
+++ b/src/platforms/web/security.js
@@ -1,23 +1,31 @@
 /* @flow */
+import Vue from 'core/index'
+import {getTrustedTypes, isTrustedValue} from 'shared/util'
 
 type TrustedTypePolicy = {
   // value returned is actually an object with toString method returning the wrapped value
   createHTML: (value: any) => string;
 };
 
-let policy: TrustedTypePolicy
-export function convertToTrustedType(value: any) {
+let policy: ?TrustedTypePolicy
+// we need this function to clear the policy in tests
+Vue.prototype.$clearTrustedTypesPolicy = function() {
+  policy = undefined
+}
+
+export function maybeCreateDangerousSvgHTML(value: any): string {
   // create policy lazily to simplify testing
   const tt = getTrustedTypes()
   if (tt && !policy) {
-    policy = tt.createPolicy('vue', {createHTML: (s) => s});
+    policy = tt.createPolicy(Vue.config.trustedTypesPolicyName, {createHTML: (s) => s});
   }
 
-  if (!tt) return value;
-  else return policy.createHTML(value);
+  if (!tt) return `<svg>${value}</svg>`;
+  else if (!isTrustedValue(value)) throw new Error('Expected svg innerHTML to be TrustedHTML!');
+  // flow complains 'policy' may be undefined
+  else return (policy: any).createHTML(`<svg>${value}</svg>`);
 }
 
-export function getTrustedTypes() {
-  // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
-  return window.trustedTypes || window.TrustedTypes;
+export function getTrustedShouldDecodeInnerHTML(href: boolean): string {
+  return href ? `<a href="\n"/>` : `<div a="\n"/>`
 }

--- a/src/platforms/web/util/compat.js
+++ b/src/platforms/web/util/compat.js
@@ -1,13 +1,13 @@
 /* @flow */
 
 import { inBrowser } from 'core/util/index'
-import {convertToTrustedType} from 'web/security'
+import {getTrustedShouldDecodeInnerHTML} from 'web/security'
 
 // check whether current browser encodes a char inside attribute values
 let div
 function getShouldDecode (href: boolean): boolean {
   div = div || document.createElement('div')
-  div.innerHTML = convertToTrustedType(href ? `<a href="\n"/>` : `<div a="\n"/>`)
+  div.innerHTML = getTrustedShouldDecodeInnerHTML(href)
   return div.innerHTML.indexOf('&#10;') > 0
 }
 

--- a/src/platforms/web/util/compat.js
+++ b/src/platforms/web/util/compat.js
@@ -1,12 +1,13 @@
 /* @flow */
 
 import { inBrowser } from 'core/util/index'
+import {convertToTrustedType} from 'web/security'
 
 // check whether current browser encodes a char inside attribute values
 let div
 function getShouldDecode (href: boolean): boolean {
   div = div || document.createElement('div')
-  div.innerHTML = href ? `<a href="\n"/>` : `<div a="\n"/>`
+  div.innerHTML = convertToTrustedType(href ? `<a href="\n"/>` : `<div a="\n"/>`)
   return div.innerHTML.indexOf('&#10;') > 0
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -79,14 +79,23 @@ export function isPromise (val: any): boolean {
   )
 }
 
+export function getTrustedTypes() {
+  // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
+  return typeof window !== 'undefined' && (window.trustedTypes || window.TrustedTypes);
+}
+
+export function isTrustedValue(value: any): boolean {
+  const tt = getTrustedTypes();
+  if (!tt) return false;
+  // TrustedURLs are deprecated and will be removed soon: https://github.com/WICG/trusted-types/pull/204
+  else return tt.isHTML(value) || tt.isScript(value) || tt.isScriptURL(value) || (tt.isURL && tt.isURL(value))
+}
+
 /**
  * Convert a value to a string that is actually rendered.
  */
 export function toString (val: any): string {
-  // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
-  const tt = window.trustedTypes || window.TrustedTypes;
-  // TrustedURLs are deprecated and will be removed soon: https://github.com/WICG/trusted-types/pull/204
-  if (tt && (tt.isHTML(val) || tt.isScript(val) || tt.isScriptURL(val) || (tt.isURL && tt.isURL(val)))) {
+  if (isTrustedValue(val)) {
     return val;
   } else {
     return val == null

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -83,11 +83,18 @@ export function isPromise (val: any): boolean {
  * Convert a value to a string that is actually rendered.
  */
 export function toString (val: any): string {
-  return val == null
-    ? ''
-    : Array.isArray(val) || (isPlainObject(val) && val.toString === _toString)
-      ? JSON.stringify(val, null, 2)
-      : String(val)
+  // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
+  const tt = window.trustedTypes || window.TrustedTypes;
+  // TrustedURLs are deprecated and will be removed soon: https://github.com/WICG/trusted-types/pull/204
+  if (tt && (tt.isHTML(val) || tt.isScript(val) || tt.isScriptURL(val) || (tt.isURL && tt.isURL(val)))) {
+    return val;
+  } else {
+    return val == null
+      ? ''
+      : Array.isArray(val) || (isPlainObject(val) && val.toString === _toString)
+        ? JSON.stringify(val, null, 2)
+        : String(val)
+  }
 }
 
 /**

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -79,9 +79,13 @@ export function isPromise (val: any): boolean {
   )
 }
 
+let trustedTypes = undefined
 export function getTrustedTypes() {
-  // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
-  return typeof window !== 'undefined' && (window.trustedTypes || window.TrustedTypes);
+  if (trustedTypes === undefined) {
+    // TrustedTypes have been renamed to trustedTypes https://github.com/WICG/trusted-types/issues/177
+    trustedTypes = typeof window !== 'undefined' ? (window.trustedTypes || window.TrustedTypes) : null;
+  }
+  return trustedTypes;
 }
 
 export function isTrustedValue(value: any): boolean {

--- a/test/unit/features/trusted-types.spec.js
+++ b/test/unit/features/trusted-types.spec.js
@@ -201,7 +201,8 @@ describe('rendering with trusted types enforced', () => {
 
       expect(() => {
         vm.$mount();
-      }).toThrowError('Expected svg innerHTML to be TrustedHTML!');
+      }).toThrow();
+      expect(errorLog).toEqual([createTTErrorMessage('innerHTML', `<svg>${unsafeHtml}</svg>`)]);
     });
 
     it('passes if payload is TrustedHTML', () => {

--- a/test/unit/features/trusted-types.spec.js
+++ b/test/unit/features/trusted-types.spec.js
@@ -1,0 +1,219 @@
+// NOTE: We emulate trusted types behaviour such that the tests
+// are deterministic. These tests needs to be updated if the trusted
+// types API changes.
+// 
+// You can find trusted types repository here:
+// https://github.com/WICG/trusted-types
+// 
+// TODO: replace testing setup with polyfill, once it exports
+// enforcing API.
+
+import Vue from 'vue'
+
+// we don't differentiate between different types of trusted values
+const createTrustedValue = (value) => `TRUSTED${value}`;
+const isTrustedValue = (value) => value.startsWith('TRUSTED');
+const unwrapTrustedValue = (value) => value.substr('TRUSTED'.length);
+
+const unsafeHtml = '<img src=x onerror="alert(0)">';
+const unsafeScript = 'alert(0)';
+
+describe('rendering with trusted types enforced', () => {
+  let descriptorEntries = [];
+  let setAttributeDescriptor;
+  let policy;
+  // NOTE: trusted type error is not propagated from v-html directive and application will not
+  // render the dangerous html, but will continue rendering other components. If the error is 
+  // thrown by unsafe setAttribute call (e.g. srcdoc in iframe) the rendering fails completely.
+  // We log the errors, before throwing so we can be sure that trusted types work.
+  let errorLog;
+
+  function emulateSetAttribute() {
+    // enforce trusted values only on properties in this array
+    const unsafeAttributeList = ['srcdoc', 'onclick'];
+    setAttributeDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'setAttribute');
+    Object.defineProperty(Element.prototype, 'setAttribute', {
+      value: function(name, value) {
+        let args = [name, value];
+        unsafeAttributeList.forEach((attr) => {
+          if (attr === name) {
+            if (isTrustedValue(value)) {
+              args = [name, unwrapTrustedValue(value)];
+            } else {
+              errorLog.push(createTTErrorMessage(attr, value));
+              throw new Error(value);
+            }
+          }
+        });
+        setAttributeDescriptor.value.apply(this, args);
+      }
+    });
+  }
+
+  function emulateTrustedTypesOnProperty(object, prop) {
+    const desc = Object.getOwnPropertyDescriptor(object, prop);
+    descriptorEntries.push({object, prop, desc});
+    Object.defineProperty(object, prop, {
+      set: function(value) {
+        if (isTrustedValue(value)) {
+          desc.set.apply(this, [unwrapTrustedValue(value)]);
+        } else {
+          errorLog.push(createTTErrorMessage(prop, value));
+          throw new Error(value);
+        }
+      },
+    });
+  }
+
+  function removeAllTrustedTypesEmulation() {
+    descriptorEntries.forEach(({object, prop, desc}) => {
+      Object.defineProperty(object, prop, desc);
+    });
+    descriptorEntries = [];
+
+    Object.defineProperty(
+        Element.prototype, 'setAttribute', setAttributeDescriptor);
+  }
+
+  function createTTErrorMessage(name, value) {
+    return `TT ERROR: ${name} ${value}`;
+  }
+
+  beforeEach(() => {
+    window.trustedTypes = {
+      createPolicy: () => {
+        return {
+          createHTML: createTrustedValue,
+          createScript: createTrustedValue,
+          createScriptURL: createTrustedValue,
+        };
+      },
+      isHTML: (v) => isTrustedValue(v),
+      isScript: (v) => isTrustedValue(v),
+      isScriptURL: (v) => isTrustedValue(v),
+    };
+
+    emulateTrustedTypesOnProperty(Element.prototype, 'innerHTML');
+    emulateTrustedTypesOnProperty(HTMLIFrameElement.prototype, 'srcdoc');
+    emulateSetAttribute();
+
+    // TODO: this needs to be changed once we use trusted types polyfill
+    policy = window.trustedTypes.createPolicy();
+
+    errorLog = [];
+  });
+
+  afterEach(() => {
+    removeAllTrustedTypesEmulation();
+    delete window.trustedTypes;
+  });
+
+  it('Trusted types emulation works', () => {
+    const el = document.createElement('div');
+    expect(el.innerHTML).toBe('');
+    el.innerHTML = policy.createHTML('<span>val</span>');
+    expect(el.innerHTML, '<span>val</span>');
+
+    expect(() => {
+      el.innerHTML = '<span>val</span>';
+    }).toThrow();
+  });
+
+  // html interpolation is safe because it's put into DOM as text node
+  it('interpolation is trusted', () => {
+    const vm = new Vue({
+      data: {
+        unsafeHtml,
+      },
+      template: '<div>{{unsafeHtml}}</div>'
+    })
+
+    vm.$mount();
+    expect(vm.$el.textContent).toBe(document.createTextNode(unsafeHtml).textContent);
+  });
+
+  describe('throws on untrusted values', () => {
+    it('v-html directive', () => {
+      const vm = new Vue({
+        data: {
+          unsafeHtml,
+        },
+        template: '<div v-html="unsafeHtml"></div>'
+      })
+
+      vm.$mount();
+      expect(errorLog).toEqual([createTTErrorMessage('innerHTML', unsafeHtml)]);
+    });
+
+    it('attribute interpolation', () => {
+      const vm = new Vue({
+        data: {
+          unsafeHtml,
+        },
+        template: '<iframe :srcdoc="unsafeHtml"></iframe>'
+      })
+      
+      expect(() => {
+        vm.$mount();
+      }).toThrow();
+      expect(errorLog).toEqual([createTTErrorMessage('srcdoc', unsafeHtml)]);
+    });
+
+    it('on* events', () => {
+      const vm = new Vue({
+        data: {
+          unsafeScript,
+        },
+        template: '<button :onclick="unsafeScript">unsafe btn</button>'
+      })
+
+      expect(() => {
+        vm.$mount();
+      }).toThrow();
+      expect(errorLog).toEqual([createTTErrorMessage('onclick', unsafeScript)]);
+    });
+  });
+
+  describe('runs without error on trusted values', () => {
+    it('v-html directive', () => {
+      const vm = new Vue({
+        data: {
+          safeHtml: policy.createHTML('safeHtmlValue'),
+        },
+        template: '<div v-html="safeHtml"></div>'
+      })
+
+      vm.$mount();
+      expect(vm.$el.innerHTML).toBe('safeHtmlValue');
+      expect(errorLog).toEqual([]);
+    });
+
+    it('attribute interpolation', () => {
+      const vm = new Vue({
+        data: {
+          safeScript: policy.createScript('safeScriptValue'),
+        },
+        template: '<iframe :srcdoc="safeScript"></iframe>'
+      })
+
+      vm.$mount();
+      expect(vm.$el.srcdoc).toBe('safeScriptValue');
+      expect(errorLog).toEqual([]);
+    });
+
+    it('on* events', () => {
+      const vm = new Vue({
+        data: {
+          safeScript: policy.createScript('safeScriptValue'),
+        },
+        template: '<button :onclick="safeScript">unsafe btn</button>'
+      })
+
+      vm.$mount();
+      const onClickFn = vm.$el.onclick.toString();
+      const onClickBody = onClickFn.substring(onClickFn.indexOf("{") + 1, onClickFn.lastIndexOf("}"));
+      expect(onClickBody.trim()).toBe('safeScriptValue');
+      expect(errorLog).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Trusted Types
[Trusted Types](https://github.com/WICG/trusted-types) ([spec](https://wicg.github.io/trusted-types/dist/spec/), [introductory article](https://developers.google.com/web/updates/2019/02/trusted-types)) is a new experimental DOM API implemented within the WICG , with a working [Chrome implementation](https://www.chromestatus.com/feature/5650088592408576).

The API creates a few new objects available on the global object in the browser, like most other web APIs ([impl in TS](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/trusted-types/index.d.ts) and in [Closure compiler](https://github.com/WICG/trusted-types/blob/master/externs/externs.js)).

Under certain conditions, controlled by a HTTP header (analogous to Content-Security-Policy behavior), the API can enable the enforcement - then it changes the signature of several DOM API functions and property setters, such that they accept specific object types, and reject strings. Colloquially, DOM API becomes strongly typed.

For example, with Trusted Types Element.innerHTML property setter accepts a TrustedHTML object.

Trusted Type objects stringify to their inner value. This API shape is a deliberate choice that enables existing web applications and libraries to gradually migrate from strings to Trusted Types without breaking functionality. In our example, it makes it possible to write the following:

```javascript
const policy = TrustedTypes.createPolicy('foo', { 
  createHTML: (s) => { /* some validation*/; return s} 
});

const trustedHTML = policy.createHTML('bar');
anElement.innerHTML = trustedHTML

anElement.innerHTML === 'bar'
```

The above code works regardless if the Trusted Types enforcement is enabled or not.

Reading from the DOM is unaffected, so Element.innerHTML getter returns a string. That's for practical reasons -- web applications read from DOM more often than they write to it, and only writing exposes the application to DOM XSS risks. Typing only the setters allows us to secure web applications with minimal code changes.

### Integrating Trusted Types to Vue
The integration is fairly simple as there are not many places which break when using Vue with Trusted Types. There one place though, which I am not sure if it's even called (couldn't trigger it myself). It's marked in a code with `TT_TODO: ...` comment. I hope someone can clarify this for me. **The PR doesn't introduce any breaking changes**. All of the code is applied only when the trustedTypes API is available in the global object.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The PR adds support for Trusted Types only on client side, but it might be beneficial to use them also on server side. There is no DOM on server side, however we can check if the values are trusted before creating markup with dangerous attributes. This also makes the applications render the same thing on the server and on client. There is already a similar [PR for this for React](https://github.com/facebook/react/pull/16555).

If you would like to try this change there is a [really simple application](https://github.com/Siegrift/vue-example-app) with the instructions how to setup vue locally in which you can play with Trusted Types. Vue cli uses webpack for development which provides features like hot-reloading. This currently breaks, but the [PR is already fired and we are waiting for review](https://github.com/webpack/webpack/pull/9426).