### PR TITLE
Vnode $scopedSlot with no prop (like callback)

### DIFF
--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -5,7 +5,7 @@ type ScopedSlotReturnValue = VNode | string | boolean | null | undefined | Scope
 interface ScopedSlotReturnArray extends Array<ScopedSlotReturnValue> {}
 
 // Scoped slots are guaranteed to return Array of VNodes starting in 2.6
-export type NormalizedScopedSlot = (props: any) => ScopedSlotChildren;
+export type NormalizedScopedSlot = (props?: any) => ScopedSlotChildren;
 export type ScopedSlotChildren = VNode[] | undefined;
 
 // Relaxed type compatible with $createElement


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ X ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ X ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ X ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ X ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Because use $scopedSlot with callback inside (with no prop)