### PR TITLE
feat(server): make MAX_STACK_DEPTH configurable

### DIFF
--- a/src/server/write.js
+++ b/src/server/write.js
@@ -1,6 +1,13 @@
 /* @flow */
 
-const MAX_STACK_DEPTH = 800
+const MAX_STACK_DEPTH =
+  parseInt(
+    (typeof process !== "undefined" &&
+      process.env &&
+      process.env.MAX_STACK_DEPTH) ||
+      0,
+    10
+  ) || 800;
 const noop = _ => _
 
 const defer = typeof process !== 'undefined' && process.nextTick


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

In my scenario, there are many recursive calls in render function, and `SSR` application would throw the `Maximum call stack size exceeded` before the `stackDepth` reach `800`. I want the `MAX_STACK_DEPTH` configurable in this case.

**Other information:**
