### PR TITLE
fix(src/server/render.js): Fixes component directives rendering

### DIFF
--- a/src/server/render.js
+++ b/src/server/render.js
@@ -201,6 +201,11 @@ function renderComponentInner (node, isRoot, context) {
       type: 'Component',
       prevActive
     })
+    if (isDef(node.data) && isDef(node.data.directives)) {
+      childNode.data = (childNode.data || {})
+      childNode.data.directives = node.data.directives
+      childNode.isComponentRootElement = true
+    }
     renderNode(childNode, isRoot, context)
   }
 
@@ -364,7 +369,7 @@ function renderStartingTag (node: VNode, context) {
           if (dirRenderer) {
             // directives mutate the node's data
             // which then gets rendered by modules
-            dirRenderer(node, dirs[i])
+            dirRenderer(node.isComponentRootElement ? node.parent : node, dirs[i])
           }
         }
       }

--- a/test/ssr/ssr-string.spec.js
+++ b/test/ssr/ssr-string.spec.js
@@ -829,7 +829,7 @@ describe('SSR: renderToString', () => {
     })
   })
 
-  it('custom directives', done => {
+  it('custom directives on raw element', done => {
     const renderer = createRenderer({
       directives: {
         'class-prefixer': (node, dir) => {
@@ -857,6 +857,80 @@ describe('SSR: renderToString', () => {
     }), (err, result) => {
       expect(err).toBeNull()
       expect(result).toContain('<p data-server-rendered="true" class="my-class2 my-class1">hello world</p>')
+      done()
+    })
+  })
+
+  it('custom directives on component', done => {
+    const Test = {
+      template: '<span>hello world</span>'
+    }
+    const renderer = createRenderer({
+      directives: {
+        'class-prefixer': (node, dir) => {
+          if (node.data.class) {
+            node.data.class = `${dir.value}-${node.data.class}`
+          }
+          if (node.data.staticClass) {
+            node.data.staticClass = `${dir.value}-${node.data.staticClass}`
+          }
+        }
+      }
+    })
+    renderer.renderToString(new Vue({
+      template: '<p><Test v-class-prefixer="\'my\'" class="class1" :class="\'class2\'" /></p>',
+      components: { Test },
+    }), (err, result) => {
+      expect(err).toBeNull()
+      expect(result).toContain('<p data-server-rendered="true"><span class="my-class1 my-class2">hello world</span></p>')
+      done()
+    })
+  })
+
+  it('custom directives on element root of a component', done => {
+    const Test = {
+      template: '<span v-class-prefixer="\'my\'" class="class1" :class="\'class2\'">hello world</span>'
+    }
+    const renderer = createRenderer({
+      directives: {
+        'class-prefixer': (node, dir) => {
+          if (node.data.class) {
+            node.data.class = `${dir.value}-${node.data.class}`
+          }
+          if (node.data.staticClass) {
+            node.data.staticClass = `${dir.value}-${node.data.staticClass}`
+          }
+        }
+      }
+    })
+    renderer.renderToString(new Vue({
+      template: '<p><Test /></p>',
+      components: { Test },
+    }), (err, result) => {
+      expect(err).toBeNull()
+      expect(result).toContain('<p data-server-rendered="true"><span class="my-class1 my-class2">hello world</span></p>')
+      done()
+    })
+  })
+
+  it('custom directives on element with parent element', done => {
+    const renderer = createRenderer({
+      directives: {
+        'class-prefixer': (node, dir) => {
+          if (node.data.class) {
+            node.data.class = `${dir.value}-${node.data.class}`
+          }
+          if (node.data.staticClass) {
+            node.data.staticClass = `${dir.value}-${node.data.staticClass}`
+          }
+        }
+      }
+    })
+    renderer.renderToString(new Vue({
+      template: '<p><span v-class-prefixer="\'my\'" class="class1" :class="\'class2\'">hello world</span></p>',
+    }), (err, result) => {
+      expect(err).toBeNull()
+      expect(result).toContain('<p data-server-rendered="true"><span class="my-class1 my-class2">hello world</span></p>')
       done()
     })
   })


### PR DESCRIPTION
fix #10733

SSR render does not execute directives attached to a component, this is happening because during SSR render we're using the component's root element as a source for rendering, thus there's no directive associated with it.

This fixes it by copying directives from the Component declaration to the Component's root element, while rendering the root element it references the Component instance vnode to properly render it's modules applying the directives.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
