### PR TITLE
fix(core): fix casting symbol values to strings in the prop type check warning

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -210,7 +210,8 @@ function getInvalidTypeMessage (name, value, expectedTypes) {
   // check if we need to specify expected value
   if (expectedTypes.length === 1 &&
       isExplicable(expectedType) &&
-      !isBoolean(expectedType, receivedType)) {
+      !isBoolean(expectedType, receivedType) &&
+      !isSymbol(expectedType, receivedType)) {
     message += ` with value ${expectedValue}`
   }
   message += `, got ${receivedType} `
@@ -223,11 +224,11 @@ function getInvalidTypeMessage (name, value, expectedTypes) {
 
 function styleValue (value, type) {
   if (type === 'String') {
-    return `"${value}"`
+    return `"${String(value)}"`
   } else if (type === 'Number') {
-    return `${Number(value)}`
+    return `${Number(String(value))}`
   } else {
-    return `${value}`
+    return String(value)
   }
 }
 
@@ -238,4 +239,8 @@ function isExplicable (value) {
 
 function isBoolean (...args) {
   return args.some(elem => elem.toLowerCase() === 'boolean')
+}
+
+function isSymbol (...args) {
+  return args.some(elem => elem.toLowerCase() === 'symbol')
 }

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -241,6 +241,36 @@ describe('Options props', () => {
         makeInstance({}, Symbol)
         expect('Expected Symbol, got Object').toHaveBeenWarned()
       })
+
+      it('string & symbol', () => {
+        makeInstance(Symbol('foo'), String)
+        expect('Expected String, got Symbol').toHaveBeenWarned()
+      })
+
+      it('number & symbol', () => {
+        makeInstance(Symbol('foo'), Number)
+        expect('Expected Number, got Symbol').toHaveBeenWarned()
+      })
+
+      it('boolean & symbol', () => {
+        makeInstance(Symbol('foo'), Boolean)
+        expect('Expected Boolean, got Symbol').toHaveBeenWarned()
+      })
+
+      it('function & symbol', () => {
+        makeInstance(Symbol('foo'), Function)
+        expect('Expected Function, got Symbol').toHaveBeenWarned()
+      })
+
+      it('object & symbol', () => {
+        makeInstance(Symbol('foo'), Object)
+        expect('Expected Object, got Symbol').toHaveBeenWarned()
+      })
+
+      it('array & symbol', () => {
+        makeInstance(Symbol('foo'), Array)
+        expect('Expected Array, got Symbol').toHaveBeenWarned()
+      })
     }
 
     it('custom constructor', () => {


### PR DESCRIPTION

If the default value of the prop in the prop definition doesn't match the type of the prop, it should throw a warning, but instead it throws a `TypeError` when the default value is defined as a `Symbol`, e.g.:
```
testProp: {
    type: Number,
    default: Symbol('foo')
};
```
*expected*: `Invalid prop: type check failed for prop "testProp". Expected Number, got Symbol`
*currently*: `TypeError: Cannot convert a Symbol value to a number`

This PR changes the symbol->string casting from `"" + value` to `String(value)`, as the first approach doesn't work well with symbols.
Also, I've added an `isSymbol` check, so it doesn't try to read the "value" of the symbol in the message warning + tests.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
