### PR TITLE
fix(types): Update compiler module types to include optional modifiers

### DIFF
--- a/flow/compiler.js
+++ b/flow/compiler.js
@@ -47,13 +47,13 @@ declare type CompiledResult = {
 declare type ModuleOptions = {
   // transform an AST node before any attributes are processed
   // returning an ASTElement from pre/transforms replaces the element
-  preTransformNode: (el: ASTElement) => ?ASTElement;
+  preTransformNode?: (el: ASTElement) => ?ASTElement;
   // transform an AST node after built-ins like v-if, v-for are processed
-  transformNode: (el: ASTElement) => ?ASTElement;
+  transformNode?: (el: ASTElement) => ?ASTElement;
   // transform an AST node after its children have been processed
   // cannot return replacement in postTransform because tree is already finalized
-  postTransformNode: (el: ASTElement) => void;
-  genData: (el: ASTElement) => string; // generate extra data string for an element
+  postTransformNode?: (el: ASTElement) => void;
+  genData?: (el: ASTElement) => string; // generate extra data string for an element
   transformCode?: (el: ASTElement, code: string) => string; // further transform generated code for an element
   staticKeys?: Array<string>; // AST properties to be considered static
 };

--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -35,10 +35,10 @@ interface CompiledResultFunctions {
 }
 
 interface ModuleOptions {
-  preTransformNode: (el: ASTElement) => ASTElement | undefined;
-  transformNode: (el: ASTElement) => ASTElement | undefined;
-  postTransformNode: (el: ASTElement) => void;
-  genData: (el: ASTElement) => string;
+  preTransformNode?: (el: ASTElement) => ASTElement | undefined;
+  transformNode?: (el: ASTElement) => ASTElement | undefined;
+  postTransformNode?: (el: ASTElement) => void;
+  genData?: (el: ASTElement) => string;
   transformCode?: (el: ASTElement, code: string) => string;
   staticKeys?: string[];
 }


### PR DESCRIPTION
The Vue compiler accepts modules that have any combination of the available properties - none are
required. This commit updates the flow and TypeScript definitions for ModuleOptions to accurately
reflect the optional nature of compiler module properties.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
