### PR TITLE
fix #10614: the select's v-model set to `undefined` in some corner case

### DIFF
--- a/src/platforms/web/compiler/directives/model.js
+++ b/src/platforms/web/compiler/directives/model.js
@@ -118,7 +118,7 @@ function genSelect (
     `.map(function(o){var val = "_value" in o ? o._value : o.value;` +
     `return ${number ? '_n(val)' : 'val'}})`
 
-  const assignment = '$event.target.multiple ? $$selectedVal : $$selectedVal[0]'
+  const assignment = `$event.target.multiple ? $$selectedVal : ($$selectedVal.length > 0 ? $$selectedVal[0] : ${value})`
   let code = `var $$selectedVal = ${selectedVal};`
   code = `${code} ${genAssignmentCode(value, assignment)}`
   addHandler(el, 'change', code, null, true)

--- a/test/unit/features/directives/model-select.spec.js
+++ b/test/unit/features/directives/model-select.spec.js
@@ -232,6 +232,25 @@ describe('Directive v-model select', () => {
     }).then(done)
   })
 
+  it('should not set model to `undefined` when both model and options changed', (done) => {
+    const vm = new Vue({
+      data: {
+        test: 'a',
+        opts: ['a', 'b', 'c']
+      },
+      template:
+        '<select v-model="test">' +
+          '<option v-for="o in opts" :value="o">option {{ o }}</option>' +
+        '</select>'
+    }).$mount()
+    document.body.appendChild(vm.$el)
+    vm.test = '1'
+    vm.opts = ['2', '3', '4']
+    waitForUpdate(() => {
+      expect(vm.test).toBe('1') // should not set vm.test to `undefined` but reserves '1'
+    }).then(done)
+  })
+
   if (!hasMultiSelectBug()) {
     it('multiple', done => {
       const vm = new Vue({


### PR DESCRIPTION
fix(select-model): fix the issue of select's v-model set to `undefined` in some corner case
fix #10614

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
