### PR TITLE
fix(props): support BigInt in props type validation

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -146,7 +146,7 @@ function assertProp (
   }
 }
 
-const simpleCheckRE = /^(String|Number|Boolean|Function|Symbol)$/
+const simpleCheckRE = /^(String|Number|Boolean|Function|Symbol|BigInt)$/
 
 function assertType (value: any, type: Function): {
   valid: boolean;

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -242,6 +242,16 @@ describe('Options props', () => {
         expect('Expected Symbol, got Object').toHaveBeenWarned()
       })
     }
+	
+    if (typeof BigInt !== 'undefined') {
+      /* global BigInt */
+      it('bigint', () => {
+        makeInstance(BigInt(100), BigInt)
+        expect(console.error.calls.count()).toBe(0)
+        makeInstance({}, BigInt)
+        expect('Expected BigInt, got Object').toHaveBeenWarned()
+      })
+    }
 
     it('custom constructor', () => {
       function Class () {}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Just a simple addition to make BigInt validation work.

Close #11126