### PR TITLE
 fix(typescript): added index signature for dynamic directive definition

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -197,6 +197,7 @@ export interface DirectiveOptions {
   update?: DirectiveFunction;
   componentUpdated?: DirectiveFunction;
   unbind?: DirectiveFunction;
+  [index: string]: DirectiveFunction | undefined,
 }
 
 export type InjectKey = string | symbol;

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,4 +1,4 @@
-import Vue, { PropType, VNode } from "../index";
+import Vue, { DirectiveOptions, DirectiveFunction, PropType, VNode } from "../index";
 import { ComponentOptions, Component } from "../index";
 import { CreateElement } from "../vue";
 
@@ -478,3 +478,11 @@ Vue.component('functional-component-v-model', {
 
 
 Vue.component('async-es-module-component', () => import('./es-module'))
+
+const indexEntries: Array<string> = ["bind", "inserted"];
+const directiveOptions: DirectiveOptions = {};
+const directiveFunction: DirectiveFunction = () => {};
+for (let index in indexEntries){
+  directiveOptions[index] = directiveFunction;
+}
+Vue.directive("index-definition", directiveOptions)

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -1,5 +1,6 @@
-import Vue, { DirectiveOptions, DirectiveFunction, PropType, VNode } from "../index";
+import Vue, { PropType, VNode } from "../index";
 import { ComponentOptions, Component } from "../index";
+import { DirectiveOptions, DirectiveFunction } from "../index";
 import { CreateElement } from "../vue";
 
 interface MyComponent extends Vue {

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -483,7 +483,7 @@ Vue.component('async-es-module-component', () => import('./es-module'))
 const indexEntries: Array<string> = ["bind", "inserted"];
 const directiveOptions: DirectiveOptions = {};
 const directiveFunction: DirectiveFunction = () => {};
-for (let index in indexEntries){
+for (let index of indexEntries){
   directiveOptions[index] = directiveFunction;
 }
 Vue.directive("index-definition", directiveOptions)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When defining directives dynamically, the typescript compiler throws an error due to the missing index signature for string keys. Current local usage:

```
import Vue, { DirectiveFunction as VueDirectiveFunction, DirectiveOptions as VueDirectiveOptions } from 'vue';

interface DirectiveOptions extends VueDirectiveOptions {
    [index: string]: VueDirectiveFunction | undefined,
}

const indexEntries: Array<string> = ['bind', 'update'];
const directiveOptions: DirectiveOptions = {};
const directiveFunction: VueDirectiveFunction = () => {
    console.log('directive');
};
for (const index of indexEntries) {
    directiveOptions[index] = directiveFunction;
}

Vue.directive('img-circle', directiveOptions);
```

Usage after change:

```
import Vue, { DirectiveFunction, DirectiveOptions } from 'vue';

const indexEntries: Array<string> = ['bind', 'update'];
const directiveOptions: DirectiveOptions = {};
const directiveFunction: DirectiveFunction = () => {
    console.log('directive');
};
for (const index of indexEntries) {
    directiveOptions[index] = directiveFunction;
}

Vue.directive('img-circle', directiveOptions);
```
