### PR TITLE
types: porting types from vue-next

### DIFF
--- a/types/apiDefineComponent.d.ts
+++ b/types/apiDefineComponent.d.ts
@@ -1,0 +1,183 @@
+import {
+  ComputedOptions,
+  MethodOptions,
+  ComponentOptionsWithoutProps,
+  ComponentOptionsWithArrayProps,
+  ComponentOptionsWithObjectProps,
+  ComponentOptionsMixin,
+} from "./componentOptions";
+import {
+  CreateComponentPublicInstance,
+  ComponentPublicInstanceConstructor,
+} from "./componentProxy";
+import { ExtractPropTypes, ComponentPropsOptions } from "./componentProps";
+import { EmitsOptions } from "./componentEmits";
+import { VNodeProps } from "./vnode";
+
+// defineComponent is a utility that is primarily used for type inference
+// when declaring components. Type inference is provided in the component
+// options (provided as the argument). The returned value has artificial types
+// for TSX / manual render function / IDE support.
+
+// overload 1: direct setup function
+// (uses user defined props interface)
+// export function defineComponent<Props, RawBindings = object>(
+//   setup: (
+//     props: Readonly<Props>,
+//     ctx: SetupContext
+//   ) => RawBindings | RenderFunction
+// ): ComponentPublicInstanceConstructor<
+//   CreateComponentPublicInstance<
+//     Props,
+//     RawBindings,
+//     {},
+//     {},
+//     {},
+//     {},
+//     {},
+//     {},
+//     // public props
+//     VNodeProps & Props
+//   >
+// > &
+//   FunctionalComponent<Props>;
+
+// overload 2: object format with no props
+// (uses user defined props interface)
+// return type is for Vetur and TSX support
+export function defineComponent<
+  Props = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = Record<string, any>,
+  EE extends string = string
+>(
+  options: ComponentOptionsWithoutProps<
+    Props,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >
+): ComponentPublicInstanceConstructor<
+  CreateComponentPublicInstance<
+    Props,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    VNodeProps & Props
+  >
+> &
+  ComponentOptionsWithoutProps<
+    Props,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >;
+
+// overload 3: object format with array props declaration
+// props inferred as { [key in PropNames]?: any }
+// return type is for Vetur and TSX support
+export function defineComponent<
+  PropNames extends string,
+  D,
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = Record<string, any>,
+  EE extends string = string
+>(
+  options: ComponentOptionsWithArrayProps<
+    PropNames,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >
+): ComponentPublicInstanceConstructor<
+  // array props technically doesn't place any contraints on props in TSX before,
+  // but now we can export array props in TSX
+  CreateComponentPublicInstance<
+    Readonly<{ [key in PropNames]?: any }>,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E
+  >
+> &
+  ComponentOptionsWithArrayProps<
+    PropNames,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >;
+
+// overload 4: object format with object props declaration
+// see `ExtractPropTypes` in ./componentProps.ts
+export function defineComponent<
+  // the Readonly constraint allows TS to treat the type of { required: true }
+  // as constant instead of boolean.
+  PropsOptions extends Readonly<ComponentPropsOptions>,
+  D,
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = Record<string, any>,
+  EE extends string = string
+>(
+  options: ComponentOptionsWithObjectProps<
+    PropsOptions,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >
+): ComponentPublicInstanceConstructor<
+  CreateComponentPublicInstance<
+    ExtractPropTypes<PropsOptions, false>,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    VNodeProps
+  >
+> &
+  ComponentOptionsWithObjectProps<
+    PropsOptions,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE
+  >;

--- a/types/component.ts
+++ b/types/component.ts
@@ -1,0 +1,278 @@
+import { VNode, VNodeChild } from "./vnode";
+import {
+  CreateComponentPublicInstance,
+  ComponentPublicInstance,
+} from "./componentProxy";
+import {
+  ComponentPropsOptions,
+  NormalizedPropsOptions,
+} from "./componentProps";
+import { Directive } from "./directives";
+import { ComponentOptions } from "./componentOptions";
+import { EmitsOptions, ObjectEmitsOptions, EmitFn } from "./componentEmits";
+import { InjectOptions, RenderContext } from "./options";
+import { CreateElement } from "./vue";
+
+export type Data = { [key: string]: unknown };
+
+// Note: can't mark this whole interface internal because some public interfaces
+// extend it.
+export interface ComponentInternalOptions {
+  /**
+   * @internal
+   */
+  __props?: NormalizedPropsOptions | [];
+  /**
+   * @internal
+   */
+  __scopeId?: string;
+  /**
+   * @internal
+   */
+  __cssModules?: Data;
+  /**
+   * @internal
+   */
+  __hmrId?: string;
+  /**
+   * This one should be exposed so that devtools can make use of it
+   */
+  __file?: string;
+}
+
+// export interface FunctionalComponent<P = {}, E extends EmitsOptions = {}>
+//   extends ComponentInternalOptions {
+//   // // use of any here is intentional so it can be a valid JSX Element constructor
+//   // (props: P, ctx: SetupContext<E>): any;
+//   // props?: ComponentPropsOptions<P>;
+//   // emits?: E | (keyof E)[];
+//   // inheritAttrs?: boolean;
+//   // displayName?: string;
+// }
+
+export interface FunctionalComponent<Props = {}> {
+  name?: string;
+  props?: ComponentPropsOptions<Props>;
+  model?: {
+    prop?: string;
+    event?: string;
+  };
+  inject?: InjectOptions;
+  functional: boolean;
+  render?(
+    this: undefined,
+    createElement: CreateElement,
+    context: RenderContext<Props>
+  ): VNode | VNode[];
+}
+
+export interface ClassComponent {
+  new (...args: any[]): ComponentPublicInstance<any, any, any, any, any>;
+  __vccOpts: ComponentOptions;
+}
+
+export type Component = ComponentOptions | FunctionalComponent<any>;
+
+// A type used in public APIs where a component type is expected.
+// The constructor type is an artificial type returned by defineComponent().
+export type PublicAPIComponent =
+  | Component
+  | {
+      new (...args: any[]): CreateComponentPublicInstance<
+        any,
+        any,
+        any,
+        any,
+        any
+      >;
+    };
+
+export { ComponentOptions };
+
+type LifecycleHook = Function[] | null;
+
+export const enum LifecycleHooks {
+  BEFORE_CREATE = "bc",
+  CREATED = "c",
+  BEFORE_MOUNT = "bm",
+  MOUNTED = "m",
+  BEFORE_UPDATE = "bu",
+  UPDATED = "u",
+  BEFORE_UNMOUNT = "bum",
+  UNMOUNTED = "um",
+  DEACTIVATED = "da",
+  ACTIVATED = "a",
+  RENDER_TRIGGERED = "rtg",
+  RENDER_TRACKED = "rtc",
+  ERROR_CAPTURED = "ec",
+}
+
+/**
+ * @internal
+ */
+export type InternalRenderFunction = {
+  (
+    ctx: ComponentPublicInstance,
+    cache: ComponentInternalInstance["renderCache"]
+  ): VNodeChild;
+  _rc?: boolean; // isRuntimeCompiled
+};
+
+/**
+ * We expose a subset of properties on the internal instance as they are
+ * useful for advanced external libraries and tools.
+ */
+export interface ComponentInternalInstance {
+  uid: number;
+  type: Component;
+  parent: ComponentInternalInstance | null;
+  root: ComponentInternalInstance;
+  /**
+   * Vnode representing this component in its parent's vdom tree
+   */
+  vnode: VNode;
+  /**
+   * The pending new vnode from parent updates
+   * @internal
+   */
+  next: VNode | null;
+  /**
+   * Root vnode of this component's own vdom tree
+   */
+  subTree: VNode;
+  /**
+   * The reactive effect for rendering and patching the component. Callable.
+   */
+  update(): void;
+  /**
+   * The render function that returns vdom tree.
+   * @internal
+   */
+  render: InternalRenderFunction | null;
+  /**
+   * Object containing values this component provides for its descendents
+   * @internal
+   */
+  provides: Data;
+  /**
+   * cache for proxy access type to avoid hasOwnProperty calls
+   * @internal
+   */
+  accessCache: Data | null;
+  /**
+   * cache for render function values that rely on _ctx but won't need updates
+   * after initialized (e.g. inline handlers)
+   * @internal
+   */
+  renderCache: (Function | VNode)[];
+
+  /**
+   * Asset hashes that prototypally inherits app-level asset hashes for fast
+   * resolution
+   * @internal
+   */
+  components: Record<string, Component>;
+  /**
+   * @internal
+   */
+  directives: Record<string, Directive>;
+
+  // the rest are only for stateful components ---------------------------------
+
+  // main proxy that serves as the public instance (`this`)
+  proxy: ComponentPublicInstance | null;
+
+  /**
+   * alternative proxy used only for runtime-compiled render functions using
+   * `with` block
+   * @internal
+   */
+  withProxy: ComponentPublicInstance | null;
+  /**
+   * This is the target for the public instance proxy. It also holds properties
+   * injected by user options (computed, methods etc.) and user-attached
+   * custom properties (via `this.x = ...`)
+   * @internal
+   */
+  ctx: Data;
+
+  // internal state
+  data: Data;
+  props: Data;
+  attrs: Data;
+  slots: {}; //TODO check this cr
+  refs: Data;
+  emit: EmitFn;
+
+  /**
+   * setup related
+   * @internal
+   */
+  setupState: Data;
+
+  /**
+   * @internal
+   */
+  asyncDep: Promise<any> | null;
+  /**
+   * @internal
+   */
+  asyncResolved: boolean;
+
+  // lifecycle
+  isMounted: boolean;
+  isUnmounted: boolean;
+  isDeactivated: boolean;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.BEFORE_CREATE]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.CREATED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.BEFORE_MOUNT]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.MOUNTED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.BEFORE_UPDATE]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.UPDATED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.BEFORE_UNMOUNT]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.UNMOUNTED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.RENDER_TRACKED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.RENDER_TRIGGERED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.ACTIVATED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.DEACTIVATED]: LifecycleHook;
+  /**
+   * @internal
+   */
+  [LifecycleHooks.ERROR_CAPTURED]: LifecycleHook;
+}

