### PR TITLE
feat(v-for): add 'loop' iterator to v-for 

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -148,6 +148,7 @@ declare type ASTElement = {
   alias?: string;
   iterator1?: string;
   iterator2?: string;
+  iterator3?: string;
 
   staticClass?: string;
   classBinding?: string;

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -133,6 +133,7 @@ export interface ASTElement {
   alias?: string;
   iterator1?: string;
   iterator2?: string;
+  iterator3?: string;
 
   staticClass?: string;
   classBinding?: string;

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -193,6 +193,7 @@ export function genFor (
   const alias = el.alias
   const iterator1 = el.iterator1 ? `,${el.iterator1}` : ''
   const iterator2 = el.iterator2 ? `,${el.iterator2}` : ''
+  const iterator3 = el.iterator3 ? `,${el.iterator3}` : ''
 
   if (process.env.NODE_ENV !== 'production' &&
     state.maybeComponent(el) &&
@@ -211,7 +212,7 @@ export function genFor (
 
   el.forProcessed = true // avoid recursion
   return `${altHelper || '_l'}((${exp}),` +
-    `function(${alias}${iterator1}${iterator2}){` +
+    `function(${alias}${iterator1}${iterator2}${iterator3}){` +
       `return ${(altGen || genElement)(el, state)}` +
     '})'
 }

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -26,7 +26,7 @@ export const dirRE = process.env.VBIND_PROP_SHORTHAND
   ? /^v-|^@|^:|^\.|^#/
   : /^v-|^@|^:|^#/
 export const forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
-export const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
+export const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?(?:,([^,\}\]]*))?$/
 const stripParensRE = /^\(|\)$/g
 const dynamicArgRE = /^\[.*\]$/
 
@@ -506,6 +506,7 @@ type ForParseResult = {
   alias: string;
   iterator1?: string;
   iterator2?: string;
+  iterator3?: string;
 };
 
 export function parseFor (exp: string): ?ForParseResult {
@@ -520,6 +521,9 @@ export function parseFor (exp: string): ?ForParseResult {
     res.iterator1 = iteratorMatch[1].trim()
     if (iteratorMatch[2]) {
       res.iterator2 = iteratorMatch[2].trim()
+    }
+    if (iteratorMatch[3]) {
+      res.iterator3 = iteratorMatch[3].trim()
     }
   } else {
     res.alias = alias

--- a/src/core/instance/render-helpers/render-list.js
+++ b/src/core/instance/render-helpers/render-list.js
@@ -5,32 +5,57 @@ import { isObject, isDef, hasSymbol } from 'core/util/index'
 /**
  * Runtime helper for rendering v-for lists.
  */
-export function renderList (
+type ForLoopParams = {
+  first: boolean;
+  last: boolean;
+  even: boolean;
+  odd: boolean;
+  remaining: number;
+}
+
+function genForLoopParams(i, length): ForLoopParams {
+  return {
+    first: i === 0,
+    last: i === length - 1,
+    even: i % 2 === 0,
+    odd: i % 2 !== 0,
+    remaining: length - (i + 1)
+  }
+}
+
+export function renderList(
   val: any,
   render: (
     val: any,
     keyOrIndex: string | number,
-    index?: number
+    indexOrLoop?: number | ForLoopParams,
+    loop?: ForLoopParams
   ) => VNode
 ): ?Array<VNode> {
   let ret: ?Array<VNode>, i, l, keys, key
   if (Array.isArray(val) || typeof val === 'string') {
     ret = new Array(val.length)
     for (i = 0, l = val.length; i < l; i++) {
-      ret[i] = render(val[i], i)
+      ret[i] = render(val[i], i, genForLoopParams(i, ret.length))
     }
   } else if (typeof val === 'number') {
     ret = new Array(val)
     for (i = 0; i < val; i++) {
-      ret[i] = render(i + 1, i)
+      ret[i] = render(i + 1, i, genForLoopParams(i, val))
     }
   } else if (isObject(val)) {
     if (hasSymbol && val[Symbol.iterator]) {
       ret = []
+      const iterator1: Iterator<any> = val[Symbol.iterator]()
+      let size = 0, res = iterator1.next()
+      while (!res.done) {
+        size++
+        res = iterator1.next()
+      }
       const iterator: Iterator<any> = val[Symbol.iterator]()
       let result = iterator.next()
       while (!result.done) {
-        ret.push(render(result.value, ret.length))
+        ret.push(render(result.value, ret.length, genForLoopParams(ret.length, size)))
         result = iterator.next()
       }
     } else {
@@ -38,7 +63,7 @@ export function renderList (
       ret = new Array(keys.length)
       for (i = 0, l = keys.length; i < l; i++) {
         key = keys[i]
-        ret[i] = render(val[key], key, i)
+        ret[i] = render(val[key], key, i, genForLoopParams(i, ret.length))
       }
     }
   }

--- a/test/unit/features/directives/for.spec.js
+++ b/test/unit/features/directives/for.spec.js
@@ -55,6 +55,33 @@ describe('Directive v-for', () => {
       expect(vm.$el.innerHTML).toBe('<span>0-x</span><span>1-y</span>')
     }).then(done)
   })
+  
+  it('should render array of primitive values with loop', done => {
+    const vm = new Vue({
+      template: `
+        <div>
+          <span v-for="(item, i, loop) in list">{{i}}-{{item}}{{loop.first ? '-first' : '' }}{{loop.last ? '-last' : '' }}{{loop.odd ? '-odd' : '' }}{{loop.even ? '-even' : '' }}{{loop.remaining == 2 ? '-more-2' : '' }}</span>
+        </div>
+      `,
+      data: {
+        list: ['a', 'b', 'c']
+      }
+    }).$mount()
+    expect(vm.$el.innerHTML).toBe('<span>0-a-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+    Vue.set(vm.list, 0, 'd')
+    waitForUpdate(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-d-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+      vm.list.push('d')
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-d-first-even</span><span>1-b-odd-more-2</span><span>2-c-even</span><span>3-d-last-odd</span>')
+      vm.list.splice(1, 2)
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-d-first-even</span><span>1-d-last-odd</span>')
+      vm.list = ['x', 'y']
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-x-first-even</span><span>1-y-last-odd</span>')
+    }).then(done)
+  })
 
   it('should render array of object values', done => {
     const vm = new Vue({
@@ -121,6 +148,40 @@ describe('Directive v-for', () => {
       vm.list = [{ value: 'x' }, { value: 'y' }]
     }).then(() => {
       expect(vm.$el.innerHTML).toBe('<span>0-x</span><span>1-y</span>')
+    }).then(done)
+  })
+
+  it('should render array of object values with loop', done => {
+    const vm = new Vue({
+      template: `
+        <div>
+          <span v-for="(item, i, loop) in list">{{i}}-{{item.value}}{{loop.first ? '-first' : '' }}{{loop.last ? '-last' : '' }}{{loop.odd ? '-odd' : '' }}{{loop.even ? '-even' : '' }}{{loop.remaining == 2 ? '-more-2' : '' }}</span>
+        </div>
+      `,
+      data: {
+        list: [
+          { value: 'a' },
+          { value: 'b' },
+          { value: 'c' }
+        ]
+      }
+    }).$mount()
+    expect(vm.$el.innerHTML).toBe('<span>0-a-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+    Vue.set(vm.list, 0, { value: 'd' })
+    waitForUpdate(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-d-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+      vm.list[0].value = 'e'
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-e-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+      vm.list.push({})
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-e-first-even</span><span>1-b-odd-more-2</span><span>2-c-even</span><span>3--last-odd</span>')
+      vm.list.splice(1, 2)
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-e-first-even</span><span>1--last-odd</span>')
+      vm.list = [{ value: 'x' }, { value: 'y' }]
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>0-x-first-even</span><span>1-y-last-odd</span>')
     }).then(done)
   })
 
@@ -236,6 +297,52 @@ describe('Directive v-for', () => {
       }).then(done)
     })
 
+    it('should render iterable of primitive values with loop', done => {
+      const iterable = {
+        models: ['a', 'b', 'c'],
+        index: 0,
+        [Symbol.iterator] () {
+          const iterator = {
+            index: 0,
+            models: this.models,
+            next () {
+              if (this.index < this.models.length) {
+                return { value: this.models[this.index++] }
+              } else {
+                return { done: true }
+              }
+            }
+          }
+          return iterator
+        }
+      }
+
+      const vm = new Vue({
+        template: `
+          <div>
+          <span v-for="(item, i, loop) in list">{{i}}-{{item}}{{loop.first ? '-first' : '' }}{{loop.last ? '-last' : '' }}{{loop.odd ? '-odd' : '' }}{{loop.even ? '-even' : '' }}{{loop.remaining == 2 ? '-more-2' : '' }}</span>
+          </div>
+        `,
+        data: {
+          list: iterable
+        }
+      }).$mount()
+      expect(vm.$el.innerHTML).toBe('<span>0-a-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+      Vue.set(vm.list.models, 0, 'd')
+      waitForUpdate(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-d-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+        vm.list.models.push('d')
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-d-first-even</span><span>1-b-odd-more-2</span><span>2-c-even</span><span>3-d-last-odd</span>')
+        vm.list.models.splice(1, 2)
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-d-first-even</span><span>1-d-last-odd</span>')
+        vm.list.models = ['x', 'y']
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-x-first-even</span><span>1-y-last-odd</span>')
+      }).then(done)
+    })
+
     it('should render iterable of object values', done => {
       const iterable = {
         models: [
@@ -341,6 +448,59 @@ describe('Directive v-for', () => {
         expect(vm.$el.innerHTML).toBe('<span>0-x</span><span>1-y</span>')
       }).then(done)
     })
+    
+    it('should render iterable of object values with loop', done => {
+      const iterable = {
+        models: [
+          { value: 'a' },
+          { value: 'b' },
+          { value: 'c' }
+        ],
+        index: 0,
+        [Symbol.iterator] () {
+          const iterator = {
+            index: 0,
+            models: this.models,
+            next () {
+              if (this.index < this.models.length) {
+                return { value: this.models[this.index++] }
+              } else {
+                return { done: true }
+              }
+            }
+          }
+          return iterator
+        }
+      }
+
+      const vm = new Vue({
+        template: `
+          <div>
+            <span v-for="(item, i, loop) in list">{{i}}-{{item.value}}{{loop.first ? '-first' : '' }}{{loop.last ? '-last' : '' }}{{loop.odd ? '-odd' : '' }}{{loop.even ? '-even' : '' }}{{loop.remaining == 2 ? '-more-2' : '' }}</span>
+          </div>
+        `,
+        data: {
+          list: iterable
+        }
+      }).$mount()
+      expect(vm.$el.innerHTML).toBe('<span>0-a-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+      Vue.set(vm.list.models, 0, { value: 'd' })
+      waitForUpdate(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-d-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+        vm.list.models[0].value = 'e'
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-e-first-even-more-2</span><span>1-b-odd</span><span>2-c-last-even</span>')
+        vm.list.models.push({})
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-e-first-even</span><span>1-b-odd-more-2</span><span>2-c-even</span><span>3--last-odd</span>')
+        vm.list.models.splice(1, 2)
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-e-first-even</span><span>1--last-odd</span>')
+        vm.list.models = [{ value: 'x' }, { value: 'y' }]
+      }).then(() => {
+        expect(vm.$el.innerHTML).toBe('<span>0-x-first-even</span><span>1-y-last-odd</span>')
+      }).then(done)
+    })
   }
 
   it('should render an Object', done => {
@@ -412,6 +572,30 @@ describe('Directive v-for', () => {
       Vue.delete(vm.obj, 'a')
     }).then(() => {
       expect(vm.$el.innerHTML).toBe('<span>1-b-0</span><span>2-c-1</span><span>4-d-2</span>')
+    }).then(done)
+  })
+
+  it('should render an Object with key and loop', done => {
+    const vm = new Vue({
+      template: `
+        <div>
+          <span v-for="(val, key, i, loop) in obj">{{val}}-{{key}}-{{i}}{{loop.first ? '-first' : '' }}{{loop.last ? '-last' : '' }}{{loop.odd ? '-odd' : '' }}{{loop.even ? '-even' : '' }}{{loop.remaining == 2 ? '-more-2' : '' }}</span>
+        </div>
+      `,
+      data: {
+        obj: { a: 0, b: 1, c: 2 }
+      }
+    }).$mount()
+    expect(vm.$el.innerHTML).toBe('<span>0-a-0-first-even-more-2</span><span>1-b-1-odd</span><span>2-c-2-last-even</span>')
+    vm.obj.a = 3
+    waitForUpdate(() => {
+      expect(vm.$el.innerHTML).toBe('<span>3-a-0-first-even-more-2</span><span>1-b-1-odd</span><span>2-c-2-last-even</span>')
+      Vue.set(vm.obj, 'd', 4)
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>3-a-0-first-even</span><span>1-b-1-odd-more-2</span><span>2-c-2-even</span><span>4-d-3-last-odd</span>')
+      Vue.delete(vm.obj, 'a')
+    }).then(() => {
+      expect(vm.$el.innerHTML).toBe('<span>1-b-0-first-even-more-2</span><span>2-c-1-odd</span><span>4-d-2-last-even</span>')
     }).then(done)
   })
 

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -284,15 +284,17 @@ describe('parser', () => {
     expect(liAst.alias).toBe('item')
     expect(liAst.iterator1).toBe('index')
     expect(liAst.iterator2).toBeUndefined()
+    expect(liAst.iterator3).toBeUndefined()
   })
 
   it('v-for directive iteration syntax (multiple)', () => {
-    const ast = parse('<ul><li v-for="(item, key, index) in items"></li></ul>', baseOptions)
+    const ast = parse('<ul><li v-for="(item, key, index, loop) in items"></li></ul>', baseOptions)
     const liAst = ast.children[0]
     expect(liAst.for).toBe('items')
     expect(liAst.alias).toBe('item')
     expect(liAst.iterator1).toBe('key')
     expect(liAst.iterator2).toBe('index')
+    expect(liAst.iterator3).toBe('loop')
   })
 
   it('v-for directive key', () => {
@@ -335,12 +337,13 @@ describe('parser', () => {
     expect(liAst.iterator1).toBe('i')
 
     // with key + index
-    ast = parse('<ul><li v-for="({ foo }, i, j) in items"></li></ul>', baseOptions)
+    ast = parse('<ul><li v-for="({ foo }, i, j, l) in items"></li></ul>', baseOptions)
     liAst = ast.children[0]
     expect(liAst.for).toBe('items')
     expect(liAst.alias).toBe('{ foo }')
     expect(liAst.iterator1).toBe('i')
     expect(liAst.iterator2).toBe('j')
+    expect(liAst.iterator3).toBe('l')
 
     // multi-var destructuring with index
     ast = parse('<ul><li v-for="({ foo, bar, baz }, i) in items"></li></ul>', baseOptions)
@@ -381,12 +384,13 @@ describe('parser', () => {
     expect(liAst.iterator1).toBe('i')
 
     // array with key + index
-    ast = parse('<ul><li v-for="([ foo ], i, j) in items"></li></ul>', baseOptions)
+    ast = parse('<ul><li v-for="([ foo ], i, j, l) in items"></li></ul>', baseOptions)
     liAst = ast.children[0]
     expect(liAst.for).toBe('items')
     expect(liAst.alias).toBe('[ foo ]')
     expect(liAst.iterator1).toBe('i')
     expect(liAst.iterator2).toBe('j')
+    expect(liAst.iterator3).toBe('l')
 
     // multi-array with paren
     ast = parse('<ul><li v-for="([ foo, bar, baz ]) in items"></li></ul>', baseOptions)
@@ -402,20 +406,22 @@ describe('parser', () => {
     expect(liAst.iterator1).toBe('i')
 
     // nested
-    ast = parse('<ul><li v-for="({ foo, bar: { baz }, qux: [ n ] }, i, j) in items"></li></ul>', baseOptions)
+    ast = parse('<ul><li v-for="({ foo, bar: { baz }, qux: [ n ] }, i, j, l) in items"></li></ul>', baseOptions)
     liAst = ast.children[0]
     expect(liAst.for).toBe('items')
     expect(liAst.alias).toBe('{ foo, bar: { baz }, qux: [ n ] }')
     expect(liAst.iterator1).toBe('i')
     expect(liAst.iterator2).toBe('j')
+    expect(liAst.iterator3).toBe('l')
 
     // array nested
-    ast = parse('<ul><li v-for="([ foo, { bar }, baz ], i, j) in items"></li></ul>', baseOptions)
+    ast = parse('<ul><li v-for="([ foo, { bar }, baz ], i, j, l) in items"></li></ul>', baseOptions)
     liAst = ast.children[0]
     expect(liAst.for).toBe('items')
     expect(liAst.alias).toBe('[ foo, { bar }, baz ]')
     expect(liAst.iterator1).toBe('i')
     expect(liAst.iterator2).toBe('j')
+    expect(liAst.iterator3).toBe('l')
   })
 
   it('v-for directive invalid syntax', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When using v-for directive, no additional statement is needed to determine whether the current element is the first or the last element, or whether the sequence is even or odd. Also added 'remaining' variable, which tells you how many elements are left before the end of the loop.
