### PR TITLE
(v-model): trigger change event and reset value of select element if currently selected option was removed (fix #10527)

### DIFF
--- a/src/platforms/web/runtime/directives/model.js
+++ b/src/platforms/web/runtime/directives/model.js
@@ -63,7 +63,7 @@ const directive = {
         // no matching option found for at least one value
         const needReset = el.multiple
           ? binding.value.some(v => hasNoMatchingOption(v, curOptions))
-          : binding.value !== binding.oldValue && hasNoMatchingOption(binding.value, curOptions)
+          : binding.value !== el.value && hasNoMatchingOption(binding.value, curOptions)
         if (needReset) {
           trigger(el, 'change')
         }

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -231,7 +231,32 @@ describe('Directive v-model select', () => {
       expect(spy.calls.count()).toBe(0)
     }).then(done)
   })
-
+  
+  it('should work with select when selected option is removed', (done) => {
+    const spy = jasmine.createSpy()
+    const vm = new Vue({
+      data: {
+        id: 2,
+        list: [1, 2, 3]
+      },
+      template:
+        '<div>' +
+          '<select @change="test" v-model="id">' +
+            '<option v-for="item in list" :value="item">{{item}}</option>' +
+          '</select>' +
+        '</div>',
+      methods: {
+        test: spy
+      }
+    }).$mount()
+    document.body.appendChild(vm.$el)
+    vm.list = [4, 5]
+    waitForUpdate(() => {
+      expect(spy.calls.count()).toBe(1)
+      expect(vm.id).toBe(undefined)
+    }).then(done)
+  })
+  
   if (!hasMultiSelectBug()) {
     it('multiple', done => {
       const vm = new Vue({


### PR DESCRIPTION
When a select element is bound with v-model and currently selected option is removed then browser sets select's value to `undefined` but vue's model is not updated and still has previous value making model out of sync with DOM.
This will resolve this situation by triggering "change" event the same way how it is now handled for selects with `multiple` attribute.

close #10527 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

I think it cannot be considered as a breaking change. This PR fixes an issue introduced in a minor version (2.0.3)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