--- a/types/component.ts
+++ b/types/component.ts
@@ -11,7 +11,7 @@ import { Directive } from "./directives";
 import { ComponentOptions } from "./componentOptions";
 import { EmitsOptions, ObjectEmitsOptions, EmitFn } from "./componentEmits";
 import { InjectOptions, RenderContext } from "./options";
-import { CreateElement } from "./vue";
+import { CreateElement } from "./h";
 
 export type Data = { [key: string]: unknown };
 

--- a/types/componentEmits.ts
+++ b/types/componentEmits.ts
@@ -1,0 +1,22 @@
+import { UnionToIntersection } from "./typeUtils";
+
+export type ObjectEmitsOptions = Record<
+  string,
+  ((...args: any[]) => any) | null
+>;
+export type EmitsOptions = ObjectEmitsOptions | string[];
+
+export type EmitFn<
+  Options = ObjectEmitsOptions,
+  Event extends keyof Options = keyof Options
+> = Options extends any[]
+  ? (event: Options[0], ...args: any[]) => void
+  : {} extends Options // if the emit is empty object (usually the default value for emit) should be converted to function
+  ? (event: string, ...args: any[]) => void
+  : UnionToIntersection<
+      {
+        [key in Event]: Options[key] extends (...args: infer Args) => any
+          ? (event: key, ...args: Args) => void
+          : (event: key, ...args: any[]) => void;
+      }[Event]
+    >;

--- a/types/componentOptions.ts
+++ b/types/componentOptions.ts
@@ -1,0 +1,293 @@
+import {
+  ComponentInternalInstance,
+  Data,
+  ComponentInternalOptions,
+  PublicAPIComponent,
+  Component,
+} from "./component";
+// import { WatchOptions, WatchCallback } from "./apiWatch";
+import {
+  ComponentObjectPropsOptions,
+  ExtractPropTypes,
+} from "./componentProps";
+import { EmitsOptions } from "./componentEmits";
+// import { Directive } from './directives'
+import {
+  CreateComponentPublicInstance,
+  ComponentPublicInstance,
+} from "./componentProxy";
+import { VNodeChild } from "./vnode";
+import { Directive } from "./directives";
+
+/**
+ * Interface for declaring custom options.
+ *
+ * @example
+ * ```ts
+ * declare module '@vue/runtime-core' {
+ *   interface ComponentCustomOptions {
+ *     beforeRouteUpdate?(
+ *       to: Route,
+ *       from: Route,
+ *       next: () => void
+ *     ): void
+ *   }
+ * }
+ * ```
+ */
+export interface ComponentCustomOptions {}
+
+export type RenderFunction = () => VNodeChild;
+
+export interface ComponentOptionsBase<
+  Props,
+  D,
+  C extends ComputedOptions,
+  M extends MethodOptions,
+  Mixin extends ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin,
+  E extends EmitsOptions,
+  EE extends string = string
+>
+  extends LegacyOptions<Props, D, C, M, Mixin, Extends>,
+    ComponentInternalOptions,
+    ComponentCustomOptions {
+  name?: string;
+  template?: string | object; // can be a direct DOM node
+  // Note: we are intentionally using the signature-less `Function` type here
+  // since any type with signature will cause the whole inference to fail when
+  // the return expression contains reference to `this`.
+  // Luckily `render()` doesn't need any arguments nor does it care about return
+  // type.
+  render?: Function;
+  components?: Record<string, PublicAPIComponent>;
+  directives?: Record<string, Directive>;
+  inheritAttrs?: boolean;
+  emits?: E | EE[];
+
+  // Internal ------------------------------------------------------------------
+
+  /**
+   * SSR only. This is produced by compiler-ssr and attached in compiler-sfc
+   * not user facing, so the typing is lax and for test only.
+   *
+   * @internal
+   */
+  ssrRender?: (
+    ctx: any,
+    push: (item: any) => void,
+    parentInstance: ComponentInternalInstance,
+    attrs?: Data
+  ) => void;
+
+  /**
+   * marker for AsyncComponentWrapper
+   * @internal
+   */
+  __asyncLoader?: () => Promise<Component>;
+  /**
+   * cache for merged $options
+   * @internal
+   */
+  __merged?: ComponentOptions;
+
+  // Type differentiators ------------------------------------------------------
+
+  // Note these are internal but need to be exposed in d.ts for type inference
+  // to work!
+
+  // type-only differentiator to separate OptionWithoutProps from a constructor
+  // type returned by defineComponent() or FunctionalComponent
+  call?: (this: unknown, ...args: unknown[]) => never;
+  // type-only differentiators for built-in Vnode types
+  __isFragment?: never;
+  __isTeleport?: never;
+  __isSuspense?: never;
+}
+
+export type ComponentOptionsWithoutProps<
+  Props = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = EmitsOptions,
+  EE extends string = string
+> = ComponentOptionsBase<Props, D, C, M, Mixin, Extends, E, EE> & {
+  props?: undefined;
+} & ThisType<
+    CreateComponentPublicInstance<
+      {},
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      Readonly<Props>
+    >
+  >;
+
+export type ComponentOptionsWithArrayProps<
+  PropNames extends string = string,
+  RawBindings = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = EmitsOptions,
+  EE extends string = string,
+  Props = Readonly<{ [key in PropNames]?: any }>
+> = ComponentOptionsBase<Props, D, C, M, Mixin, Extends, E, EE> & {
+  props: PropNames[];
+} & ThisType<CreateComponentPublicInstance<Props, D, C, M, Mixin, Extends, E>>;
+
+export type ComponentOptionsWithObjectProps<
+  PropsOptions = ComponentObjectPropsOptions,
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = EmitsOptions,
+  EE extends string = string,
+  Props = Readonly<ExtractPropTypes<PropsOptions>>
+> = ComponentOptionsBase<Props, D, C, M, Mixin, Extends, E, EE> & {
+  props: PropsOptions;
+} & ThisType<CreateComponentPublicInstance<Props, D, C, M, Mixin, Extends, E>>;
+
+export type ComponentOptions =
+  | ComponentOptionsWithoutProps<any, any, any, any, any>
+  | ComponentOptionsWithObjectProps<any, any, any, any, any>
+  | ComponentOptionsWithArrayProps<any, any, any, any, any>;
+
+export type ComponentOptionsMixin = ComponentOptionsBase<
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any
+>;
+
+export type ComputedOptions = Record<
+  string,
+  ComputedGetter<any> | WritableComputedOptions<any>
+>;
+
+export type ComputedGetter<T> = (ctx?: any) => T;
+export type ComputedSetter<T> = (v: T) => void;
+
+export interface WritableComputedOptions<T> {
+  get: ComputedGetter<T>;
+  set: ComputedSetter<T>;
+}
+
+export interface MethodOptions {
+  [key: string]: Function;
+}
+
+export type ExtractComputedReturns<T extends any> = {
+  [key in keyof T]: T[key] extends { get: (...args: any[]) => infer TReturn }
+    ? TReturn
+    : T[key] extends (...args: any[]) => infer TReturn
+    ? TReturn
+    : never;
+};
+
+export interface WatchOptions {
+  deep?: boolean;
+  immediate?: boolean;
+}
+
+export type WatchCallback<V = any, OV = any> = (
+  value: V,
+  oldValue: OV
+  // onInvalidate: InvalidateCbRegistrator
+) => any;
+
+type WatchOptionItem =
+  | string
+  | WatchCallback
+  | ({ handler: WatchCallback } & WatchOptions);
+
+type ComponentWatchOptionItem = WatchOptionItem | WatchOptionItem[];
+
+type ComponentWatchOptions = Record<string, ComponentWatchOptionItem>;
+
+type ComponentInjectOptions =
+  | string[]
+  | Record<
+      string | symbol,
+      string | symbol | { from: string | symbol; default?: unknown }
+    >;
+
+interface LegacyOptions<
+  Props,
+  D,
+  C extends ComputedOptions,
+  M extends MethodOptions,
+  Mixin extends ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin
+> {
+  // allow any custom options
+  [key: string]: any;
+
+  // state
+  // Limitation: we cannot expose RawBindings on the `this` context for data
+  // since that leads to some sort of circular inference and breaks ThisType
+  // for the entire component.
+  data?: (
+    this: CreateComponentPublicInstance<Props>,
+    vm: CreateComponentPublicInstance<Props>
+  ) => D;
+  computed?: C;
+  methods?: M;
+  watch?: ComponentWatchOptions;
+  provide?: Data | Function;
+  inject?: ComponentInjectOptions;
+
+  // composition
+  mixins?: Mixin[];
+  extends?: Extends;
+
+  // lifecycle
+  beforeCreate?(): void;
+  created?(): void;
+  beforeMount?(): void;
+  mounted?(): void;
+  beforeUpdate?(): void;
+  updated?(): void;
+  activated?(): void;
+  deactivated?(): void;
+  beforeUnmount?(): void;
+  unmounted?(): void;
+}
+
+export type OptionTypesKeys = "P" | "D" | "C" | "M";
+
+export type OptionTypesType<
+  P = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {}
+> = {
+  P: P;
+  D: D;
+  C: C;
+  M: M;
+};
+
+const enum OptionTypes {
+  PROPS = "Props",
+  DATA = "Data",
+  COMPUTED = "Computed",
+  METHODS = "Methods",
+  INJECT = "Inject",
+}
+
+type DataFn = (vm: ComponentPublicInstance) => any;

