### PR TITLE
dist/README.md : small Webpack sample code fix

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -90,9 +90,7 @@ module.exports = {
   plugins: [
     // ...
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production')
-      }
+      'process.env.NODE_ENV': JSON.stringify('production')
     })
   ]
 }


### PR DESCRIPTION
This PR fixs the sample code for Webpack configuration, following the note in the [define-plugin#usage](https://webpack.js.org/plugins/define-plugin/#usage) documention:

> When defining values for process prefer 'process.env.NODE_ENV': JSON.stringify('production') over process: { env: { NODE_ENV: JSON.stringify('production') } }. Using the latter will overwrite the process object which can break compatibility with some modules that expect other values on the process object to be defined.