### PR TITLE
refactor: remove unused UserAgent variables of env.js

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -13,8 +13,6 @@ export const isIE9 = UA && UA.indexOf('msie 9.0') > 0
 export const isEdge = UA && UA.indexOf('edge/') > 0
 export const isAndroid = (UA && UA.indexOf('android') > 0) || (weexPlatform === 'android')
 export const isIOS = (UA && /iphone|ipad|ipod|ios/.test(UA)) || (weexPlatform === 'ios')
-export const isChrome = UA && /chrome\/\d+/.test(UA) && !isEdge
-export const isPhantomJS = UA && /phantomjs/.test(UA)
 export const isFF = UA && UA.match(/firefox\/(\d+)/)
 
 // Firefox has a "watch" function on Object.prototype...


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)


**Other information:**
UserAgent variables `isPhantomJS` and `isChrome` in `vue\src\core\util\env.js` was no longer used since:
- Replace `isPhantomJS` with`isChrome`: [2019-1-11: refactor: better solution for async edge case.](https://github.com/vuejs/vue/commit/3504d7f6d6c8f5bf156fa9242bf54f502c077520#diff-f2722526eac8096c360952e2ffa057f9)
- Replace `isChrome` with`isUsingMicroTask`: [2019-01-24: fix: async edge case fix should apply to more browsers](https://github.com/vuejs/vue/commit/ba0ebd4771ddb5c56c1261f82c842b57ca7163a6#diff-f2722526eac8096c360952e2ffa057f9).

But now, they still exist and will be bundled into the dist version, eg: `vue\dist\vue.min.js`. 

These userless code can be simplified, And reduce production version size slightly, So I made this PR.

