### PR TITLE
Export public types from types/options.d.ts

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -60,10 +60,10 @@ export type ThisTypedComponentOptionsWithRecordProps<V extends Vue, Data, Method
   ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
   ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Props>>>;
 
-type DefaultData<V> =  object | ((this: V) => object);
-type DefaultProps = Record<string, any>;
-type DefaultMethods<V> =  { [key: string]: (this: V, ...args: any[]) => any };
-type DefaultComputed = { [key: string]: any };
+export type DefaultData<V> =  object | ((this: V) => object);
+export type DefaultProps = Record<string, any>;
+export type DefaultMethods<V> =  { [key: string]: (this: V, ...args: any[]) => any };
+export type DefaultComputed = { [key: string]: any };
 export interface ComponentOptions<
   V extends Vue,
   Data=DefaultData<V>,


### PR DESCRIPTION

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

https://github.com/vuejs/vue/blob/dev/types/umd.d.ts#L3-L7

`types/umd.d.ts` imports `DefaultData` (and others) from the `options.d.ts` file, but those type definitions are never actually exported. It seems like TypeScript doesn't fail on this (which is surprising, but I've seen them allow bugs in `.d.ts` files before) but other tooling gets confused and breaks when it can't find this export.