--- a/types/componentProps.ts
+++ b/types/componentProps.ts
@@ -1,0 +1,80 @@
+import { Data } from "./component";
+
+export type ComponentPropsOptions<P = Data> =
+  | ComponentObjectPropsOptions<P>
+  | string[];
+
+export type ComponentObjectPropsOptions<P = Data> = {
+  [K in keyof P]: Prop<P[K]> | null;
+};
+
+export type Prop<T> = PropOptions<T> | PropType<T>;
+
+type DefaultFactory<T> = () => T | null | undefined;
+
+interface PropOptions<T = any> {
+  type?: PropType<T> | true | null;
+  required?: boolean;
+  default?: T | DefaultFactory<T> | null | undefined;
+  validator?(value: unknown): boolean;
+}
+
+export type PropType<T> = PropConstructor<T> | PropConstructor<T>[];
+
+type PropConstructor<T = any> =
+  | { new (...args: any[]): T & object }
+  | { (): T }
+  | PropMethod<T>;
+
+type PropMethod<T, TConstructor = any> = T extends (...args: any) => any // if is function with args
+  ? { new (): TConstructor; (): T; readonly prototype: TConstructor } // Create Function like constructor
+  : never;
+
+type RequiredKeys<T, MakeDefaultRequired> = {
+  [K in keyof T]: T[K] extends
+    | { required: true }
+    | (MakeDefaultRequired extends true ? { default: any } : never)
+    ? K
+    : never;
+}[keyof T];
+
+type OptionalKeys<T, MakeDefaultRequired> = Exclude<
+  keyof T,
+  RequiredKeys<T, MakeDefaultRequired>
+>;
+
+type InferPropType<T> = T extends null
+  ? any // null & true would fail to infer
+  : T extends { type: null | true }
+  ? any // As TS issue https://github.com/Microsoft/TypeScript/issues/14829 // somehow `ObjectConstructor` when inferred from { (): T } becomes `any` // `BooleanConstructor` when inferred from PropConstructor(with PropMethod) becomes `Boolean`
+  : T extends ObjectConstructor | { type: ObjectConstructor }
+  ? { [key: string]: any }
+  : T extends BooleanConstructor | { type: BooleanConstructor }
+  ? boolean
+  : T extends Prop<infer V>
+  ? V
+  : T;
+
+export type ExtractPropTypes<
+  O,
+  MakeDefaultRequired extends boolean = true
+> = O extends object
+  ? { [K in RequiredKeys<O, MakeDefaultRequired>]: InferPropType<O[K]> } &
+      { [K in OptionalKeys<O, MakeDefaultRequired>]?: InferPropType<O[K]> }
+  : { [K in string]: any };
+
+const enum BooleanFlags {
+  shouldCast,
+  shouldCastTrue,
+}
+
+type NormalizedProp =
+  | null
+  | (PropOptions & {
+      [BooleanFlags.shouldCast]?: boolean;
+      [BooleanFlags.shouldCastTrue]?: boolean;
+    });
+
+// normalized value is a tuple of the actual normalized options
+// and an array of prop keys that need value casting (booleans and defaults)
+export type NormalizedPropsOptions = [Record<string, NormalizedProp>, string[]];

--- a/types/componentProxy.ts
+++ b/types/componentProxy.ts
@@ -1,0 +1,151 @@
+import { ComponentInternalInstance, Data } from "./component";
+import {
+  ExtractComputedReturns,
+  ComponentOptionsBase,
+  ComputedOptions,
+  MethodOptions,
+  ComponentOptionsMixin,
+  OptionTypesType,
+  OptionTypesKeys,
+} from "./componentOptions";
+import { EmitsOptions, EmitFn } from "./componentEmits";
+import { UnionToIntersection } from "./typeUtils";
+import { VNode, WatchOptions } from "./umd";
+
+// type nextTick  nextTick<T>(callback: (this: T) => void, context?: T): void;
+// nextTick(): Promise<void>
+
+/**
+ * Custom properties added to component instances in any way and can be accessed through `this`
+ *
+ * @example
+ * Here is an example of adding a property `$router` to every component instance:
+ * ```ts
+ * import { createApp } from 'vue'
+ * import { Router, createRouter } from 'vue-router'
+ *
+ * declare module '@vue/runtime-core' {
+ *   interface ComponentCustomProperties {
+ *     $router: Router
+ *   }
+ * }
+ *
+ * // effectively adding the router to every component instance
+ * const app = createApp({})
+ * const router = createRouter()
+ * app.config.globalProperties.$router = router
+ *
+ * const vm = app.mount('#app')
+ * // we can access the router from the instance
+ * vm.$router.push('/')
+ * ```
+ */
+export interface ComponentCustomProperties {}
+
+type IsDefaultMixinComponent<T> = T extends ComponentOptionsMixin
+  ? ComponentOptionsMixin extends T
+    ? true
+    : false
+  : false;
+
+type MixinToOptionTypes<T> = T extends ComponentOptionsBase<
+  infer P,
+  infer D,
+  infer C,
+  infer M,
+  infer Mixin,
+  infer Extends,
+  any
+>
+  ? OptionTypesType<P & {}, D & {}, C & {}, M & {}> &
+      IntersectionMixin<Mixin> &
+      IntersectionMixin<Extends>
+  : never;
+
+// ExtractMixin(map type) is used to resolve circularly references
+type ExtractMixin<T> = {
+  Mixin: MixinToOptionTypes<T>;
+}[T extends ComponentOptionsMixin ? "Mixin" : never];
+
+type IntersectionMixin<T> = IsDefaultMixinComponent<T> extends true
+  ? OptionTypesType<{}, {}, {}, {}>
+  : UnionToIntersection<ExtractMixin<T>>;
+
+type UnwrapMixinsType<
+  T,
+  Type extends OptionTypesKeys
+> = T extends OptionTypesType ? T[Type] : never;
+
+type EnsureNonVoid<T> = T extends void ? {} : T;
+
+export type CreateComponentPublicInstance<
+  P = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = {},
+  PublicProps = P,
+  PublicMixin = IntersectionMixin<Mixin> & IntersectionMixin<Extends>,
+  PublicP = UnwrapMixinsType<PublicMixin, "P"> & EnsureNonVoid<P>,
+  PublicD = UnwrapMixinsType<PublicMixin, "D"> & EnsureNonVoid<D>,
+  PublicC extends ComputedOptions = UnwrapMixinsType<PublicMixin, "C"> &
+    EnsureNonVoid<C>,
+  PublicM extends MethodOptions = UnwrapMixinsType<PublicMixin, "M"> &
+    EnsureNonVoid<M>
+> = ComponentPublicInstance<
+  PublicP,
+  PublicD,
+  PublicC,
+  PublicM,
+  E,
+  PublicProps,
+  ComponentOptionsBase<P, D, C, M, Mixin, Extends, E>
+>;
+// public properties exposed on the proxy, which is used as the render context
+// in templates (as `this` in the render option)
+export type ComponentPublicInstance<
+  P = {}, // props type extracted from props option
+  D = {}, // return from data()
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  E extends EmitsOptions = {},
+  PublicProps = P,
+  Options = ComponentOptionsBase<any, any, any, any, any, any, any, any>
+> = {
+  $: ComponentInternalInstance;
+  $data: D;
+  $props: P & PublicProps;
+  $attrs: Data;
+  $refs: Data;
+  readonly $slots: { [key: string]: VNode[] | undefined };
+  $root: ComponentPublicInstance | null;
+  $parent: ComponentPublicInstance | null;
+  $emit: EmitFn<E>;
+  $el: any;
+  $options: Options;
+  $forceUpdate(): void;
+  nextTick<T>(callback: (this: T) => void, context?: T): void;
+  nextTick(): Promise<void>;
+  $watch: typeof instanceWatch;
+} & P &
+  D &
+  ExtractComputedReturns<C> &
+  M &
+  ComponentCustomProperties;
+
+export type ComponentPublicInstanceConstructor<
+  T extends ComponentPublicInstance
+> = {
+  new (): T;
+};
+
+export type WatchStopHandle = () => void;
+
+declare function instanceWatch(
+  this: ComponentInternalInstance,
+  source: string | Function,
+  cb: Function,
+  options?: WatchOptions
+): WatchStopHandle;

--- a/types/componentProxy.ts
+++ b/types/componentProxy.ts
@@ -7,10 +7,11 @@ import {
   ComponentOptionsMixin,
   OptionTypesType,
   OptionTypesKeys,
+  WatchOptions,
 } from "./componentOptions";
 import { EmitsOptions, EmitFn } from "./componentEmits";
 import { UnionToIntersection } from "./typeUtils";
-import { VNode, WatchOptions } from "./umd";
+import { VNode, NormalizedScopedSlot } from "./vnode";
 
 // type nextTick  nextTick<T>(callback: (this: T) => void, context?: T): void;
 // nextTick(): Promise<void>
@@ -129,6 +130,24 @@ export type ComponentPublicInstance<
   nextTick<T>(callback: (this: T) => void, context?: T): void;
   nextTick(): Promise<void>;
   $watch: typeof instanceWatch;
+
+
+  // readonly $el: Element;
+  // readonly $options: ComponentOptions<Vue>;
+  // readonly $parent: Vue;
+  // readonly $root: Vue;
+  // readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[] };
+  // readonly $slots: { [key: string]: VNode[] | undefined };
+  // readonly $data: Record<string, any>;
+  // readonly $props: Record<string, any>;
+  // readonly $attrs: Record<string, string>;
+
+  readonly $children: Vue[];
+  readonly $scopedSlots: { [key: string]: NormalizedScopedSlot | undefined };
+  readonly $isServer: boolean;
+  readonly $ssrContext: any;
+  readonly $vnode: VNode;
+  readonly $listeners: Record<string, Function | Function[]>;
 } & P &
   D &
   ExtractComputedReturns<C> &

--- a/types/directives.ts
+++ b/types/directives.ts
@@ -1,0 +1,69 @@
+/**
+Runtime helper for applying directives to a vnode. Example usage:
+
+const comp = resolveComponent('comp')
+const foo = resolveDirective('foo')
+const bar = resolveDirective('bar')
+
+return withDirectives(h(comp), [
+  [foo, this.x],
+  [bar, this.y]
+])
+*/
+
+import { VNode } from "./vnode";
+import { Data } from "./component";
+import { ComponentPublicInstance } from "./componentProxy";
+
+export interface DirectiveBinding<V = any> {
+  instance: ComponentPublicInstance | null;
+  value: V;
+  oldValue: V | null;
+  arg?: string;
+  modifiers: DirectiveModifiers;
+  dir: ObjectDirective<any, V>;
+}
+
+export type DirectiveHook<T = any, Prev = VNode<any, T> | null, V = any> = (
+  el: T,
+  binding: DirectiveBinding<V>,
+  vnode: VNode<any, T>,
+  prevVNode: Prev
+) => void;
+
+export type SSRDirectiveHook = (
+  binding: DirectiveBinding,
+  vnode: VNode
+) => Data | undefined;
+
+export interface ObjectDirective<T = any, V = any> {
+  beforeMount?: DirectiveHook<T, null, V>;
+  mounted?: DirectiveHook<T, null, V>;
+  beforeUpdate?: DirectiveHook<T, VNode<any, T>, V>;
+  updated?: DirectiveHook<T, VNode<any, T>, V>;
+  beforeUnmount?: DirectiveHook<T, null, V>;
+  unmounted?: DirectiveHook<T, null, V>;
+  getSSRProps?: SSRDirectiveHook;
+}
+
+export type FunctionDirective<T = any, V = any> = DirectiveHook<T, any, V>;
+
+export type Directive<T = any, V = any> =
+  | ObjectDirective<T, V>
+  | FunctionDirective<T, V>;
+
+export type DirectiveModifiers = Record<string, boolean>;
+
+export type VNodeDirectiveData = [
+  unknown,
+  string | undefined,
+  DirectiveModifiers
+];
+
+// Directive, value, argument, modifiers
+export type DirectiveArguments = Array<
+  | [Directive]
+  | [Directive, any]
+  | [Directive, any, string]
+  | [Directive, any, string, DirectiveModifiers]
+>;

