### PR TITLE
fix(v-on): avoid events with empty keyCode (autocomplete)

### DIFF
--- a/src/core/instance/render-helpers/check-keycodes.js
+++ b/src/core/instance/render-helpers/check-keycodes.js
@@ -31,4 +31,5 @@ export function checkKeyCodes (
   } else if (eventKeyName) {
     return hyphenate(eventKeyName) !== key
   }
+  return eventKeyCode === undefined
 }

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -962,6 +962,17 @@ describe('Directive v-on', () => {
     expect(value).toBe(1)
   })
 
+  it('should not execute callback if modifiers are present', () => {
+    vm = new Vue({
+      el,
+      template: '<input @keyup.?="foo">',
+      methods: { foo: spy }
+    })
+    // simulating autocomplete event (Event object with type keyup but without keyCode)
+    triggerEvent(vm.$el, 'keyup')
+    expect(spy.calls.count()).toBe(0)
+  })
+
   describe('dynamic arguments', () => {
     it('basic', done => {
       const spy = jasmine.createSpy()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Chromium browsers (and Safari) trigger a `keydown`/`keyup` event on autocomplete. An `Event` object without `key` or `keyCode` is generated.
Vue, when listening with modifiers, is triggering the callback even if the modifier key doesn't match the `undefined` keyCode of the event.

Current behaviour: https://codepen.io/zupolgec/pen/RwWRxdK
New behaviour: https://codepen.io/zupolgec/pen/qBONxMj

Try autocompleting the first field: in the first demo is counted, in the second demo is ignored.

See also same kind of issue on another JS library: https://github.com/alpinejs/alpine/pull/389#issuecomment-615935688