### PR TITLE
feat(ssr): add context to shouldPrefetch and shouldPreload

### DIFF
--- a/packages/vue-server-renderer/types/index.d.ts
+++ b/packages/vue-server-renderer/types/index.d.ts
@@ -28,8 +28,8 @@ interface BundleRenderer {
 interface RendererOptions {
   template?: string;
   inject?: boolean;
-  shouldPreload?: (file: string, type: string) => boolean;
-  shouldPrefetch?: (file: string, type: string) => boolean;
+  shouldPreload?: (file: string, type: string, context: object) => boolean;
+  shouldPrefetch?: (file: string, type: string, context: object) => boolean;
   cache?: RenderCache;
   directives?: {
     [key: string]: (vnode: VNode, dir: VNodeDirective) => void

--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -14,8 +14,8 @@ type TemplateRendererOptions = {
   template?: string | (content: string, context: any) => string;
   inject?: boolean;
   clientManifest?: ClientManifest;
-  shouldPreload?: (file: string, type: string) => boolean;
-  shouldPrefetch?: (file: string, type: string) => boolean;
+  shouldPreload?: (file: string, type: string, context: any) => boolean;
+  shouldPrefetch?: (file: string, type: string, context: any) => boolean;
   serializer?: Function;
 };
 
@@ -165,7 +165,7 @@ export default class TemplateRenderer {
           return ''
         }
         // user wants to explicitly control what to preload
-        if (shouldPreload && !shouldPreload(fileWithoutQuery, asType)) {
+        if (shouldPreload && !shouldPreload(fileWithoutQuery, asType, context)) {
           return ''
         }
         if (asType === 'font') {
@@ -192,7 +192,7 @@ export default class TemplateRenderer {
         return usedAsyncFiles && usedAsyncFiles.some(f => f.file === file)
       }
       return this.prefetchFiles.map(({ file, fileWithoutQuery, asType }) => {
-        if (shouldPrefetch && !shouldPrefetch(fileWithoutQuery, asType)) {
+        if (shouldPrefetch && !shouldPrefetch(fileWithoutQuery, asType, context)) {
           return ''
         }
         if (alreadyRendered(file)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Right now `shouldPrefetch` and `shouldPreload` are triggered on each request and we don't have enough information to decide what should be filtered. For example when we create dynamic import 
```
import(/* webpackChunkName: "somelib-locales-[lang]" */ `somelib/locale/${lang}`)
```
then we will get all files prefetched/preloaded. It would be great to filter those files that are not matching current lang in `shouldPrefetch/shouldPreload`. So I think adding `context` would give us information that is needed. 
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
