### PR TITLE
feat(ssr): wait for context.rendered (fix #11256)

### DIFF
--- a/src/server/create-renderer.js
+++ b/src/server/create-renderer.js
@@ -34,11 +34,11 @@ export type RenderOptions = {
   runInNewContext?: boolean | 'once';
 };
 
-function runRenderedCallback(context) {
+function runRenderedCallback(context, component) {
   if (!context || !context.rendered) {
     return Promise.resolve();
   }
-  const result = context.rendered(context);
+  const result = context.rendered(context, component);
   return isPromise(result) ? result : Promise.resolve();
 }
 
@@ -94,7 +94,7 @@ export function createRenderer ({
           if (err) {
             return cb(err)
           }
-          runRenderedCallback(context).then(() => {
+          runRenderedCallback(context, component).then(() => {
             if (template) {
               try {
                 const res = templateRenderer.render(result, context)

--- a/test/ssr/ssr-bundle-render.spec.js
+++ b/test/ssr/ssr-bundle-render.spec.js
@@ -84,6 +84,38 @@ function createAssertions (runInNewContext) {
     })
   })
 
+  it('renderToString calls context.rendered', done => {
+    createRenderer('app.js', { runInNewContext }, renderer => {
+      const rendered = jasmine.createSpy();
+      const context = { url: '/test', rendered }
+      renderer.renderToString(context, () => {
+        expect(rendered).toHaveBeenCalledWith(context)
+        expect(rendered).toHaveBeenCalledTimes(1)
+        done()
+      })
+    })
+  })
+
+  it('renderToString waits if context.rendered returns a promise', done => {
+    createRenderer('app.js', { runInNewContext }, renderer => {
+      const rendered = (context) => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            context.msg = 'Hello from context.rendered'
+            resolve()
+          }, 1000)
+        })
+      }
+      const context = { url: '/test', rendered }
+      renderer.renderToString(context, (err, res) => {
+        expect(err).toBeNull()
+        expect(res).toBe('<div data-server-rendered="true">/test</div>')
+        expect(context.msg).toBe('Hello from context.rendered')
+        done()
+      })
+    })
+  })
+
   it('renderToStream catch error', done => {
     createRenderer('error.js', { runInNewContext }, renderer => {
       const stream = renderer.renderToStream()

--- a/test/ssr/ssr-bundle-render.spec.js
+++ b/test/ssr/ssr-bundle-render.spec.js
@@ -89,7 +89,8 @@ function createAssertions (runInNewContext) {
       const rendered = jasmine.createSpy();
       const context = { url: '/test', rendered }
       renderer.renderToString(context, () => {
-        expect(rendered).toHaveBeenCalledWith(context)
+        expect(rendered).toHaveBeenCalledWith(context, jasmine.any(Object))
+        expect(rendered.calls.mostRecent().args[1].constructor.name).toBe("Vue")
         expect(rendered).toHaveBeenCalledTimes(1)
         done()
       })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR fixes #11256.
What this PR does is basically wait for `context.rendered(context)` function call if it returns a Promise.
If `rendered` can be asynchronous, SSR can become more flexible and powerful.
I wrote all the details in #11256.