### PR TITLE
fix(vue.d.ts): add mixin type definition (fix #11759)

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -113,7 +113,13 @@ export interface VueConstructor<V extends Vue = Vue> {
 
   use<T>(plugin: PluginObject<T> | PluginFunction<T>, options?: T): VueConstructor<V>;
   use(plugin: PluginObject<any> | PluginFunction<any>, ...options: any[]): VueConstructor<V>;
+
+  mixin<Data, Methods, Computed, PropNames extends string = never>(mixin?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames>): VueConstructor<V>;
+  mixin<Data, Methods, Computed, Props>(mixin?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props>): VueConstructor<V>;
+  mixin<PropNames extends string = never>(definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]>): VueConstructor<V>;
+  mixin<Props>(definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>>): VueConstructor<V>;
   mixin(mixin: VueConstructor | ComponentOptions<Vue>): VueConstructor<V>;
+
   compile(template: string): {
     render(createElement: typeof Vue.prototype.$createElement): VNode;
     staticRenderFns: (() => VNode)[];


### PR DESCRIPTION
This allows to define `data` mixin properties without writing a specific definition file.

fix #11759

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR is only a **proposal**...  
It solved my original problem: #11759  

**BUT...**
I'm not so sure about all the code that could be involved with these changes...  
I think I'll need some help from someone from the core development team.