### PR TITLE
Ignore .DS_Store files in the bundle

### DIFF
--- a/src/.npmignore
+++ b/src/.npmignore
@@ -1,0 +1,2 @@
+.npmignore
+.DS_Store


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

Bundle includes `.DS_Store` files https://unpkg.com/browse/vue@2.6.12/src/ 
 These files are macOS artifacts and clearly not intended to be included in the release modules.

The problem stems from how npm handles bare directories.  The `files` entry in package.json merely says `"src"`.  The npm client includes all files in the src directory, including those in `.gitignore`.  The proposed fix tells NPM not to include `.DS_Store` files.

Fixes #10112 