### PR TITLE
fix: iframe-window-name-update (fixes Issue #11569)

### DIFF
--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -109,7 +109,14 @@ function baseSetAttr (el, key, value) {
       // $flow-disable-line
       el.__ieph = true /* IE placeholder patched */
     }
-    el.setAttribute(key, value)
+    // When changing the attribute 'name' of an iframe element, the iframes window must be updated aswell. Otherwise
+    // anchor tags with a 'target' attribute won't hit the right iframe.
+    if (el.tagName === 'IFRAME' && key === 'name') {
+      setTimeout((el: HTMLIFrameElement) => {
+        el.contentWindow.name = value;
+      }, 0, el);
+    }
+    el.setAttribute(key, value);
   }
 }
 


### PR DESCRIPTION
fix: When changing the attribute 'name' of an iframe element, the iframes window must be updated aswell. Otherwise anchor tags with a 'target' attribute won't hit the right iframe.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This Issue actually wasn’t only present in safari. When iframes are created a window will be attached to the iframe which actually is the target. When updating the name attribute of an existing iframe the window inside the iframe doesn’t get updated.

In native javascript you could fix this with:
document.querySelector('iframe').documentWindow.name = 'theNewName';

The reproduction fiddle in the Issue #11569 only is bugged in safari, but if you try to change the attribute dynamically it doesn’t work in chrome or firefox either.

Check this fiddle for the cross-platform issue : https://jsfiddle.net/ug2jhmL6/1/
