### PR TITLE
fix(warn): warns when template has v-show attribute (close #10786)

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -201,6 +201,16 @@ export function parse (
     }
   }
 
+  function checkTemplateConstraints (el) {
+    if (el.tag === 'template' && el.attrsMap.hasOwnProperty('v-show')) {
+      warnOnce(
+        'Cannot use v-show on a <template> component because adding ' +
+        'style to it may generate side-affects.',
+        el.rawAttrsMap['v-show']
+      )
+    }
+  }
+
   parseHTML(template, {
     warn,
     expectHTML: options.expectHTML,
@@ -289,6 +299,10 @@ export function parse (
         }
       }
 
+      if (process.env.NODE_ENV !== 'production') {
+        checkTemplateConstraints(element)
+      }
+      
       if (!unary) {
         currentParent = element
         stack.push(element)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I added a warning message when a v-show attribute is detected in a template tag because it may generate side-effects as it's adding style to it.
