### PR TITLE
feat(core):avoid stack overflow when observe watcher

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -2,6 +2,7 @@
 
 import Dep from './dep'
 import VNode from '../vdom/vnode'
+import Watcher from './watcher'
 import { arrayMethods } from './array'
 import {
   def,
@@ -139,6 +140,11 @@ export function defineReactive (
   customSetter?: ?Function,
   shallow?: boolean
 ) {
+  // avoid stack overflow when observe watcher
+  if (obj instanceof Watcher) {
+    return
+  }
+
   const dep = new Dep()
 
   const property = Object.getOwnPropertyDescriptor(obj, key)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

It happens in vue1.x and vue2.x version, when observes data that contains watcher instance.
the maximum call stack size exceeded error  will appear
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