--- a/types/h.d.ts
+++ b/types/h.d.ts
@@ -81,3 +81,8 @@ export declare function h<P>(
   props?: (RawProps & P) | ({} extends P ? null : never),
   children?: RawChildren //| RawSlots
 ): VNode;
+
+
+
+type hType = typeof h;
+export interface CreateElement extends hType {}

--- a/types/h.d.ts
+++ b/types/h.d.ts
@@ -1,0 +1,83 @@
+// `h` is a more user-friendly version of `createVNode` that allows omitting the
+// props when possible. It is intended for manually written render functions.
+// Compiler-generated code uses `createVNode` because
+// 1. it is monomorphic and avoids the extra call overhead
+// 2. it allows specifying patchFlags for optimization
+
+import { VNode, VNodeChildrenArrayContents, VNodeChildren } from "./vnode";
+import { EmitsOptions } from "./componentEmits";
+import { FunctionalComponent, Component } from "./component";
+
+/*
+// type only
+h('div')
+
+// type + props
+h('div', {})
+
+// type + omit props + children
+// Omit props does NOT support named slots
+h('div', []) // array
+h('div', 'foo') // text
+h('div', h('br')) // vnode
+h(Component, () => {}) // default slot
+
+// type + props + children
+h('div', {}, []) // array
+h('div', {}, 'foo') // text
+h('div', {}, h('br')) // vnode
+h(Component, {}, () => {}) // default slot
+h(Component, {}, {}) // named slots
+
+// named slots without props requires explicit `null` to avoid ambiguity
+h(Component, null, {})
+**/
+
+// fake constructor type returned from `defineComponent`
+interface Constructor<P = any> {
+  new (): { $props: P };
+}
+
+type RawProps = Record<string, any> & {
+//   // used to differ from a single VNode object as children
+//   __v_isVNode?: never;
+  // used to differ from Array children
+  [Symbol.iterator]?: never;
+};
+
+type RawChildren =
+  | string
+  | number
+  | boolean
+  | VNode
+  | VNodeChildren
+  | (() => any);
+
+// The following is a series of overloads for providing props validation of
+// manually written render functions.
+
+// element
+export declare function h(type: string, children?: RawChildren): VNode;
+export declare function h(
+  type: string,
+  props?: RawProps | null,
+  children?: RawChildren //| RawSlots
+): VNode;
+
+// functional component
+export declare function h<P, E extends EmitsOptions = {}>(
+  type: FunctionalComponent<P>,
+  props?: (RawProps & P) | ({} extends P ? null : never),
+  children?: RawChildren //| RawSlots
+): VNode;
+
+// catch-all for generic component types
+export declare function h(type: Component, children?: RawChildren): VNode;
+
+// fake constructor type returned by `defineComponent` or class component
+export declare function h(type: Constructor, children?: RawChildren): VNode;
+export declare function h<P>(
+  type: Constructor<P>,
+  props?: (RawProps & P) | ({} extends P ? null : never),
+  children?: RawChildren //| RawSlots
+): VNode;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,31 +3,42 @@ import "./umd";
 
 export default Vue;
 
-export {
-  CreateElement,
-  VueConstructor
-} from "./vue";
+export { VueConstructor } from "./vue";
+
+export { CreateElement } from "./h";
 
 export {
-  Component,
-  AsyncComponent,
-  ComponentOptions,
-  FunctionalComponentOptions,
   RenderContext,
-  PropType,
-  PropOptions,
   ComputedOptions,
-  WatchHandler,
   WatchOptions,
-  WatchOptionsWithHandler,
-  DirectiveFunction,
-  DirectiveOptions
-} from "./options";
+} from "./componentOptions";
+
+export { PropType } from "./componentProps";
 
 export {
-  PluginFunction,
-  PluginObject
-} from "./plugin";
+  PublicAPIComponent,
+  ClassComponent,
+  Component,
+  ComponentOptions,
+  FunctionalComponent,
+} from "./component";
+// export {
+//   Component,
+//   AsyncComponent,
+//   ComponentOptions,
+//   FunctionalComponentOptions,
+//   RenderContext,
+//   PropType,
+//   PropOptions,
+//   ComputedOptions,
+//   WatchHandler,
+//   WatchOptions,
+//   WatchOptionsWithHandler,
+//   DirectiveFunction,
+//   DirectiveOptions
+// } from "./options";
+
+export { PluginFunction, PluginObject } from "./plugin";
 
 export {
   VNodeChildren,
@@ -35,5 +46,5 @@ export {
   VNode,
   VNodeComponentOptions,
   VNodeData,
-  VNodeDirective
+  VNodeDirective,
 } from "./vnode";

--- a/types/test/augmentation-test.ts
+++ b/types/test/augmentation-test.ts
@@ -23,20 +23,23 @@ declare module "../options" {
 
 const vm = new Vue({
   props: ["bar"],
-  data: {
-    a: true
-  },
+  // data: {
+  //   a: true
+  // },
+  data: () => ({
+    a: true,
+  }),
   foo: "foo",
   methods: {
     foo() {
       this.a = false;
-    }
+    },
   },
   computed: {
     BAR(): string {
       return this.bar.toUpperCase();
-    }
-  }
+    },
+  },
 });
 
 vm.$instanceProperty;

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,6 +1,11 @@
 import Vue, { PropType, VNode } from "../index";
-import { ComponentOptions, Component } from "../index";
-import { CreateElement } from "../vue";
+import {
+  ComponentOptions,
+  Component,
+  CreateElement,
+  PublicAPIComponent,
+  ComputedOptions,
+} from "../index";
 
 interface MyComponent extends Vue {
   a: number;
@@ -9,74 +14,74 @@ interface MyComponent extends Vue {
 const option: ComponentOptions<MyComponent> = {
   data() {
     return {
-      a: 123
-    }
-  }
-}
+      a: 123,
+    };
+  },
+};
 
 // contravariant generic should use never
-const anotherOption: ComponentOptions<never> = option
-const componentType: Component = option
+const anotherOption: ComponentOptions<never> = option;
+const componentType: Component = option;
 
-Vue.component('sub-component', {
+Vue.component("sub-component", {
   components: {
     a: Vue.component(""),
-    b: {}
-  }
+    b: {},
+  },
 });
 
-Vue.component('prop-component', {
+Vue.component("prop-component", {
   props: {
     size: Number,
     name: {
       type: String,
-      default: '0',
+      default: "0",
       required: true,
-    }
+    },
   },
   data() {
     return {
       fixedSize: this.size.toFixed(),
-      capName: this.name.toUpperCase()
-    }
-  }
+      capName: this.name.toUpperCase(),
+    };
+  },
 });
 
-Vue.component('string-prop', {
-  props: ['size', 'name'],
+Vue.component("string-prop", {
+  props: ["size", "name"],
   data() {
     return {
       fixedSize: this.size.whatever,
-      capName: this.name.isany
-    }
-  }
+      capName: this.name.isany,
+    };
+  },
 });
 
 class User {
-  private u = 1
+  private u = 1;
 }
 class Cat {
-  private u = 1
+  private u = 1;
 }
 
 interface IUser {
-  foo: string,
-  bar: number
+  foo: string;
+  bar: number;
 }
 
 interface ICat {
-  foo: any,
-  bar: object
+  foo: any;
+  bar: object;
 }
 type ConfirmCallback = (confirm: boolean) => void;
 
