### PR TITLE
fix(vdom): check old handlers are defined before remove (fix #11151)

### DIFF
--- a/src/core/vdom/helpers/update-listeners.js
+++ b/src/core/vdom/helpers/update-listeners.js
@@ -6,6 +6,7 @@ import {
 } from 'core/util/index'
 import {
   cached,
+  isDef,
   isUndef,
   isTrue,
   isPlainObject
@@ -89,7 +90,9 @@ export function updateListeners (
   for (name in oldOn) {
     if (isUndef(on[name])) {
       event = normalizeEvent(name)
-      remove(event.name, oldOn[name], event.capture)
+      if (isDef(oldOn[name])) {
+        remove(event.name, oldOn[name], event.capture)
+      }
     }
   }
 }

--- a/test/unit/modules/vdom/modules/events.spec.js
+++ b/test/unit/modules/vdom/modules/events.spec.js
@@ -100,6 +100,18 @@ describe('vdom events module', () => {
     expect(click.calls.count()).toBe(2)
   })
 
+  // #11151
+  it('should not remove handlers that are undefined', () => {
+    const vnode1 = new VNode('a', { on: { click: undefined }})
+    const vnode2 = new VNode('a', {})
+
+    expect(()=>{
+      patch(null, vnode1)
+      patch(vnode1, vnode2)
+    }).not.toThrow()
+    expect('[Vue warn]: Invalid handler for event "click": got undefined').toHaveBeenWarned()
+  })
+
   // #4650
   it('should handle single -> array or array -> single handler changes', () => {
     const click = jasmine.createSpy()


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
