### PR TITLE
fix(core): jsdom is not inBrowser when run unit:test(fix #10472)

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -4,7 +4,7 @@
 export const hasProto = '__proto__' in {}
 
 // Browser environment sniffing
-export const inBrowser = typeof window !== 'undefined'
+export const inBrowser = typeof window !== 'undefined' && window.Math
 export const inWeex = typeof WXEnvironment !== 'undefined' && !!WXEnvironment.platform
 export const weexPlatform = inWeex && WXEnvironment.platform.toLowerCase()
 export const UA = inBrowser && window.navigator.userAgent.toLowerCase()

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -4,7 +4,7 @@
 export const hasProto = '__proto__' in {}
 
 // Browser environment sniffing
-export const inBrowser = typeof window !== 'undefined' && window.Math
+export const inBrowser = typeof window !== 'undefined' && !!window.Math
 export const inWeex = typeof WXEnvironment !== 'undefined' && !!WXEnvironment.platform
 export const weexPlatform = inWeex && WXEnvironment.platform.toLowerCase()
 export const UA = inBrowser && window.navigator.userAgent.toLowerCase()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
the bugfix for [Disable productionTip in a vue dev common.js version](https://github.com/vuejs/vue/issues/10472l)

Because mocha-webpack use `jsdom` and run code in Node env, and `jsdom` has `window` property , so  vue  was wrong to think it  was in browser  and displayed a productionTip

Also, I find thant jsdom's `window`  only contains DOM-related properties,  so I use `window.Math`
to tell vue that 'hi boy~, I am in jsdom, not do something only in browser'