### PR TITLE
fix(compiler): support decode &nbsp; in the value of prop and attribute (fix #8895)

### DIFF
--- a/src/compiler/parser/html-parser.js
+++ b/src/compiler/parser/html-parser.js
@@ -31,6 +31,7 @@ export const isPlainTextElement = makeMap('script,style,textarea', true)
 const reCache = {}
 
 const decodingMap = {
+  '&nbsp;': ' ',
   '&lt;': '<',
   '&gt;': '>',
   '&quot;': '"',
@@ -39,8 +40,8 @@ const decodingMap = {
   '&#9;': '\t',
   '&#39;': "'"
 }
-const encodedAttr = /&(?:lt|gt|quot|amp|#39);/g
-const encodedAttrWithNewLines = /&(?:lt|gt|quot|amp|#39|#10|#9);/g
+const encodedAttr = /&(?:lt|gt|quot|amp|#39|nbsp);/g
+const encodedAttrWithNewLines = /&(?:lt|gt|quot|amp|#39|nbsp|#10|#9);/g
 
 // #5992
 const isIgnoreNewlineTag = makeMap('pre,textarea', true)

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -881,4 +881,10 @@ describe('parser', () => {
     expect(ast.children[2].type).toBe(3)
     expect(ast.children[2].text).toBe('\ndef')
   })
+
+  it(`should decode &nbsp; in the value of attribute`, () => {
+    const options = extend({}, baseOptions)
+    const ast = parse('<input value="white&nbsp;space" />', options)
+    expect(ast.attrsList[0].value).toBe('white space')
+  })
 })


### PR DESCRIPTION
Fix #8895.

After this commit, the `&nbsp;` value of attribute and props will be decoded into `' '`, like the other HTML entities.

### Demo
Before Fix: 
- https://codepen.io/avertes/pen/LYYpNRe
- https://jsfiddle.net/50wL7mdz/756973/

After Fix: 
- attribute value: https://jsfiddle.net/juniortour/nv041crt/
- prop value: https://jsfiddle.net/juniortour/tcgv03fa/13/

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
