### PR TITLE
fix(keep-alive): should not cache destroyed instance

### DIFF
--- a/src/core/components/keep-alive.js
+++ b/src/core/components/keep-alive.js
@@ -104,7 +104,9 @@ export default {
         ? componentOptions.Ctor.cid + (componentOptions.tag ? `::${componentOptions.tag}` : '')
         : vnode.key
       if (cache[key]) {
-        vnode.componentInstance = cache[key].componentInstance
+        const { _isDestroyed } = cache[key].componentInstance
+        if (_isDestroyed) cache[key] = vnode
+        else vnode.componentInstance = cache[key].componentInstance
         // make current key freshest
         remove(keys, key)
         keys.push(key)

--- a/test/unit/features/component/component-keep-alive.spec.js
+++ b/test/unit/features/component/component-keep-alive.spec.js
@@ -713,6 +713,35 @@ describe('Component keep-alive', () => {
     }).then(done)
   })
 
+  it('should not cache destroyed instance', done => {
+    const vm = new Vue({
+      template: `
+        <div>
+          <keep-alive include="one,two">
+            <component :is="view"></component>
+          </keep-alive>
+        </div>
+      `,
+      data: { view: 'one' },
+      components
+    }).$mount()
+    vm.view='two' 
+    waitForUpdate(()=>{ vm.view='one' })
+    .then(()=>{ vm.view ='two' })
+    .then(()=>{ vm.view='one' })
+    .then(()=>{ assertHookCalls(one, [1, 1, 3, 2, 0]) })
+    .then(()=>{ vm.view='two' })
+    .then(()=>{ vm.$children[0].$destroy() })
+    .then(()=>{ vm.view='one' })
+    .then(()=>{ vm.view='two' })
+    .then(()=>{ vm.view='one' }) 
+    .then(()=>{ 
+      assertHookCalls(one, [2, 2, 5, 4, 1])
+      expect(vm.$children.length).toBe(2) 
+    })
+    .then(done)
+  })
+
   if (!isIE9) {
     it('with transition-mode out-in', done => {
       let next


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

reproduce link : [https://jsfiddle.net/mwpeodL8](https://jsfiddle.net/mwpeodL8)

After keep-alive child component destroys itself,
component instance is being created every time when it re-activated

Please check reproduce link and test code