### PR TITLE
fix: check if a component instance is null on destroy

### DIFF
--- a/src/core/vdom/create-component.js
+++ b/src/core/vdom/create-component.js
@@ -86,7 +86,7 @@ const componentVNodeHooks = {
 
   destroy (vnode: MountedComponentVNode) {
     const { componentInstance } = vnode
-    if (!componentInstance._isDestroyed) {
+    if (componentInstance && !componentInstance._isDestroyed) {
       if (!vnode.data.keepAlive) {
         componentInstance.$destroy()
       } else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

My Vue.js project throws TypeError `Unable to get property '_isDestroyed' of undefined or null reference` on this line.
I couldn't write the code to reproduce it, but it seems vue destroying the null component somewhere.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
