### PR TITLE
feat(core): observe array changes from fill and copywithin methods (re #10973)

### DIFF
--- a/src/core/observer/array.js
+++ b/src/core/observer/array.js
@@ -15,7 +15,9 @@ const methodsToPatch = [
   'unshift',
   'splice',
   'sort',
-  'reverse'
+  'reverse',
+  'fill',
+  'copyWithin'
 ]
 
 /**
@@ -36,6 +38,8 @@ methodsToPatch.forEach(function (method) {
       case 'splice':
         inserted = args.slice(2)
         break
+      case 'fill':
+        inserted = [args[0]]
     }
     if (inserted) ob.observeArray(inserted)
     // notify change

--- a/test/unit/modules/observer/observer.spec.js
+++ b/test/unit/modules/observer/observer.spec.js
@@ -329,7 +329,7 @@ describe('Observer', () => {
     const ob = observe(arr)
     const dep = ob.dep
     spyOn(dep, 'notify')
-    const objs = [{}, {}, {}]
+    const objs = [{}, {}, {}, {}]
     arr.push(objs[0])
     arr.pop()
     arr.unshift(objs[1])
@@ -337,7 +337,9 @@ describe('Observer', () => {
     arr.splice(0, 0, objs[2])
     arr.sort()
     arr.reverse()
-    expect(dep.notify.calls.count()).toBe(7)
+    arr.fill(objs[3])
+    arr.copyWithin(0)
+    expect(dep.notify.calls.count()).toBe(9)
     // inserted elements should be observed
     objs.forEach(obj => {
       expect(obj.__ob__ instanceof Observer).toBe(true)


### PR DESCRIPTION
re #10973. `fill` and `copyWithin` are methods that, at this point, have good browser support and are standardized, so this PR adds support for Vue to observe mutating changes from those methods.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
