### PR TITLE
Improve inBrowser sniffing

### DIFF
--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -4,7 +4,7 @@
 export const hasProto = '__proto__' in {}
 
 // Browser environment sniffing
-export const inBrowser = typeof window !== 'undefined' && window.hasOwnProperty('navigator')
+export const inBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined'
 export const inWeex = typeof WXEnvironment !== 'undefined' && !!WXEnvironment.platform
 export const weexPlatform = inWeex && WXEnvironment.platform.toLowerCase()
 export const UA = inBrowser && window.navigator.userAgent.toLowerCase()

--- a/src/core/util/env.js
+++ b/src/core/util/env.js
@@ -4,7 +4,7 @@
 export const hasProto = '__proto__' in {}
 
 // Browser environment sniffing
-export const inBrowser = typeof window !== 'undefined'
+export const inBrowser = typeof window !== 'undefined' && window.hasOwnProperty('navigator')
 export const inWeex = typeof WXEnvironment !== 'undefined' && !!WXEnvironment.platform
 export const weexPlatform = inWeex && WXEnvironment.platform.toLowerCase()
 export const UA = inBrowser && window.navigator.userAgent.toLowerCase()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

My project is a Webpack build helper CLI which attaches react dev tooling to the `window` global (although it is not consumed in the browser.) 

The presence of the `window` global causes vue builds to fail since the duck typing on `inBrowser` only checks for the presence of `window` and then assumes the presence of `document` related properties (like `navigator`).

https://github.com/vuejs/vue/blob/a9a303009a4267b7f12b956741b4e34dfdc6566f/src/core/util/env.js#L7

The specific error this results in is a type error here: 

https://github.com/vuejs/vue/blob/a9a303009a4267b7f12b956741b4e34dfdc6566f/src/core/util/env.js#L10. 

The slightly more stringent check introduced in this PR avoids this type error. While my particular use case is admittedly niche I think this change is still a general improvement for Vue.

Thanks! 