### PR TITLE
$http.delete shows warning "avoid using JavaScript unary operator as property name" (fix #11090)

### DIFF
--- a/src/compiler/error-detector.js
+++ b/src/compiler/error-detector.js
@@ -59,7 +59,7 @@ function checkNode (node: ASTNode, warn: Function) {
 function checkEvent (exp: string, text: string, warn: Function, range?: Range) {
   const stripped = exp.replace(stripStringRE, '')
   const keywordMatch: any = stripped.match(unaryOperatorsRE)
-  if (keywordMatch && stripped.charAt(keywordMatch.index - 1) !== '$') {
+  if (keywordMatch && !['$', '.'].includes(stripped.charAt(keywordMatch.index - 1))) {
     warn(
       `avoid using JavaScript unary operator as property name: ` +
       `"${keywordMatch[0]}" in expression ${text.trim()}`,

--- a/test/unit/features/options/template.spec.js
+++ b/test/unit/features/options/template.spec.js
@@ -88,4 +88,13 @@ describe('Options template', () => {
       `avoid using JavaScript unary operator as property name: "delete()" in expression @click="delete('Delete')"`
     ).toHaveBeenWarned()
   })
+
+  it('warn error in generated function (v-on)', () => {
+    Vue.prototype.$http = { delete: () => {} };
+    new Vue({
+      template: `<div @click="$http.delete('/endpoint')"></div>`
+    }).$mount();
+    expect("Error compiling template").not.toHaveBeenWarned();
+    delete Vue.prototype.$http;
+  })
 })


### PR DESCRIPTION
Update error-detector to look for . prefix

fix #11090

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
