### PR TITLE
fix(types): fix function prop type inference, fix #9357

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -150,12 +150,12 @@ export type PropType<T> = Prop<T> | Prop<T>[];
 
 export type PropValidator<T> = PropOptions<T> | PropType<T>;
 
-export interface PropOptions<T=any> {
-  type?: PropType<T>;
+export type PropOptions<T=any> = (<TypeAsAccessed extends T, TypeAsDefined extends PropType<T>>() => {
+  type?: TypeAsDefined;
   required?: boolean;
-  default?: T | null | undefined | (() => T | null | undefined);
-  validator?(value: T): boolean;
-}
+  default?: TypeAsDefined extends PropType<(...args: any[]) => any> ? TypeAsAccessed | null | undefined : TypeAsAccessed | null | undefined | (() => TypeAsAccessed | null | undefined);
+  validator?(value: TypeAsAccessed): boolean;
+}) extends () => infer Opts ? Opts : never;
 
 export type RecordPropsDefinition<T> = {
   [K in keyof T]: PropValidator<T[K]>

--- a/types/test/vue-test.ts
+++ b/types/test/vue-test.ts
@@ -1,5 +1,5 @@
 import Vue, { VNode } from "../index";
-import { ComponentOptions } from "../options";
+import { ComponentOptions, PropType } from "../options";
 
 class Test extends Vue {
   a: number = 0;
@@ -152,6 +152,45 @@ const FunctionalScopedSlotsComponent = Vue.extend({
   render(h, ctx) {
     return ctx.scopedSlots.default && ctx.scopedSlots.default({}) || h('div', 'functional scoped slots');
   }
+});
+
+declare function assertBoolean<A>(value: string extends A ? never : (A extends boolean ? A : never)): true;
+
+declare const val1: boolean;
+// declare const val2: boolean | (() => boolean);
+// declare const val3: any;
+
+assertBoolean(val1);    //=> compiles (good)
+// assertBoolean(val2); //=> does not compile (good)
+// assertBoolean(val3); //=> does not compile (good)
+
+const ComponentWithFunctionProps = Vue.extend({
+  props: {
+    functionProp: {
+      type: Function,
+      default: () => true,
+    },
+    functionPropWithBooleanReturnType: {
+      type: Function as PropType<() => boolean>,
+      default: () => true,
+    },
+    booleanProp: {
+      type: Boolean,
+      default: true,
+    },
+    booleanPropWithFunctionDefault: {
+      type: Boolean,
+      default: () => true,
+    },
+  },
+  methods: {
+    test(): void {
+      this.functionProp(); // callable (good)
+      assertBoolean(this.functionPropWithBooleanReturnType())
+      assertBoolean(this.booleanProp);
+      assertBoolean(this.booleanPropWithFunctionDefault);
+    },
+  },
 });
 
 const Parent = Vue.extend({


### PR DESCRIPTION
close #9357

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

## Before this change:

```ts
const ComponentWithFunctionProps = Vue.extend({
  props: {
    functionProp: {
      type: Function,
      default: () => true,
    },
    functionPropWithBooleanReturnType: {
      type: Function as PropType<() => boolean>,
      default: () => true,
    },
    booleanProp: {
      type: Boolean,
      default: true,
    },
    booleanPropWithFunctionDefault: {
      type: Boolean,
      default: () => true,
    },
  },
  methods: {
    test(): void {
      // ERROR!
      // (property) functionProp: boolean | Function
      // -------------------------------------------
      // This expression is not callable.
      //   No constituent of type 'boolean | Function' is callable.ts(2349)
      this.functionProp();

      // ERROR!
      // (property) functionPropWithBooleanReturnType: boolean | (() => boolean)
      // -----------------------------------------------------------------------
      // This expression is not callable.
      //   Not all constituents of type 'boolean | (() => boolean)' are callable.
      //     Type 'false' has no call signatures.ts(2349)
      this.functionPropWithBooleanReturnType();

      // const foo: boolean
      const foo = this.booleanProp;

      // const bar: boolean
      const bar = this.booleanPropWithFunctionDefault;
    },
  },
});
```

## After this change:

```ts
const ComponentWithFunctionProps = Vue.extend({
  props: {
    functionProp: {
      type: Function,
      default: () => true,
    },
    functionPropWithBooleanReturnType: {
      type: Function as PropType<() => boolean>,
      default: () => true,
    },
    booleanProp: {
      type: Boolean,
      default: true,
    },
    booleanPropWithFunctionDefault: {
      type: Boolean,
      default: () => true,
    },
  },
  methods: {
    test(): void {
      // (property) functionProp: Function
      this.functionProp();

      // (property) functionPropWithBooleanReturnType: () => boolean
      this.functionPropWithBooleanReturnType();

      // const foo: boolean
      const foo = this.booleanProp;

      // const bar: boolean
      const bar = this.booleanPropWithFunctionDefault;
    },
  },
});
```