### PR TITLE
fix: v-model avoid triggering extra input event in firefox

### DIFF
--- a/test/unit/features/directives/model-text.spec.js
+++ b/test/unit/features/directives/model-text.spec.js
@@ -337,7 +337,7 @@ describe('Directive v-model text', () => {
       expect(spy.calls.count()).toBe(1)
     })
 
-    it('triggers extra input on compositionstart + end', () => {
+    it('triggers extra input only on compositionupdate + input + end', () => {
       const spy = jasmine.createSpy()
       const vm = new Vue({
         data: {
@@ -355,8 +355,16 @@ describe('Directive v-model text', () => {
       triggerEvent(vm.$el, 'input')
       expect(spy.calls.count()).toBe(1)
       triggerEvent(vm.$el, 'compositionstart')
+      triggerEvent(vm.$el, 'compositionupdate')
+      triggerEvent(vm.$el, 'input')
       triggerEvent(vm.$el, 'compositionend')
-      expect(spy.calls.count()).toBe(2)
+      expect(spy.calls.count()).toBe(3)
+
+      triggerEvent(vm.$el, 'compositionstart')
+      triggerEvent(vm.$el, 'compositionupdate')
+      triggerEvent(vm.$el, 'compositionend')
+      triggerEvent(vm.$el, 'input')
+      expect(spy.calls.count()).toBe(4)
     })
 
     // #4392


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
