### PR TITLE
feat(ssr): add integrity and crossorigin support

### DIFF
--- a/packages/vue-server-renderer/package.json
+++ b/packages/vue-server-renderer/package.json
@@ -26,7 +26,8 @@
     "lodash.uniq": "^4.5.0",
     "resolve": "^1.2.0",
     "serialize-javascript": "^2.1.2",
-    "source-map": "0.5.6"
+    "source-map": "0.5.6",
+    "ssri": "^7.1.0"
   },
   "devDependencies": {
     "vue": "file:../.."

--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -31,6 +31,8 @@ export type RenderOptions = {
   clientManifest?: ClientManifest;
   serializer?: Function;
   runInNewContext?: boolean | 'once';
+  integrity?: boolean;
+  crossorigin?: string;
 };
 
 export function createRenderer ({
@@ -43,7 +45,9 @@ export function createRenderer ({
   shouldPreload,
   shouldPrefetch,
   clientManifest,
-  serializer
+  serializer,
+  integrity,
+  crossorigin
 }: RenderOptions = {}): Renderer {
   const render = createRenderFunction(modules, directives, isUnaryTag, cache)
   const templateRenderer = new TemplateRenderer({
@@ -52,7 +56,9 @@ export function createRenderer ({
     shouldPreload,
     shouldPrefetch,
     clientManifest,
-    serializer
+    serializer,
+    integrity,
+    crossorigin
   })
 
   return {

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -17,6 +17,8 @@ type TemplateRendererOptions = {
   shouldPreload?: (file: string, type: string) => boolean;
   shouldPrefetch?: (file: string, type: string) => boolean;
   serializer?: Function;
+  integrity?: boolean;
+  crossorigin?: string;
 };
 
 export type ClientManifest = {
@@ -49,13 +51,22 @@ export default class TemplateRenderer {
   prefetchFiles: Array<Resource>;
   mapFiles: AsyncFileMapper;
   serialize: Function;
+  integrity: boolean;
+  crossorigin: string;
 
   constructor (options: TemplateRendererOptions) {
     this.options = options
     this.inject = options.inject !== false
+    this.integrity = options.integrity === true
+    this.crossorigin = ['', 'anonymous', 'use-credentials'].includes(options.crossorigin) ? options.crossorigin : false
+
+    if (options.crossorigin !== undefined && this.crossorigin === false) {
+      throw new Error("crossorigin option must be one of '', 'anonymous', or 'use-credentials'")
+    }
+
     // if no template option is provided, the renderer is created
     // as a utility object for rendering assets like preload links and scripts.
-    
+
     const { template } = options
     this.parsedTemplate = template
       ? typeof template === 'string'
@@ -80,6 +91,8 @@ export default class TemplateRenderer {
       this.prefetchFiles = (clientManifest.async || []).map(normalizeFile)
       // initial async chunk mapping
       this.mapFiles = createMapper(clientManifest)
+    } else if (this.integrity) {
+      throw new Error('integrity option only works if clientManifest supplied')
     }
   }
 
@@ -133,8 +146,11 @@ export default class TemplateRenderer {
     return (
       // render links for css files
       (cssFiles.length
-        ? cssFiles.map(({ file }) => `<link rel="stylesheet" href="${this.publicPath}${file}">`).join('')
-        : '') +
+        ? cssFiles.map(({ file }) => {
+          const crossoriginAttr = this.crossorigin ? ` crossorigin="${this.crossorigin}"` : ''
+          const integrityAttr = this.integrity ? ` integrity="${this.clientManifest.integrity[file]}"` : ''
+          return `<link${crossoriginAttr}${integrityAttr} rel="stylesheet" href="${this.publicPath}${file}">`
+        }).join('') : '') +
       // context.styles is a getter exposed by vue-style-loader which contains
       // the inline component styles collected during SSR
       (context.styles || '')
@@ -168,8 +184,13 @@ export default class TemplateRenderer {
         if (shouldPreload && !shouldPreload(fileWithoutQuery, asType)) {
           return ''
         }
+        let crossorigin = this.crossorigin
         if (asType === 'font') {
-          extra = ` type="font/${extension}" crossorigin`
+          extra = ` type="font/${extension}"`
+          crossorigin = crossorigin || ''
+        }
+        if (crossorigin !== false) {
+          extra += ` crossorigin="${crossorigin}"`
         }
         return `<link rel="preload" href="${
           this.publicPath}${file
@@ -198,7 +219,8 @@ export default class TemplateRenderer {
         if (alreadyRendered(file)) {
           return ''
         }
-        return `<link rel="prefetch" href="${this.publicPath}${file}">`
+        const crossoriginAttr = this.crossorigin !== false ? ` crossorigin="${this.crossorigin}"` : ''
+        return `<link rel="prefetch" href="${this.publicPath}${file}"${crossoriginAttr}>`
       }).join('')
     } else {
       return ''
@@ -226,7 +248,9 @@ export default class TemplateRenderer {
       const async = (this.getUsedAsyncFiles(context) || []).filter(({ file }) => isJS(file))
       const needed = [initial[0]].concat(async, initial.slice(1))
       return needed.map(({ file }) => {
-        return `<script src="${this.publicPath}${file}" defer></script>`
+        const crossoriginAttr = this.crossorigin !== false ? ` crossorigin="${this.crossorigin}"` : ''
+        const integrityAttr = this.integrity ? ` integrity="${this.clientManifest.integrity[file]}"` : ''
+        return `<script${crossoriginAttr}${integrityAttr} src="${this.publicPath}${file}" defer></script>`
       }).join('')
     } else {
       return ''


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Currently subresource integrity isn't supported by SSR. This PR implements it (along with crossorigin support) by putting the SRI hashes into the client manifest so that they can be added during server rendering. The feature is opt-in when creating the renderer.