### PR TITLE
feat(ssr): add csp nonce to all elements

### DIFF
--- a/packages/server-renderer/src/template-renderer/index.ts
+++ b/packages/server-renderer/src/template-renderer/index.ts
@@ -150,7 +150,9 @@ export default class TemplateRenderer {
         ? cssFiles
             .map(
               ({ file }) =>
-                `<link rel="stylesheet" href="${this.publicPath}${file}">`
+                `<link rel="stylesheet" href="${
+                  this.publicPath
+                }${file}"${getNonceAttribute(context)}>`
             )
             .join('')
         : '') +
@@ -193,7 +195,7 @@ export default class TemplateRenderer {
           }
           return `<link rel="preload" href="${this.publicPath}${file}"${
             asType !== '' ? ` as="${asType}"` : ''
-          }${extra}>`
+          }${extra}${getNonceAttribute(context)}>`
         })
         .join('')
     } else {
@@ -216,7 +218,9 @@ export default class TemplateRenderer {
           if (alreadyRendered(file)) {
             return ''
           }
-          return `<link rel="prefetch" href="${this.publicPath}${file}">`
+          return `<link rel="prefetch" href="${
+            this.publicPath
+          }${file}"${getNonceAttribute(context)}>`
         })
         .join('')
     } else {
@@ -234,9 +238,10 @@ export default class TemplateRenderer {
     const autoRemove = __DEV__
       ? ''
       : ';(function(){var s;(s=document.currentScript||document.scripts[document.scripts.length-1]).parentNode.removeChild(s);}());'
-    const nonceAttr = context.nonce ? ` nonce="${context.nonce}"` : ''
     return context[contextKey]
-      ? `<script${nonceAttr}>window.${windowKey}=${state}${autoRemove}</script>`
+      ? `<script${getNonceAttribute(
+          context
+        )}>window.${windowKey}=${state}${autoRemove}</script>`
       : ''
   }
 
@@ -249,7 +254,9 @@ export default class TemplateRenderer {
       const needed = [initial[0]].concat(async, initial.slice(1))
       return needed
         .map(({ file }) => {
-          return `<script src="${this.publicPath}${file}" defer></script>`
+          return `<script src="${
+            this.publicPath
+          }${file}" defer${getNonceAttribute(context)}></script>`
         })
         .join('')
     } else {
@@ -303,4 +310,8 @@ function getPreloadType(ext: string): string {
     // not exhausting all possibilities here, but above covers common cases
     return ''
   }
+}
+
+function getNonceAttribute(context: Record<string, any>): string {
+  return context.nonce ? ` nonce="${context.nonce}"` : ''
 }


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

[CSPv3](https://csp.withgoogle.com/docs/strict-csp.html)  allows simple nonce based policies and directives such as `stict-dynamic`. Declaring a policy such as:

```
Content-Security-Policy:
  object-src 'none';
  script-src 'nonce-{random}' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;
  base-uri 'none';
  report-uri https://your-report-collector.example.com/
```

Would not work with current nonce support with features such as resource hints. This policy creates errors such as 

```
Refused to load the script 'http://localhost:8082/manifest.js' because it violates the following Content Security Policy directive: "script-src 'self' 'nonce-68f9bed4d31fcde221e7b5e871860ff2' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' http:". 'strict-dynamic' is present, so host-based allowlisting is disabled. Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.
```

This is because not all rendered elements have an associated nonce. 

To support stricter policies that only work scripts / resource hinting add `nonce` attribute to all element that could be affected via a nonce based policy. 
