### PR TITLE
chore(compiler): remove unused parameter of parseEndTag

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -283,7 +283,7 @@ export function parseHTML (html, options) {
           )
         }
         if (options.end) {
-          options.end(stack[i].tag, start, end)
+          options.end(start, end)
         }
       }
 
@@ -299,7 +299,7 @@ export function parseHTML (html, options) {
         options.start(tagName, [], false, start, end)
       }
       if (options.end) {
-        options.end(tagName, start, end)
+        options.end(start, end)
       }
     }
   }

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -297,7 +297,7 @@ export function parse (
       }
     },
 
-    end (tag, start, end) {
+    end (start, end) {
       const element = stack[stack.length - 1]
       // pop stack
       stack.length -= 1

--- a/src/sfc/parser.js
+++ b/src/sfc/parser.js
@@ -93,7 +93,7 @@ export function parseComponent (
     }
   }
 
-  function end (tag: string, start: number) {
+  function end (start: number) {
     if (depth === 1 && currentBlock) {
       currentBlock.end = start
       let text = content.slice(currentBlock.start, currentBlock.end)


### PR DESCRIPTION
The tageName parameter pass to option.end function  was never used since it was
added, remove it can save some bytes for production bundle and simplify
code logic.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
