### PR TITLE
Fix mergeHook when parentVal is not an array

### DIFF
--- a/src/core/util/options.js
+++ b/src/core/util/options.js
@@ -144,12 +144,14 @@ strats.data = function (
  * Hooks and props are merged as arrays.
  */
 function mergeHook (
-  parentVal: ?Array<Function>,
+  parentVal: ?Function | ?Array<Function>,
   childVal: ?Function | ?Array<Function>
 ): ?Array<Function> {
   const res = childVal
     ? parentVal
-      ? parentVal.concat(childVal)
+      ? Array.isArray(parentVal)
+        ? parentVal.concat(childVal)
+        : [parentVal].concat(childVal)
       : Array.isArray(childVal)
         ? childVal
         : [childVal]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is related to a [vue-router issue](https://github.com/vuejs/vue-router/issues/3004).  

A bit of context: 

VueRouter comes with 3 hooks (beforeRouteEnter, beforeRouteLeave, beforeRouteUpdate).
The merging strategy to deal with inheritance with these hooks is defined in src/install.js in VueRouter.
The chosen strategy is mergeHook (in vue/src/core/util/options.js, the same as the created hook of Vue).

As you can see in the code, mergeHook is expecting a different type parentVal or childVal. If parentVal ends up not being an array, the code crashes.

The fix we propose is to put parentVal into an array before calling concat, if parentVal is not an array.
