### PR TITLE
fix: clear extra styles when hydrating/mounting element

### DIFF
--- a/src/platforms/web/runtime/modules/style.js
+++ b/src/platforms/web/runtime/modules/style.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getStyle, normalizeStyleBinding } from 'web/util/style'
+import { getStyle, normalizeStyleBinding, parseStyleText } from 'web/util/style'
 import { cached, camelize, extend, isDef, isUndef, hyphenate } from 'shared/util'
 
 const cssVarRE = /^--/
@@ -44,7 +44,7 @@ const normalize = cached(function (prop) {
   }
 })
 
-function updateStyle (oldVnode: VNodeWithData, vnode: VNodeWithData) {
+function updateStyle (oldVnode: VNodeWithData, vnode: VNodeWithData, creating = false) {
   const data = vnode.data
   const oldData = oldVnode.data
 
@@ -60,7 +60,7 @@ function updateStyle (oldVnode: VNodeWithData, vnode: VNodeWithData) {
   const oldStyleBinding: any = oldData.normalizedStyle || oldData.style || {}
 
   // if static style exists, stylebinding already merged into it when doing normalizeStyleData
-  const oldStyle = oldStaticStyle || oldStyleBinding
+  let oldStyle = oldStaticStyle || oldStyleBinding
 
   const style = normalizeStyleBinding(vnode.data.style) || {}
 
@@ -72,6 +72,10 @@ function updateStyle (oldVnode: VNodeWithData, vnode: VNodeWithData) {
     : style
 
   const newStyle = getStyle(vnode, true)
+
+  if (creating && el.style.cssText) {
+    oldStyle = parseStyleText(el.style.cssText)
+  }
 
   for (name in oldStyle) {
     if (isUndef(newStyle[name])) {
@@ -88,6 +92,6 @@ function updateStyle (oldVnode: VNodeWithData, vnode: VNodeWithData) {
 }
 
 export default {
-  create: updateStyle,
+  create: (oldVNode, vnode) => updateStyle(oldVNode, vnode, true),
   update: updateStyle
 }

--- a/test/unit/modules/vdom/patch/hydration.spec.js
+++ b/test/unit/modules/vdom/patch/hydration.spec.js
@@ -372,6 +372,19 @@ describe('vdom patch: hydration', () => {
     }).then(done)
   })
 
+  it('should hydrate with correct inline styles', () => {
+    const dom = createMockSSRDOM('<div style="padding-left: 0px; padding-right: 3px"></div>')
+
+    const vm = new Vue({
+      data: {
+        style: { paddingLeft: '2px' }
+      },
+      template: `<div><div :style="style"></div></div>`
+    }).$mount(dom)
+
+    expect(vm.$el.innerHTML).toBe('<div style="padding-left: 2px;"></div>')
+  })
+
   it('should properly initialize dynamic class bindings for future updates', done => {
     const dom = createMockSSRDOM('<div class="foo bar"></div>')
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Inline styles already existing on an element which Vue is mounted on, or server-side rendered DOM, may be removed if the component does not render those styles. Developers should not rely on extra inline styles being left untouched.

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

There's currently a somewhat sharp gotcha with SSR where an inline style rendered for an element on the server, but not rendered on the client, will end up stuck on the element, leading to partially broken markup.

The styles may differ between the SSR DOM and the client DOM due to practices such as using the screen size as a prop value, which causes a style to be applied on the server which is not applied on the client when loaded on mobile clients. See vuetifyjs/vuetify#10163 for a real-world example of this.

I tried to keep this PR concise and focused, but it's worth discussing potential side effects of this change. Ideally it would be scoped just to hydration to limit the surface area for side effects, but that wasn't as simple as limiting it to creation, so I opted for the simpler route for the PR.

Some users may be relying on the current behavior (perhaps without realizing it), so this would break behavior for them. However, considering the current gotcha for otherwise sane looking code, it seems to be a reasonable trade-off to potentially break a tiny amount of code to remove a hard to debug issue which can lead to messed up markup.

An argument could be made that much as the DOM structure needing to match when hydrating, perhaps styles should also be required to match, which would avoid this issue. However, it seems like a tall order to ensure all styles are rendered identically between server and client since more style-oriented information is available on the client (screen size, device capabilities, etc). So, that seems like an overly burdensome requirement to put on developers for SSR. However, if that's preferred, this PR could be turned into issuing a warning on style-mismatch instead.