### PR TITLE
fix(compiler): avoid converting &nbps; to spaces

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -38,7 +38,7 @@ const modifierRE = /\.[^.\]]+(?=[^\]]*$)/g
 const slotRE = /^v-slot(:|$)|^#/
 
 const lineBreakRE = /[\r\n]/
-const whitespaceRE = /[ \t\r\n]+/g
+const whitespaceRE = /[ \f\t\r\n]+/g
 
 const invalidAttributeRE = /[\s"'<>\/=]/
 

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -38,7 +38,7 @@ const modifierRE = /\.[^.\]]+(?=[^\]]*$)/g
 const slotRE = /^v-slot(:|$)|^#/
 
 const lineBreakRE = /[\r\n]/
-const whitespaceRE = /\s+/g
+const whitespaceRE = /[ \t\r\n]+/g
 
 const invalidAttributeRE = /[\s"'<>\/=]/
 

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -845,6 +845,14 @@ describe('parser', () => {
     expect(ast.children[4].children[0].text).toBe('. Have fun! ')
   })
 
+  it(`maintains &nbsp; with whitespace: 'condense'`, () => {
+    const options = extend({}, condenseOptions)
+    const ast = parse('<span>&nbsp;</span>', options)
+    const code = ast.children[0]
+    expect(code.type).toBe(3)
+    expect(code.text).toBe('\xA0')
+  })
+
   it(`preserve whitespace in <pre> tag with whitespace: 'condense'`, function () {
     const options = extend({}, condenseOptions)
     const ast = parse('<pre><code>  \n<span>hi</span>\n  </code><span> </span></pre>', options)


### PR DESCRIPTION
The regex for whitespace was too strict and was causing $nbps; chars to
disappear from templates when `whitespace: 'condense'` is set. Changing the rule
to avoid converting non-breaking white space chars into regular spaces.

Fixes #10485
Fixes #11059

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
