### PR TITLE
types: Change Element types to HTMLElement

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -21,12 +21,12 @@ export interface CreateElement {
 }
 
 export interface Vue {
-  readonly $el: Element;
+  readonly $el: HTMLElement;
   readonly $options: ComponentOptions<Vue>;
   readonly $parent: Vue;
   readonly $root: Vue;
   readonly $children: Vue[];
-  readonly $refs: { [key: string]: Vue | Element | Vue[] | Element[] };
+  readonly $refs: { [key: string]: Vue | HTMLElement | Vue[] | HTMLElement[] };
   readonly $slots: { [key: string]: VNode[] | undefined };
   readonly $scopedSlots: { [key: string]: NormalizedScopedSlot | undefined };
   readonly $isServer: boolean;
@@ -37,7 +37,7 @@ export interface Vue {
   readonly $attrs: Record<string, string>;
   readonly $listeners: Record<string, Function | Function[]>;
 
-  $mount(elementOrSelector?: Element | string, hydrating?: boolean): this;
+  $mount(elementOrSelector?: HTMLElement | string, hydrating?: boolean): this;
   $forceUpdate(): void;
   $destroy(): void;
   $set: typeof Vue.set;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: typings update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No, `HTMLElement` extends `Element`

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**(Hopefully) convincing reason:**
There are a lot of properties missing in the plain `Element` interface that are perfectly available when referencing these properties (in my case it was `offsetHeight`).
_As far as I know_ there is no reason why these values can't be typed as the more elaborate `HTMLElement`, but I'm by no means a Vue-expert.

Since this change is trivial I opted to directly create a PR instead of waiting for a response on an issue.