### PR TITLE
chore: spelling and grammar. fix #11480

### DIFF
--- a/flow/weex.js
+++ b/flow/weex.js
@@ -28,7 +28,7 @@ declare type WeexEnvironment = {
   appName: string; // mobile app name or browser name
   appVersion: string;
 
-  // informations of current running device
+  // information about current running device
   deviceModel: string; // phone device model
   deviceWidth: number;
   deviceHeight: number;

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -380,7 +380,7 @@ export function parse (
       }
     },
     comment (text: string, start, end) {
-      // adding anyting as a sibling to the root node is forbidden
+      // adding anything as a sibling to the root node is forbidden
       // comments should still be allowed, but ignored
       if (currentParent) {
         const child: ASTText = {

--- a/test/unit/features/directives/on.spec.js
+++ b/test/unit/features/directives/on.spec.js
@@ -280,7 +280,7 @@ describe('Directive v-on', () => {
     expect(spy.calls.count()).toBe(1)
   })
 
-  it('should support system modifers with exact', () => {
+  it('should support system modifiers with exact', () => {
     vm = new Vue({
       el,
       template: `
@@ -405,7 +405,7 @@ describe('Directive v-on', () => {
     Vue.config.keyCodes = Object.create(null)
   })
 
-  it('should override build-in keyCode', () => {
+  it('should override built-in keyCode', () => {
     Vue.config.keyCodes.up = [1, 87]
     vm = new Vue({
       el,
@@ -420,7 +420,7 @@ describe('Directive v-on', () => {
       e.keyCode = 1
     })
     expect(spy).toHaveBeenCalledTimes(2)
-    // should not affect build-in down keycode
+    // should not affect built-in down keycode
     triggerEvent(vm.$el, 'keyup', e => {
       e.keyCode = 40
     })

--- a/types/umd.d.ts
+++ b/types/umd.d.ts
@@ -7,7 +7,7 @@ import {
   PropsDefinition
 } from "./options";
 
-// Expose some types for backword compatibility...
+// Expose some types for backward compatibility...
 declare namespace Vue {
   // vue.d.ts
   export type CreateElement = V.CreateElement;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Spelling and grammar

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This is a drive-by contribution, and I had trouble testing on my host.  When I ran npm test, everything succeeded/passed until attempting to start a webserver, since I already have something listening on port 8080 that I didn't want to shut down.  I tried _npm test --port 8111, which looked like it was going to work, but there are a bunch of hard-coded instances of :8080 under e2e/specs that I think are the cause.  I'll open a separate issue for that.