### PR TITLE
fix(ssr): prevent rendering duplicate css references

### DIFF
--- a/src/server/template-renderer/index.js
+++ b/src/server/template-renderer/index.js
@@ -129,7 +129,7 @@ export default class TemplateRenderer {
   renderStyles (context: Object): string {
     const initial = this.preloadFiles || []
     const async = this.getUsedAsyncFiles(context) || []
-    const cssFiles = initial.concat(async).filter(({ file }) => isCSS(file))
+    const cssFiles = Array.from(new Set(initial.concat(async))).filter(({ file }) => isCSS(file))
     return (
       // render links for css files
       (cssFiles.length


### PR DESCRIPTION
There is a chance that the same css file is included in initial and async array, causing a <link>
element pointing to the same stylesheet to be included multiple times. This fix ensures that cannot
happen. Since multiple build systems exist, this defensive approach avoids any issues with how files
are generated regardless of which one is being used by a given project.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
