### PR TITLE
fix(vdom): avoid executing root level script tags

### DIFF
--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -45,7 +45,8 @@ export function generate (
   options: CompilerOptions
 ): CodegenResult {
   const state = new CodegenState(options)
-  const code = ast ? genElement(ast, state) : '_c("div")'
+  // fix #11483, Root level <script> tags should not be rendered.
+  const code = ast ? (ast.tag === 'script' ? 'null' : genElement(ast, state)) : '_c("div")'
   return {
     render: `with(this){return ${code}}`,
     staticRenderFns: state.staticRenderFns

--- a/test/unit/features/component/component.spec.js
+++ b/test/unit/features/component/component.spec.js
@@ -426,4 +426,17 @@ describe('Component', () => {
       vm.$destroy()
     }).then(done)
   })
+
+  it('render vnode with <script> tag as root element', () => {
+    const vm = new Vue({
+      template: '<scriptTest></scriptTest>',
+      components: {
+        scriptTest: {
+          template: '<script>console.log(1)</script>'
+        }
+      }
+    }).$mount()
+    expect(vm.$el.nodeName).toBe('#comment')
+    expect('Templates should only be responsible for mapping the state').toHaveBeenWarned()
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ x ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ x ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Root level <script> tags should not be executed, for consistent behavior. So I remove the code in <script> tag when the <script> tag is the root element of the template.

fix #11483