-Vue.component('union-prop', {
+Vue.component("union-prop", {
   props: {
     cat: Object as PropType<ICat>,
     complexUnion: { type: [User, Number] as PropType<User | number> },
     kittyUser: Object as PropType<ICat & IUser>,
     callback: Function as PropType<ConfirmCallback>,
-    union: [User, Number] as PropType<User | number>
+    union: [User, Number] as PropType<User | number>,
   },
   data() {
     this.cat;
@@ -86,55 +91,55 @@ Vue.component('union-prop', {
     this.union;
     return {
       fixedSize: this.union,
-    }
-  }
+    };
+  },
 });
 
-Vue.component('union-prop-with-no-casting', {
+Vue.component("union-prop-with-no-casting", {
   props: {
     mixed: [RegExp, Array],
     object: [Cat, User],
     primitive: [String, Number],
-    regex: RegExp
+    regex: RegExp,
   },
   data() {
     this.mixed;
     this.object;
     this.primitive;
     this.regex.compile;
-  }
-})
+  },
+});
 
-Vue.component('prop-with-primitive-default', {
+Vue.component("prop-with-primitive-default", {
   props: {
     id: {
       type: String,
-      default: () => String(Math.round(Math.random() * 10000000))
-    }
+      default: () => String(Math.round(Math.random() * 10000000)),
+    },
   },
   created(): void {
     this.id;
-  }
+  },
 });
 
-Vue.component('component', {
+Vue.component("component", {
   data() {
-    this.$mount
-    this.size
+    this.$mount;
+    this.size;
     return {
-      a: 1
-    }
+      a: 1,
+    };
   },
   props: {
     size: Number,
     name: {
       type: String,
-      default: '0',
+      default: "0",
       required: true,
-    }
+    },
   },
   propsData: {
-    msg: "Hello"
+    msg: "Hello",
   },
   computed: {
     aDouble(): number {
@@ -147,8 +152,8 @@ Vue.component('component', {
       set(v: number) {
         this.a = v - 1;
       },
-      cache: false
-    }
+      cache: false,
+    },
   },
   methods: {
     plus(): void {
@@ -156,19 +161,19 @@ Vue.component('component', {
       this.aDouble.toFixed();
       this.aPlus = 1;
       this.size.toFixed();
-    }
+    },
   },
   watch: {
-    'a': function(val: number, oldVal: number) {
+    a: function (val: number, oldVal: number) {
       console.log(`new: ${val}, old: ${oldVal}`);
     },
-    'b': 'someMethod',
-    'c': {
+    b: "someMethod",
+    c: {
       handler(val, oldVal) {
-        this.a = val
+        this.a = val;
       },
-      deep: true
-    }
+      deep: true,
+    },
   },
   el: "#app",
   template: "<div>{{ message }}</div>",
@@ -228,183 +233,183 @@ Vue.component('component', {
       [createElement("div", "message")]
     ]);
   },
-  renderError(createElement, err) {
-    return createElement('pre', { style: { color: 'red' }}, err.stack)
-  },
-  staticRenderFns: [],
+  // renderError(createElement, err) {
+  //   return createElement('pre', { style: { color: 'red' }}, err.stack)
+  // },
+  // staticRenderFns: [],
 
-  beforeCreate() {
-    (this as any).a = 1;
-  },
-  created() {},
-  beforeDestroy() {},
-  destroyed() {},
-  beforeMount() {},
-  mounted() {},
-  beforeUpdate() {},
-  updated() {},
-  activated() {},
-  deactivated() {},
-  errorCaptured(err, vm, info) {
-    err.message
-    vm.$emit('error')
-    info.toUpperCase()
-    return true
-  },
-  serverPrefetch () {
-    return Promise.resolve()
-  },
+  // beforeCreate() {
+  //   (this as any).a = 1;
+  // },
+  // created() {},
+  // beforeDestroy() {},
+  // destroyed() {},
+  // beforeMount() {},
+  // mounted() {},
+  // beforeUpdate() {},
+  // updated() {},
+  // activated() {},
+  // deactivated() {},
+  // errorCaptured(err, vm, info) {
+  //   err.message;
+  //   vm.$emit("error");
+  //   info.toUpperCase();
+  //   return true;
+  // },
+  // serverPrefetch () {
+  //   return Promise.resolve()
+  // },
 
-  directives: {
-    a: {
-      bind() {},
-      inserted() {},
-      update() {},
-      componentUpdated() {},
-      unbind() {}
-    },
-    b(el, binding, vnode, oldVnode) {
-      el.textContent;
+  // directives: {
+  //   a: {
+  //     bind() {},
+  //     inserted() {},
+  //     update() {},
+  //     componentUpdated() {},
+  //     unbind() {},
+  //   },
+  //   b(el, binding, vnode, oldVnode) {
+  //     el.textContent;
 
-      binding.name;
-      binding.value;
-      binding.oldValue;
-      binding.expression;
-      binding.arg;
-      binding.modifiers["modifier"];
-    }
-  },
-  components: {
-    a: Vue.component(""),
-    b: {} as ComponentOptions<Vue>
-  },
-  transitions: {},
-  filters: {
-    double(value: number) {
-      return value * 2;
-    }
-  },
-  parent: new Vue,
-  mixins: [Vue.component(""), ({} as ComponentOptions<Vue>)],
-  name: "Component",
-  extends: {} as ComponentOptions<Vue>,
-  delimiters: ["${", "}"]
+  //     binding.name;
+  //     binding.value;
+  //     binding.oldValue;
+  //     binding.expression;
+  //     binding.arg;
+  //     binding.modifiers["modifier"];
+  //   },
+  // },
+  // components: {
+  //   a: Vue.component(""),
+  //   b: {} as PublicAPIComponent,
+  // },
+  // transitions: {},
+  // filters: {
+  //   double(value: number) {
+  //     return value * 2;
+  //   },
+  // },
+  // // parent: new Vue(),
+  // mixins: [Vue.component(""), {} as PublicAPIComponent],
+  // name: "Component",
+  // extends: {},
+  // delimiters: ["${", "}"],
 });
 
-
-Vue.component('custom-prop-type-function', {
+Vue.component("custom-prop-type-function", {
   props: {
     callback: Function as PropType<(confirm: boolean) => void>,
   },
   methods: {
-    confirm(){
+    confirm() {
       this.callback(true);
-    }
-  }
+    },
+  },
 });
 
-Vue.component('provide-inject', {
+Vue.component("provide-inject", {
   provide: {
-    foo: 1
+    foo: 1,
   },
   inject: {
-    injectFoo: 'foo',
+    injectFoo: "foo",
     injectBar: Symbol(),
-    injectBaz: { from: 'baz' },
+    injectBaz: { from: "baz" },
     injectQux: { default: 1 },
-    injectQuux: { from: 'quuz', default: () => ({ value: 1 })}
-  }
-})
+    injectQuux: { from: "quuz", default: () => ({ value: 1 }) },
+  },
+});
 
-Vue.component('provide-function', {
+Vue.component("provide-function", {
   provide: () => ({
-    foo: 1
-  })
-})
+    foo: 1,
+  }),
+});
 
-Vue.component('component-with-slot', {
-  render (h): VNode {
-    return h('div', this.$slots.default)
-  }
-})
+Vue.component("component-with-slot", {
+  render(h): VNode {
+    return h("div", this.$slots.default);
+  },
+});
 
-Vue.component('component-with-scoped-slot', {
-  render (h) {
+Vue.component("component-with-scoped-slot", {
+  render(h) {
     interface ScopedSlotProps {
-      msg: string
+      msg: string;
     }
 
-    return h('div', [
-      h('child', [
+    return h("div", [
+      h("child", [
         // default scoped slot as children
-        (props: ScopedSlotProps) => [h('span', [props.msg])]
+        (props: ScopedSlotProps) => [h("span", [props.msg])],
       ]),
-      h('child', {
+      h("child", {
         scopedSlots: {
           // named scoped slot as vnode data
-          item: (props: ScopedSlotProps) => [h('span', [props.msg])]
-        }
+          item: (props: ScopedSlotProps) => [h("span", [props.msg])],
+        },
       }),
-      h('child', [
+      h("child", [
         // return single VNode (will be normalized to an array)
-        (props: ScopedSlotProps) => h('span', [props.msg])
+        (props: ScopedSlotProps) => h("span", [props.msg]),
       ]),
-      h('child', {
+      h("child", {
         // Passing down all slots from parent
-        scopedSlots: this.$scopedSlots
+        scopedSlots: this.$scopedSlots,
       }),
-      h('child', {
+      h("child", {
         // Passing down single slot from parent
         scopedSlots: {
-          default: this.$scopedSlots.default
-        }
-      })
-    ])
+          default: this.$scopedSlots.default,
+        },
+      }),
+    ]);
   },
   components: {
     child: {
-      render (this: Vue, h: CreateElement) {
-        const defaultSlot = this.$scopedSlots['default']!({ msg: 'hi' })
-        defaultSlot && defaultSlot.forEach(vnode => {
-          vnode.tag
-        })
-        return h('div', [
+      render(this: Vue, h: CreateElement) {
+        const defaultSlot = this.$scopedSlots["default"]!({ msg: "hi" });
+        defaultSlot &&
+          defaultSlot.forEach((vnode) => {
+            vnode.tag;
+          });
+        return h("div", [
           defaultSlot,
-          this.$scopedSlots['item']!({ msg: 'hello' })
-        ])
-      }
-    }
-  }
-})
+          this.$scopedSlots["item"]!({ msg: "hello" }),
+        ]);
+      },
+    },
+  },
+});
 
-Vue.component('narrow-array-of-vnode-type', {
-  render (h): VNode {
-    const slot = this.$scopedSlots.default!({})
-    if (typeof slot === 'string') {
+Vue.component("narrow-array-of-vnode-type", {
+  render(h): VNode {
+    const slot = this.$scopedSlots.default!({});
+    if (typeof slot === "string") {
       // <template slot-scope="data">bare string</template>
-      return h('span', slot)
+      return h("span", slot);
     } else if (Array.isArray(slot)) {
       // template with multiple children
-      const first = slot[0]
-      if (!Array.isArray(first) && typeof first !== 'string' && first) {
-        return first
+      const first = slot[0];
+      if (!Array.isArray(first) && typeof first !== "string" && first) {
+        return first;
       } else {
-        return h()
+        return h();
       }
     } else if (slot) {
       // <div slot-scope="data">bare VNode</div>
-      return slot
+      return slot;
     } else {
       // empty template, slot === undefined
-      return h()
+      return h();
     }
-  }
-})
+  },
+});
 
-Vue.component('functional-component', {
-  props: ['prop'],
+Vue.component("functional-component", {
+  props: ["prop"],
   functional: true,
-  inject: ['foo'],
+  inject: ["foo"],
   render(createElement, context) {
     context.props;
     context.children;
@@ -414,67 +419,68 @@ Vue.component('functional-component', {
     context.scopedSlots;
     context.listeners.click;
     return createElement("div", {}, context.children);
-  }
+  },
 });
 
-Vue.component('functional-component-object-inject', {
+Vue.component("functional-component-object-inject", {
   functional: true,
   inject: {
-    foo: 'foo',
+    foo: "foo",
     bar: Symbol(),
-    baz: { from: 'baz' },
+    baz: { from: "baz" },
     qux: { default: 1 },
-    quux: { from: 'quuz', default: () => ({ value: 1 })}
+    quux: { from: "quuz", default: () => ({ value: 1 }) },
   },
   render(h) {
-    return h('div')
-  }
-})
+    return h("div");
+  },
+});
 
-Vue.component('functional-component-check-optional', {
-  functional: true
-})
+Vue.component("functional-component-check-optional", {
+  functional: true,
+});
 
-Vue.component('functional-component-multi-root', {
+Vue.component("functional-component-multi-root", {
   functional: true,
   render(h) {
     return [
       h("tr", [h("td", "foo"), h("td", "bar")]),
-      h("tr", [h("td", "lorem"), h("td", "ipsum")])
-    ]
-  }
-})
+      h("tr", [h("td", "lorem"), h("td", "ipsum")]),
+    ];
+  },
+});
 
-Vue.component("async-component", ((resolve, reject) => {
+Vue.component("async-component", (resolve, reject) => {
   setTimeout(() => {
     resolve(Vue.component("component"));
   }, 0);
   return new Promise((resolve) => {
     resolve({
       functional: true,
-      render(h: CreateElement) { return h('div') }
+      render(h: CreateElement) {
+        return h("div");
+      },
     });
-  })
-}));
+  });
+});
 
-Vue.component('functional-component-v-model', {
-  props: ['foo'],
+Vue.component("functional-component-v-model", {
+  props: ["foo"],
   functional: true,
   model: {
-    prop: 'foo',
-    event: 'change'
+    prop: "foo",
+    event: "change",
   },
   render(createElement, context) {
     return createElement("input", {
       on: {
-        input: new Function()
+        input: new Function(),
       },
       domProps: {
-        value: context.props.foo
-      }
+        value: context.props.foo,
+      },
     });
-  }
+  },
 });
 
-
-Vue.component('async-es-module-component', () => import('./es-module'))
+Vue.component("async-es-module-component", () => import("./es-module"));

--- a/types/typeUtils.d.ts
+++ b/types/typeUtils.d.ts
@@ -1,0 +1,6 @@
+export type UnionToIntersection<U> = (
+    U extends any ? (k: U) => void : never
+  ) extends (k: infer I) => void
+    ? I
+    : never;
+  

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -1,7 +1,13 @@
 import { Vue } from "./vue";
 
 export type ScopedSlot = (props: any) => ScopedSlotReturnValue;
-type ScopedSlotReturnValue = VNode | string | boolean | null | undefined | ScopedSlotReturnArray;
+type ScopedSlotReturnValue =
+  | VNode
+  | string
+  | boolean
+  | null
+  | undefined
+  | ScopedSlotReturnArray;
 interface ScopedSlotReturnArray extends Array<ScopedSlotReturnValue> {}
 
 // Scoped slots are guaranteed to return Array of VNodes starting in 2.6
@@ -9,10 +15,33 @@ export type NormalizedScopedSlot = (props: any) => ScopedSlotChildren;
 export type ScopedSlotChildren = VNode[] | undefined;
 
 // Relaxed type compatible with $createElement
-export type VNodeChildren = VNodeChildrenArrayContents | [ScopedSlot] | string | boolean | null | undefined;
-export interface VNodeChildrenArrayContents extends Array<VNodeChildren | VNode> {}
+export type VNodeChildren =
+  | VNodeChildrenArrayContents
+  | [ScopedSlot]
+  | string
+  | boolean
+  | null
+  | undefined;
+export interface VNodeChildrenArrayContents
+  extends Array<VNodeChildren | VNode> {}
 
-export interface VNode {
+export type VNodeChild = VNodeChildAtom | VNodeChildrenArrayContents;
+
+type VNodeChildAtom =
+  | VNode
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | void;
+
+export interface RendererNode {
+  [key: string]: any;
+}
+export interface RendererElement extends RendererNode {}
+
+export interface VNode<HostNode = RendererNode, HostElement = RendererElement> {
   tag?: string;
   data?: VNodeData;
   children?: VNode[];

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -27,6 +27,10 @@ export interface VNodeChildrenArrayContents
 
 export type VNodeChild = VNodeChildAtom | VNodeChildrenArrayContents;
 
+export type VNodeProps = {
+  [key: string]: any;
+};
+
 type VNodeChildAtom =
   | VNode
   | string

--- a/types/vue.2.d.ts
+++ b/types/vue.2.d.ts
@@ -1,0 +1,232 @@
+import {
+  Component,
+  AsyncComponent,
+  ComponentOptions,
+  FunctionalComponentOptions,
+  WatchOptionsWithHandler,
+  WatchHandler,
+  DirectiveOptions,
+  DirectiveFunction,
+  RecordPropsDefinition,
+  ThisTypedComponentOptionsWithArrayProps,
+  ThisTypedComponentOptionsWithRecordProps,
+  WatchOptions,
+} from "./options";
+import { VNode, VNodeData, VNodeChildren, NormalizedScopedSlot } from "./vnode";
+import { PluginFunction, PluginObject } from "./plugin";
+import { h } from "./h";
+
+// export interface CreateElement {
+//   (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), children?: VNodeChildren): VNode;
+//   (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), data?: VNodeData, children?: VNodeChildren): VNode;
+// }
+
+type hType = typeof h;
+export interface CreateElement extends hType {}
+
+export interface Vue {
+  readonly $el: Element;
+  readonly $options: ComponentOptions<Vue>;
+  readonly $parent: Vue;
+  readonly $root: Vue;
+  readonly $children: Vue[];
+  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[] };
+  readonly $slots: { [key: string]: VNode[] | undefined };
+  readonly $scopedSlots: { [key: string]: NormalizedScopedSlot | undefined };
+  readonly $isServer: boolean;
+  readonly $data: Record<string, any>;
+  readonly $props: Record<string, any>;
+  readonly $ssrContext: any;
+  readonly $vnode: VNode;
+  readonly $attrs: Record<string, string>;
+  readonly $listeners: Record<string, Function | Function[]>;
+
+  $mount(elementOrSelector?: Element | string, hydrating?: boolean): this;
+  $forceUpdate(): void;
+  $destroy(): void;
+  $set: typeof Vue.set;
+  $delete: typeof Vue.delete;
+  $watch(
+    expOrFn: string,
+    callback: (this: this, n: any, o: any) => void,
+    options?: WatchOptions
+  ): () => void;
+  $watch<T>(
+    expOrFn: (this: this) => T,
+    callback: (this: this, n: T, o: T) => void,
+    options?: WatchOptions
+  ): () => void;
+  $on(event: string | string[], callback: Function): this;
+  $once(event: string | string[], callback: Function): this;
+  $off(event?: string | string[], callback?: Function): this;
+  $emit(event: string, ...args: any[]): this;
+  $nextTick(callback: (this: this) => void): void;
+  $nextTick(): Promise<void>;
+  $createElement: CreateElement;
+}
+
+export type CombinedVueInstance<
+  Instance extends Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = Data & Methods & Computed & Props & Instance;
+export type ExtendedVue<
+  Instance extends Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = VueConstructor<
+  CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue
+>;
+
+export interface VueConfiguration {
+  silent: boolean;
+  optionMergeStrategies: any;
+  devtools: boolean;
+  productionTip: boolean;
+  performance: boolean;
+  errorHandler(err: Error, vm: Vue, info: string): void;
+  warnHandler(msg: string, vm: Vue, trace: string): void;
+  ignoredElements: (string | RegExp)[];
+  keyCodes: { [key: string]: number | number[] };
+  async: boolean;
+}
+
+export interface VueConstructor<V extends Vue = Vue> {
+  new <
+    Data = object,
+    Methods = object,
+    Computed = object,
+    PropNames extends string = never
+  >(
+    options?: ThisTypedComponentOptionsWithArrayProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      PropNames
+    >
+  ): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>>;
+  // ideally, the return type should just contain Props, not Record<keyof Props, any>. But TS requires to have Base constructors with the same return type.
+  new <Data = object, Methods = object, Computed = object, Props = object>(
+    options?: ThisTypedComponentOptionsWithRecordProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Props
+    >
+  ): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>>;
+  new (options?: ComponentOptions<V>): CombinedVueInstance<
+    V,
+    object,
+    object,
+    object,
+    Record<keyof object, any>
+  >;
+
+  extend<Data, Methods, Computed, PropNames extends string = never>(
+    options?: ThisTypedComponentOptionsWithArrayProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      PropNames
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
+  extend<Data, Methods, Computed, Props>(
+    options?: ThisTypedComponentOptionsWithRecordProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Props
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Props>;
+  extend<PropNames extends string = never>(
+    definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
+  ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
+  extend<Props>(
+    definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
+  ): ExtendedVue<V, {}, {}, {}, Props>;
+  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+
+  nextTick<T>(callback: (this: T) => void, context?: T): void;
+  nextTick(): Promise<void>;
+  set<T>(object: object, key: string | number, value: T): T;
+  set<T>(array: T[], key: number, value: T): T;
+  delete(object: object, key: string | number): void;
+  delete<T>(array: T[], key: number): void;
+
+  directive(
+    id: string,
+    definition?: DirectiveOptions | DirectiveFunction
+  ): DirectiveOptions;
+  filter(id: string, definition?: Function): Function;
+
+  component(id: string): VueConstructor;
+  component<VC extends VueConstructor>(id: string, constructor: VC): VC;
+  component<Data, Methods, Computed, Props>(
+    id: string,
+    definition: AsyncComponent<Data, Methods, Computed, Props>
+  ): ExtendedVue<V, Data, Methods, Computed, Props>;
+  component<Data, Methods, Computed, PropNames extends string = never>(
+    id: string,
+    definition?: ThisTypedComponentOptionsWithArrayProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      PropNames
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
+  component<Data, Methods, Computed, Props>(
+    id: string,
+    definition?: ThisTypedComponentOptionsWithRecordProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Props
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Props>;
+  component<PropNames extends string>(
+    id: string,
+    definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
+  ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
+  component<Props>(
+    id: string,
+    definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
+  ): ExtendedVue<V, {}, {}, {}, Props>;
+  component(
+    id: string,
+    definition?: ComponentOptions<V>
+  ): ExtendedVue<V, {}, {}, {}, {}>;
+
+  use<T>(
+    plugin: PluginObject<T> | PluginFunction<T>,
+    options?: T
+  ): VueConstructor<V>;
+  use(
+    plugin: PluginObject<any> | PluginFunction<any>,
+    ...options: any[]
+  ): VueConstructor<V>;
+  mixin(mixin: VueConstructor | ComponentOptions<Vue>): VueConstructor<V>;
+  
+  compile(
+    template: string
+  ): {
+    render(createElement: typeof Vue.prototype.$createElement): VNode;
+    staticRenderFns: (() => VNode)[];
+  };
+
+  observable<T>(obj: T): T;
+
+  config: VueConfiguration;
+  version: string;
+}
+
+export const Vue: VueConstructor;

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -14,11 +14,15 @@ import {
 } from "./options";
 import { VNode, VNodeData, VNodeChildren, NormalizedScopedSlot } from "./vnode";
 import { PluginFunction, PluginObject } from "./plugin";
+import { h } from "./h";
 
-export interface CreateElement {
-  (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), children?: VNodeChildren): VNode;
-  (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), data?: VNodeData, children?: VNodeChildren): VNode;
-}
+// export interface CreateElement {
+//   (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), children?: VNodeChildren): VNode;
+//   (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), data?: VNodeData, children?: VNodeChildren): VNode;
+// }
+
+type hType = typeof h;
+export interface CreateElement extends hType {}
 
 export interface Vue {
   readonly $el: Element;
@@ -46,12 +50,12 @@ export interface Vue {
     expOrFn: string,
     callback: (this: this, n: any, o: any) => void,
     options?: WatchOptions
-  ): (() => void);
+  ): () => void;
   $watch<T>(
     expOrFn: (this: this) => T,
     callback: (this: this, n: T, o: T) => void,
     options?: WatchOptions
-  ): (() => void);
+  ): () => void;
   $on(event: string | string[], callback: Function): this;
   $once(event: string | string[], callback: Function): this;
   $off(event?: string | string[], callback?: Function): this;
@@ -61,8 +65,22 @@ export interface Vue {
   $createElement: CreateElement;
 }
 
-export type CombinedVueInstance<Instance extends Vue, Data, Methods, Computed, Props> =  Data & Methods & Computed & Props & Instance;
-export type ExtendedVue<Instance extends Vue, Data, Methods, Computed, Props> = VueConstructor<CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue>;
+export type CombinedVueInstance<
+  Instance extends Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = Data & Methods & Computed & Props & Instance;
+export type ExtendedVue<
+  Instance extends Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = VueConstructor<
+  CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue
+>;
 
 export interface VueConfiguration {
   silent: boolean;
@@ -78,19 +96,66 @@ export interface VueConfiguration {
 }
 
 export interface VueConstructor<V extends Vue = Vue> {
-  new <Data = object, Methods = object, Computed = object, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>>;
+  new <
+    Data = object,
+    Methods = object,
+    Computed = object,
+    PropNames extends string = never
+  >(
+    options?: ThisTypedComponentOptionsWithArrayProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      PropNames
+    >
+  ): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>>;
   // ideally, the return type should just contain Props, not Record<keyof Props, any>. But TS requires to have Base constructors with the same return type.
-  new <Data = object, Methods = object, Computed = object, Props = object>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>>;
-  new (options?: ComponentOptions<V>): CombinedVueInstance<V, object, object, object, Record<keyof object, any>>;
+  new <Data = object, Methods = object, Computed = object, Props = object>(
+    options?: ThisTypedComponentOptionsWithRecordProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Props
+    >
+  ): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>>;
+  new (options?: ComponentOptions<V>): CombinedVueInstance<
+    V,
+    object,
+    object,
+    object,
+    Record<keyof object, any>
+  >;
 
-  extend<Data, Methods, Computed, PropNames extends string = never>(options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
-  extend<Data, Methods, Computed, Props>(options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
-  extend<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
-  extend<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
+  extend<Data, Methods, Computed, PropNames extends string = never>(
+    options?: ThisTypedComponentOptionsWithArrayProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      PropNames
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
+  extend<Data, Methods, Computed, Props>(
+    options?: ThisTypedComponentOptionsWithRecordProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Props
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Props>;
+  extend<PropNames extends string = never>(
+    definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
+  ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
+  extend<Props>(
+    definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
+  ): ExtendedVue<V, {}, {}, {}, Props>;
   extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
 
   nextTick<T>(callback: (this: T) => void, context?: T): void;
-  nextTick(): Promise<void>
+  nextTick(): Promise<void>;
   set<T>(object: object, key: string | number, value: T): T;
   set<T>(array: T[], key: number, value: T): T;
   delete(object: object, key: string | number): void;
@@ -104,17 +169,55 @@ export interface VueConstructor<V extends Vue = Vue> {
 
   component(id: string): VueConstructor;
   component<VC extends VueConstructor>(id: string, constructor: VC): VC;
-  component<Data, Methods, Computed, Props>(id: string, definition: AsyncComponent<Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
-  component<Data, Methods, Computed, PropNames extends string = never>(id: string, definition?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
-  component<Data, Methods, Computed, Props>(id: string, definition?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): ExtendedVue<V, Data, Methods, Computed, Props>;
-  component<PropNames extends string>(id: string, definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
-  component<Props>(id: string, definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): ExtendedVue<V, {}, {}, {}, Props>;
-  component(id: string, definition?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+  component<Data, Methods, Computed, Props>(
+    id: string,
+    definition: AsyncComponent<Data, Methods, Computed, Props>
+  ): ExtendedVue<V, Data, Methods, Computed, Props>;
+  component<Data, Methods, Computed, PropNames extends string = never>(
+    id: string,
+    definition?: ThisTypedComponentOptionsWithArrayProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      PropNames
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
+  component<Data, Methods, Computed, Props>(
+    id: string,
+    definition?: ThisTypedComponentOptionsWithRecordProps<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Props
+    >
+  ): ExtendedVue<V, Data, Methods, Computed, Props>;
+  component<PropNames extends string>(
+    id: string,
+    definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
+  ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
+  component<Props>(
+    id: string,
+    definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
+  ): ExtendedVue<V, {}, {}, {}, Props>;
+  component(
+    id: string,
+    definition?: ComponentOptions<V>
+  ): ExtendedVue<V, {}, {}, {}, {}>;
 
-  use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): VueConstructor<V>;
-  use(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): VueConstructor<V>;
+  use<T>(
+    plugin: PluginObject<T> | PluginFunction<T>,
+    options?: T
+  ): VueConstructor<V>;
+  use(
+    plugin: PluginObject<any> | PluginFunction<any>,
+    ...options: any[]
+  ): VueConstructor<V>;
   mixin(mixin: VueConstructor | ComponentOptions<Vue>): VueConstructor<V>;
-  compile(template: string): {
+  compile(
+    template: string
+  ): {
     render(createElement: typeof Vue.prototype.$createElement): VNode;
     staticRenderFns: (() => VNode)[];
   };

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,28 +1,21 @@
 import {
-  Component,
-  AsyncComponent,
-  ComponentOptions,
-  FunctionalComponentOptions,
-  WatchOptionsWithHandler,
-  WatchHandler,
-  DirectiveOptions,
-  DirectiveFunction,
-  RecordPropsDefinition,
-  ThisTypedComponentOptionsWithArrayProps,
-  ThisTypedComponentOptionsWithRecordProps,
-  WatchOptions,
-} from "./options";
-import { VNode, VNodeData, VNodeChildren, NormalizedScopedSlot } from "./vnode";
-import { PluginFunction, PluginObject } from "./plugin";
-import { h } from "./h";
-
-// export interface CreateElement {
-//   (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), children?: VNodeChildren): VNode;
-//   (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any> | (() => Component), data?: VNodeData, children?: VNodeChildren): VNode;
-// }
-
-type hType = typeof h;
-export interface CreateElement extends hType {}
+  ComputedOptions,
+  MethodOptions,
+  ComponentOptionsWithoutProps,
+  ComponentOptionsWithArrayProps,
+  ComponentOptionsWithObjectProps,
+  ComponentOptionsMixin,
+  RenderFunction,
+} from "./componentOptions";
+import { FunctionalComponent, PublicAPIComponent } from "./component";
+import {
+  CreateComponentPublicInstance,
+  ComponentPublicInstanceConstructor,
+} from "./componentProxy";
+import { ExtractPropTypes, ComponentPropsOptions } from "./componentProps";
+import { EmitsOptions } from "./componentEmits";
+import { h, CreateElement } from "./h";
+import { Directive } from "./directives";
 
 export interface Vue {
   readonly $el: Element;
@@ -65,22 +58,22 @@ export interface Vue {
   $createElement: CreateElement;
 }
 
-export type CombinedVueInstance<
-  Instance extends Vue,
-  Data,
-  Methods,
-  Computed,
-  Props
-> = Data & Methods & Computed & Props & Instance;
-export type ExtendedVue<
-  Instance extends Vue,
-  Data,
-  Methods,
-  Computed,
-  Props
-> = VueConstructor<
-  CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue
->;
+// export type CombinedVueInstance<
+//   Instance extends Vue,
+//   Data,
+//   Methods,
+//   Computed,
+//   Props
+// > = Data & Methods & Computed & Props & Instance;
+// export type ExtendedVue<
+//   Instance extends Vue,
+//   Data,
+//   Methods,
+//   Computed,
+//   Props
+// > = VueConstructor<
+//   CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue
+// >;
 
 export interface VueConfiguration {
   silent: boolean;
@@ -95,137 +88,323 @@ export interface VueConfiguration {
   async: boolean;
 }
 
-export interface VueConstructor<V extends Vue = Vue> {
+//   export interface VueConstructor<V extends Vue = Vue> {
+//     new <
+//       Data = object,
+//       Methods = object,
+//       Computed = object,
+//       PropNames extends string = never
+//     >(
+//       options?: ThisTypedComponentOptionsWithArrayProps<
+//         V,
+//         Data,
+//         Methods,
+//         Computed,
+//         PropNames
+//       >
+//     ): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>>;
+//     // ideally, the return type should just contain Props, not Record<keyof Props, any>. But TS requires to have Base constructors with the same return type.
+//     new <Data = object, Methods = object, Computed = object, Props = object>(
+//       options?: ThisTypedComponentOptionsWithRecordProps<
+//         V,
+//         Data,
+//         Methods,
+//         Computed,
+//         Props
+//       >
+//     ): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>>;
+//     new (options?: ComponentOptions<V>): CombinedVueInstance<
+//       V,
+//       object,
+//       object,
+//       object,
+//       Record<keyof object, any>
+//     >;
+
+//     extend<Data, Methods, Computed, PropNames extends string = never>(
+//       options?: ThisTypedComponentOptionsWithArrayProps<
+//         V,
+//         Data,
+//         Methods,
+//         Computed,
+//         PropNames
+//       >
+//     ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
+//     extend<Data, Methods, Computed, Props>(
+//       options?: ThisTypedComponentOptionsWithRecordProps<
+//         V,
+//         Data,
+//         Methods,
+//         Computed,
+//         Props
+//       >
+//     ): ExtendedVue<V, Data, Methods, Computed, Props>;
+//     extend<PropNames extends string = never>(
+//       definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
+//     ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
+//     extend<Props>(
+//       definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
+//     ): ExtendedVue<V, {}, {}, {}, Props>;
+//     extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+
+//     nextTick<T>(callback: (this: T) => void, context?: T): void;
+//     nextTick(): Promise<void>;
+//     set<T>(object: object, key: string | number, value: T): T;
+//     set<T>(array: T[], key: number, value: T): T;
+//     delete(object: object, key: string | number): void;
+//     delete<T>(array: T[], key: number): void;
+
+//     directive(
+//       id: string,
+//       definition?: DirectiveOptions | DirectiveFunction
+//     ): DirectiveOptions;
+//     filter(id: string, definition?: Function): Function;
+
+//     component(id: string): VueConstructor;
+//     component<VC extends VueConstructor>(id: string, constructor: VC): VC;
+//     component<Data, Methods, Computed, Props>(
+//       id: string,
+//       definition: AsyncComponent<Data, Methods, Computed, Props>
+//     ): ExtendedVue<V, Data, Methods, Computed, Props>;
+//     component<Data, Methods, Computed, PropNames extends string = never>(
+//       id: string,
+//       definition?: ThisTypedComponentOptionsWithArrayProps<
+//         V,
+//         Data,
+//         Methods,
+//         Computed,
+//         PropNames
+//       >
+//     ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
+//     component<Data, Methods, Computed, Props>(
+//       id: string,
+//       definition?: ThisTypedComponentOptionsWithRecordProps<
+//         V,
+//         Data,
+//         Methods,
+//         Computed,
+//         Props
+//       >
+//     ): ExtendedVue<V, Data, Methods, Computed, Props>;
+//     component<PropNames extends string>(
+//       id: string,
+//       definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
+//     ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
+//     component<Props>(
+//       id: string,
+//       definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
+//     ): ExtendedVue<V, {}, {}, {}, Props>;
+//     component(
+//       id: string,
+//       definition?: ComponentOptions<V>
+//     ): ExtendedVue<V, {}, {}, {}, {}>;
+
+//     use<T>(
+//       plugin: PluginObject<T> | PluginFunction<T>,
+//       options?: T
+//     ): VueConstructor<V>;
+//     use(
+//       plugin: PluginObject<any> | PluginFunction<any>,
+//       ...options: any[]
+//     ): VueConstructor<V>;
+//     mixin(mixin: VueConstructor | ComponentOptions<Vue>): VueConstructor<V>;
+
+//     compile(
+//       template: string
+//     ): {
+//       render(createElement: typeof Vue.prototype.$createElement): VNode;
+//       staticRenderFns: (() => VNode)[];
+//     };
+
+//     observable<T>(obj: T): T;
+
+//     config: VueConfiguration;
+//     version: string;
+//   }
+
+type VNodeProps = Record<string, any>; // ??
+
+export interface VueConstructor {
+  // defineComponent is a utility that is primarily used for type inference
+  // when declaring components. Type inference is provided in the component
+  // options (provided as the argument). The returned value has artificial types
+  // for TSX / manual render function / IDE support.
+
+  // overload 2: object format with no props
+  // (uses user defined props interface)
+  // return type is for Vetur and TSX support
   new <
-    Data = object,
-    Methods = object,
-    Computed = object,
-    PropNames extends string = never
+    Props = {},
+    D = {},
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    E extends EmitsOptions = Record<string, any>,
+    EE extends string = string
   >(
-    options?: ThisTypedComponentOptionsWithArrayProps<
-      V,
-      Data,
-      Methods,
-      Computed,
-      PropNames
-    >
-  ): CombinedVueInstance<V, Data, Methods, Computed, Record<PropNames, any>>;
-  // ideally, the return type should just contain Props, not Record<keyof Props, any>. But TS requires to have Base constructors with the same return type.
-  new <Data = object, Methods = object, Computed = object, Props = object>(
-    options?: ThisTypedComponentOptionsWithRecordProps<
-      V,
-      Data,
-      Methods,
-      Computed,
-      Props
-    >
-  ): CombinedVueInstance<V, Data, Methods, Computed, Record<keyof Props, any>>;
-  new (options?: ComponentOptions<V>): CombinedVueInstance<
-    V,
-    object,
-    object,
-    object,
-    Record<keyof object, any>
+    options: ComponentOptionsWithoutProps<Props, D, C, M, Mixin, Extends, E, EE>
+  ): CreateComponentPublicInstance<
+    Props,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    VNodeProps & Props
   >;
 
-  extend<Data, Methods, Computed, PropNames extends string = never>(
-    options?: ThisTypedComponentOptionsWithArrayProps<
-      V,
-      Data,
-      Methods,
-      Computed,
-      PropNames
+  // overload 3: object format with array props declaration
+  // props inferred as { [key in PropNames]?: any }
+  // return type is for Vetur and TSX support
+  new <
+    PropNames extends string,
+    D,
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    E extends EmitsOptions = Record<string, any>,
+    EE extends string = string
+  >(
+    options: ComponentOptionsWithArrayProps<
+      PropNames,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      EE
     >
-  ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
-  extend<Data, Methods, Computed, Props>(
-    options?: ThisTypedComponentOptionsWithRecordProps<
-      V,
-      Data,
-      Methods,
-      Computed,
-      Props
+  ): // array props technically doesn't place any contraints on props in TSX before,
+  // but now we can export array props in TSX
+  CreateComponentPublicInstance<
+    Readonly<{ [key in PropNames]?: any }>,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E
+  >;
+
+  // overload 4: object format with object props declaration
+  // see `ExtractPropTypes` in ./componentProps.ts
+  new <
+    // the Readonly constraint allows TS to treat the type of { required: true }
+    // as constant instead of boolean.
+    PropsOptions extends Readonly<ComponentPropsOptions>,
+    D,
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    E extends EmitsOptions = Record<string, any>,
+    EE extends string = string
+  >(
+    options: ComponentOptionsWithObjectProps<
+      PropsOptions,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      EE
     >
-  ): ExtendedVue<V, Data, Methods, Computed, Props>;
-  extend<PropNames extends string = never>(
-    definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
-  ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
-  extend<Props>(
-    definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
-  ): ExtendedVue<V, {}, {}, {}, Props>;
-  extend(options?: ComponentOptions<V>): ExtendedVue<V, {}, {}, {}, {}>;
+  ): CreateComponentPublicInstance<
+    ExtractPropTypes<PropsOptions, false>,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    VNodeProps
+  >;
 
-  nextTick<T>(callback: (this: T) => void, context?: T): void;
-  nextTick(): Promise<void>;
-  set<T>(object: object, key: string | number, value: T): T;
-  set<T>(array: T[], key: number, value: T): T;
-  delete(object: object, key: string | number): void;
-  delete<T>(array: T[], key: number): void;
-
-  directive(
-    id: string,
-    definition?: DirectiveOptions | DirectiveFunction
-  ): DirectiveOptions;
-  filter(id: string, definition?: Function): Function;
-
-  component(id: string): VueConstructor;
-  component<VC extends VueConstructor>(id: string, constructor: VC): VC;
-  component<Data, Methods, Computed, Props>(
-    id: string,
-    definition: AsyncComponent<Data, Methods, Computed, Props>
-  ): ExtendedVue<V, Data, Methods, Computed, Props>;
-  component<Data, Methods, Computed, PropNames extends string = never>(
-    id: string,
-    definition?: ThisTypedComponentOptionsWithArrayProps<
-      V,
-      Data,
-      Methods,
-      Computed,
-      PropNames
+  component(name: string): PublicAPIComponent | undefined;
+  component<
+    Props = {},
+    D = {},
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    E extends EmitsOptions = Record<string, any>,
+    EE extends string = string
+  >(
+    name: string,
+    component: ComponentOptionsWithoutProps<
+      Props,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      EE
     >
-  ): ExtendedVue<V, Data, Methods, Computed, Record<PropNames, any>>;
-  component<Data, Methods, Computed, Props>(
-    id: string,
-    definition?: ThisTypedComponentOptionsWithRecordProps<
-      V,
-      Data,
-      Methods,
-      Computed,
-      Props
+  ): this;
+
+  // overload 3: object format with array props declaration
+  // props inferred as { [key in PropNames]?: any }
+  // return type is for Vetur and TSX support
+  component<
+    PropNames extends string,
+    D,
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    E extends EmitsOptions = Record<string, any>,
+    EE extends string = string
+  >(
+    name: string,
+    component: ComponentOptionsWithArrayProps<
+      PropNames,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      EE
     >
-  ): ExtendedVue<V, Data, Methods, Computed, Props>;
-  component<PropNames extends string>(
-    id: string,
-    definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>
-  ): ExtendedVue<V, {}, {}, {}, Record<PropNames, any>>;
-  component<Props>(
-    id: string,
-    definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>
-  ): ExtendedVue<V, {}, {}, {}, Props>;
-  component(
-    id: string,
-    definition?: ComponentOptions<V>
-  ): ExtendedVue<V, {}, {}, {}, {}>;
+  ): this;
 
-  use<T>(
-    plugin: PluginObject<T> | PluginFunction<T>,
-    options?: T
-  ): VueConstructor<V>;
-  use(
-    plugin: PluginObject<any> | PluginFunction<any>,
-    ...options: any[]
-  ): VueConstructor<V>;
-  mixin(mixin: VueConstructor | ComponentOptions<Vue>): VueConstructor<V>;
-  compile(
-    template: string
-  ): {
-    render(createElement: typeof Vue.prototype.$createElement): VNode;
-    staticRenderFns: (() => VNode)[];
-  };
-
-  observable<T>(obj: T): T;
-
-  config: VueConfiguration;
-  version: string;
+  // overload 4: object format with object props declaration
+  // see `ExtractPropTypes` in ./componentProps.ts
+  component<
+    // the Readonly constraint allows TS to treat the type of { required: true }
+    // as constant instead of boolean.
+    PropsOptions extends Readonly<ComponentPropsOptions>,
+    D,
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    E extends EmitsOptions = Record<string, any>,
+    EE extends string = string
+  >(
+    name: string,
+    component: ComponentOptionsWithObjectProps<
+      PropsOptions,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      E,
+      EE
+    >
+  ): this;
+  component(name: string, component: PublicAPIComponent): this;
+  
+  directive(name: string): Directive | undefined;
+  directive(name: string, directive: Directive): this;
 }
 
 export const Vue: VueConstructor;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** 

- [x] Feature
- [x] Other, please describe: Types

**Does this PR introduce a breaking change?** 

- [x] Maybe

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Bringing types from the `vue-next.

`vue-next` provides a better typescript support, some good types are the `emit` and `mixin/extend` 


> **NOTE:** : This is work in progress