### PR TITLE
fix(types): async Component types

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -12,14 +12,10 @@ export type Component<Data=DefaultData<never>, Methods=DefaultMethods<never>, Co
   | FunctionalComponentOptions<Props>
   | ComponentOptions<never, Data, Methods, Computed, Props>
 
-interface EsModuleComponent<
-  Data = DefaultData<never>,
-  Methods = DefaultMethods<never>,
-  Computed = DefaultComputed,
-  Props = DefaultProps
-> {
-  default: Component<Data, Methods, Computed, Props>;
-}
+type EsModule<T> = T | { default: T }
+
+type ImportedComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps>
+  = EsModule<Component<Data, Methods, Computed, Props>>
 
 export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps>
   = AsyncComponentPromise<Data, Methods, Computed, Props>
@@ -28,18 +24,12 @@ export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never
 export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = (
   resolve: (component: Component<Data, Methods, Computed, Props>) => void,
   reject: (reason?: any) => void
-) => Promise<
-  | Component<Data, Methods, Computed, Props>
-  | EsModuleComponent<Data, Methods, Computed, Props>
-> | void;
+) => Promise<ImportedComponent<Data, Methods, Computed, Props>> | void;
 
 export type AsyncComponentFactory<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = () => {
-  component: Promise<
-    | Component<Data, Methods, Computed, Props>
-    | EsModuleComponent<Data, Methods, Computed, Props>
-  >;
-  loading?: Component | EsModuleComponent;
-  error?: Component | EsModuleComponent;
+  component: Promise<ImportedComponent<Data, Methods, Computed, Props>>;
+  loading?: ImportedComponent;
+  error?: ImportedComponent;
   delay?: number;
   timeout?: number;
 }

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -25,7 +25,7 @@ export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never
   = AsyncComponentPromise<Data, Methods, Computed, Props>
   | AsyncComponentFactory<Data, Methods, Computed, Props>
 
-export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> = (
+export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = (
   resolve: (component: Component<Data, Methods, Computed, Props>) => void,
   reject: (reason?: any) => void
 ) => Promise<
@@ -47,7 +47,7 @@ export type AsyncComponentFactory<
   error?: Component | EsModuleComponent;
   delay?: number;
   timeout?: number;
-};
+}
 
 /**
  * When the `Computed` type parameter on `ComponentOptions` is inferred,

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,26 +1,16 @@
 import { Vue, CreateElement, CombinedVueInstance } from "./vue";
-import {
-  VNode,
-  VNodeData,
-  VNodeDirective,
-  NormalizedScopedSlot,
-} from "./vnode";
+import { VNode, VNodeData, VNodeDirective, NormalizedScopedSlot } from "./vnode";
 
 type Constructor = {
   new (...args: any[]): any;
-};
+}
 
 // we don't support infer props in async component
 // N.B. ComponentOptions<V> is contravariant, the default generic should be bottom type
-export type Component<
-  Data = DefaultData<never>,
-  Methods = DefaultMethods<never>,
-  Computed = DefaultComputed,
-  Props = DefaultProps
-> =
+export type Component<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> =
   | typeof Vue
   | FunctionalComponentOptions<Props>
-  | ComponentOptions<never, Data, Methods, Computed, Props>;
+  | ComponentOptions<never, Data, Methods, Computed, Props>
 
 interface EsModuleComponent<
   Data = DefaultData<never>,
@@ -31,21 +21,11 @@ interface EsModuleComponent<
   default: Component<Data, Methods, Computed, Props>;
 }
 
-export type AsyncComponent<
-  Data = DefaultData<never>,
-  Methods = DefaultMethods<never>,
-  Computed = DefaultComputed,
-  Props = DefaultProps
-> =
+export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> =
   | AsyncComponentPromise<Data, Methods, Computed, Props>
-  | AsyncComponentFactory<Data, Methods, Computed, Props>;
+  | AsyncComponentFactory<Data, Methods, Computed, Props>
 
-export type AsyncComponentPromise<
-  Data = DefaultData<never>,
-  Methods = DefaultMethods<never>,
-  Computed = DefaultComputed,
-  Props = DefaultProps
-> = (
+export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> = (
   resolve: (component: Component<Data, Methods, Computed, Props>) => void,
   reject: (reason?: any) => void
 ) => Promise<
@@ -76,70 +56,37 @@ export type AsyncComponentFactory<
  * to infer from the shape of `Accessors<Computed>` and work backwards.
  */
 export type Accessors<T> = {
-  [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>;
-};
+  [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>
+}
 
-type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data);
+type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data)
 /**
  * This type should be used when an array of strings is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithArrayProps<
-  V extends Vue,
-  Data,
-  Methods,
-  Computed,
-  PropNames extends string
-> = object &
-  ComponentOptions<
-    V,
-    DataDef<Data, Record<PropNames, any>, V>,
-    Methods,
-    Computed,
-    PropNames[],
-    Record<PropNames, any>
-  > &
-  ThisType<
-    CombinedVueInstance<
-      V,
-      Data,
-      Methods,
-      Computed,
-      Readonly<Record<PropNames, any>>
-    >
-  >;
+export type ThisTypedComponentOptionsWithArrayProps<V extends Vue, Data, Methods, Computed, PropNames extends string> =
+  object &
+  ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>> &
+  ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Record<PropNames, any>>>>;
 
 /**
  * This type should be used when an object mapped to `PropOptions` is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithRecordProps<
-  V extends Vue,
-  Data,
-  Methods,
-  Computed,
-  Props
-> = object &
-  ComponentOptions<
-    V,
-    DataDef<Data, Props, V>,
-    Methods,
-    Computed,
-    RecordPropsDefinition<Props>,
-    Props
-  > &
+export type ThisTypedComponentOptionsWithRecordProps<V extends Vue, Data, Methods, Computed, Props> =
+  object &
+  ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
   ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Props>>>;
 
-type DefaultData<V> = object | ((this: V) => object);
+type DefaultData<V> =  object | ((this: V) => object);
 type DefaultProps = Record<string, any>;
-type DefaultMethods<V> = { [key: string]: (this: V, ...args: any[]) => any };
+type DefaultMethods<V> =  { [key: string]: (this: V, ...args: any[]) => any };
 type DefaultComputed = { [key: string]: any };
 export interface ComponentOptions<
   V extends Vue,
-  Data = DefaultData<V>,
-  Methods = DefaultMethods<V>,
-  Computed = DefaultComputed,
-  PropsDef = PropsDefinition<DefaultProps>,
-  Props = DefaultProps
-> {
+  Data=DefaultData<V>,
+  Methods=DefaultMethods<V>,
+  Computed=DefaultComputed,
+  PropsDef=PropsDefinition<DefaultProps>,
+  Props=DefaultProps> {
   data?: Data;
   props?: PropsDef;
   propsData?: object;
@@ -168,11 +115,7 @@ export interface ComponentOptions<
   serverPrefetch?(this: V): Promise<void>;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };
-  components?: {
-    [key: string]:
-      | Component<any, any, any, any>
-      | AsyncComponent<any, any, any, any>;
-  };
+  components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> };
   transitions?: { [key: string]: object };
   filters?: { [key: string]: Function };
 
@@ -194,10 +137,7 @@ export interface ComponentOptions<
   inheritAttrs?: boolean;
 }
 
-export interface FunctionalComponentOptions<
-  Props = DefaultProps,
-  PropDefs = PropsDefinition<Props>
-> {
+export interface FunctionalComponentOptions<Props = DefaultProps, PropDefs = PropsDefinition<Props>> {
   name?: string;
   props?: PropDefs;
   model?: {
@@ -206,14 +146,10 @@ export interface FunctionalComponentOptions<
   };
   inject?: InjectOptions;
   functional: boolean;
-  render?(
-    this: undefined,
-    createElement: CreateElement,
-    context: RenderContext<Props>
-  ): VNode | VNode[];
+  render?(this: undefined, createElement: CreateElement, context: RenderContext<Props>): VNode | VNode[];
 }
 
-export interface RenderContext<Props = DefaultProps> {
+export interface RenderContext<Props=DefaultProps> {
   props: Props;
   children: VNode[];
   slots(): any;
@@ -221,19 +157,16 @@ export interface RenderContext<Props = DefaultProps> {
   parent: Vue;
   listeners: { [key: string]: Function | Function[] };
   scopedSlots: { [key: string]: NormalizedScopedSlot };
-  injections: any;
+  injections: any
 }
 
-export type Prop<T> =
-  | { (): T }
-  | { new (...args: never[]): T & object }
-  | { new (...args: string[]): Function };
+export type Prop<T> = { (): T } | { new(...args: never[]): T & object } | { new(...args: string[]): Function }
 
 export type PropType<T> = Prop<T> | Prop<T>[];
 
 export type PropValidator<T> = PropOptions<T> | PropType<T>;
 
-export interface PropOptions<T = any> {
+export interface PropOptions<T=any> {
   type?: PropType<T>;
   required?: boolean;
   default?: T | null | undefined | (() => T | null | undefined);
@@ -241,12 +174,10 @@ export interface PropOptions<T = any> {
 }
 
 export type RecordPropsDefinition<T> = {
-  [K in keyof T]: PropValidator<T[K]>;
-};
+  [K in keyof T]: PropValidator<T[K]>
+}
 export type ArrayPropsDefinition<T> = (keyof T)[];
-export type PropsDefinition<T> =
-  | ArrayPropsDefinition<T>
-  | RecordPropsDefinition<T>;
+export type PropsDefinition<T> = ArrayPropsDefinition<T> | RecordPropsDefinition<T>;
 
 export interface ComputedOptions<T> {
   get?(): T;
@@ -286,8 +217,6 @@ export interface DirectiveOptions {
 
 export type InjectKey = string | symbol;
 
-export type InjectOptions =
-  | {
-      [key: string]: InjectKey | { from?: InjectKey; default?: any };
-    }
-  | string[];
+export type InjectOptions = {
+  [key: string]: InjectKey | { from?: InjectKey, default?: any }
+} | string[];

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -33,12 +33,7 @@ export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethod
   | EsModuleComponent<Data, Methods, Computed, Props>
 > | void;
 
-export type AsyncComponentFactory<
-  Data = DefaultData<never>,
-  Methods = DefaultMethods<never>,
-  Computed = DefaultComputed,
-  Props = DefaultProps
-> = () => {
+export type AsyncComponentFactory<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = () => {
   component: Promise<
     | Component<Data, Methods, Computed, Props>
     | EsModuleComponent<Data, Methods, Computed, Props>

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -25,13 +25,18 @@ export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethod
   reject: (reason?: any) => void
 ) => Promise<Component | EsModuleComponent> | void;
 
-export type AsyncComponentFactory<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = () => {
-  component: AsyncComponentPromise<Data, Methods, Computed, Props>;
+export type AsyncComponentFactory<
+  Data = DefaultData<never>,
+  Methods = DefaultMethods<never>,
+  Computed = DefaultComputed,
+  Props = DefaultProps
+> = () => {
+  component: Promise<Component | EsModuleComponent>;
   loading?: Component | EsModuleComponent;
   error?: Component | EsModuleComponent;
   delay?: number;
   timeout?: number;
-}
+};
 
 /**
  * When the `Computed` type parameter on `ComponentOptions` is inferred,

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -7,7 +7,7 @@ type Constructor = {
 
 // we don't support infer props in async component
 // N.B. ComponentOptions<V> is contravariant, the default generic should be bottom type
-export type Component<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> =
+export type Component<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> =
   | typeof Vue
   | FunctionalComponentOptions<Props>
   | ComponentOptions<never, Data, Methods, Computed, Props>
@@ -21,8 +21,8 @@ interface EsModuleComponent<
   default: Component<Data, Methods, Computed, Props>;
 }
 
-export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> =
-  | AsyncComponentPromise<Data, Methods, Computed, Props>
+export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps>
+  = AsyncComponentPromise<Data, Methods, Computed, Props>
   | AsyncComponentFactory<Data, Methods, Computed, Props>
 
 export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props = DefaultProps> = (

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,29 +1,57 @@
 import { Vue, CreateElement, CombinedVueInstance } from "./vue";
-import { VNode, VNodeData, VNodeDirective, NormalizedScopedSlot } from "./vnode";
+import {
+  VNode,
+  VNodeData,
+  VNodeDirective,
+  NormalizedScopedSlot,
+} from "./vnode";
 
 type Constructor = {
   new (...args: any[]): any;
-}
+};
 
 // we don't support infer props in async component
 // N.B. ComponentOptions<V> is contravariant, the default generic should be bottom type
-export type Component<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> =
+export type Component<
+  Data = DefaultData<never>,
+  Methods = DefaultMethods<never>,
+  Computed = DefaultComputed,
+  Props = DefaultProps
+> =
   | typeof Vue
   | FunctionalComponentOptions<Props>
-  | ComponentOptions<never, Data, Methods, Computed, Props>
+  | ComponentOptions<never, Data, Methods, Computed, Props>;
 
-interface EsModuleComponent {
-  default: Component
+interface EsModuleComponent<
+  Data = DefaultData<never>,
+  Methods = DefaultMethods<never>,
+  Computed = DefaultComputed,
+  Props = DefaultProps
+> {
+  default: Component<Data, Methods, Computed, Props>;
 }
 
-export type AsyncComponent<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps>
-  = AsyncComponentPromise<Data, Methods, Computed, Props>
-  | AsyncComponentFactory<Data, Methods, Computed, Props>
+export type AsyncComponent<
+  Data = DefaultData<never>,
+  Methods = DefaultMethods<never>,
+  Computed = DefaultComputed,
+  Props = DefaultProps
+> =
+  | AsyncComponentPromise<Data, Methods, Computed, Props>
+  | AsyncComponentFactory<Data, Methods, Computed, Props>;
 
-export type AsyncComponentPromise<Data=DefaultData<never>, Methods=DefaultMethods<never>, Computed=DefaultComputed, Props=DefaultProps> = (
+export type AsyncComponentPromise<
+  Data = DefaultData<never>,
+  Methods = DefaultMethods<never>,
+  Computed = DefaultComputed,
+  Props = DefaultProps
+> = (
   resolve: (component: Component<Data, Methods, Computed, Props>) => void,
   reject: (reason?: any) => void
-) => Promise<Component | EsModuleComponent> | void;
+) => Promise<
+  | Component<Data, Methods, Computed, Props>
+  | EsModuleComponent<Data, Methods, Computed, Props>
+> | void;
 
 export type AsyncComponentFactory<
   Data = DefaultData<never>,
@@ -31,7 +59,10 @@ export type AsyncComponentFactory<
   Computed = DefaultComputed,
   Props = DefaultProps
 > = () => {
-  component: Promise<Component | EsModuleComponent>;
+  component: Promise<
+    | Component<Data, Methods, Computed, Props>
+    | EsModuleComponent<Data, Methods, Computed, Props>
+  >;
   loading?: Component | EsModuleComponent;
   error?: Component | EsModuleComponent;
   delay?: number;
@@ -45,37 +76,70 @@ export type AsyncComponentFactory<
  * to infer from the shape of `Accessors<Computed>` and work backwards.
  */
 export type Accessors<T> = {
-  [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>
-}
+  [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>;
+};
 
-type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data)
+type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data);
 /**
  * This type should be used when an array of strings is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithArrayProps<V extends Vue, Data, Methods, Computed, PropNames extends string> =
-  object &
-  ComponentOptions<V, DataDef<Data, Record<PropNames, any>, V>, Methods, Computed, PropNames[], Record<PropNames, any>> &
-  ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Record<PropNames, any>>>>;
+export type ThisTypedComponentOptionsWithArrayProps<
+  V extends Vue,
+  Data,
+  Methods,
+  Computed,
+  PropNames extends string
+> = object &
+  ComponentOptions<
+    V,
+    DataDef<Data, Record<PropNames, any>, V>,
+    Methods,
+    Computed,
+    PropNames[],
+    Record<PropNames, any>
+  > &
+  ThisType<
+    CombinedVueInstance<
+      V,
+      Data,
+      Methods,
+      Computed,
+      Readonly<Record<PropNames, any>>
+    >
+  >;
 
 /**
  * This type should be used when an object mapped to `PropOptions` is used for a component's `props` value.
  */
-export type ThisTypedComponentOptionsWithRecordProps<V extends Vue, Data, Methods, Computed, Props> =
-  object &
-  ComponentOptions<V, DataDef<Data, Props, V>, Methods, Computed, RecordPropsDefinition<Props>, Props> &
+export type ThisTypedComponentOptionsWithRecordProps<
+  V extends Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = object &
+  ComponentOptions<
+    V,
+    DataDef<Data, Props, V>,
+    Methods,
+    Computed,
+    RecordPropsDefinition<Props>,
+    Props
+  > &
   ThisType<CombinedVueInstance<V, Data, Methods, Computed, Readonly<Props>>>;
 
-type DefaultData<V> =  object | ((this: V) => object);
+type DefaultData<V> = object | ((this: V) => object);
 type DefaultProps = Record<string, any>;
-type DefaultMethods<V> =  { [key: string]: (this: V, ...args: any[]) => any };
+type DefaultMethods<V> = { [key: string]: (this: V, ...args: any[]) => any };
 type DefaultComputed = { [key: string]: any };
 export interface ComponentOptions<
   V extends Vue,
-  Data=DefaultData<V>,
-  Methods=DefaultMethods<V>,
-  Computed=DefaultComputed,
-  PropsDef=PropsDefinition<DefaultProps>,
-  Props=DefaultProps> {
+  Data = DefaultData<V>,
+  Methods = DefaultMethods<V>,
+  Computed = DefaultComputed,
+  PropsDef = PropsDefinition<DefaultProps>,
+  Props = DefaultProps
+> {
   data?: Data;
   props?: PropsDef;
   propsData?: object;
@@ -104,7 +168,11 @@ export interface ComponentOptions<
   serverPrefetch?(this: V): Promise<void>;
 
   directives?: { [key: string]: DirectiveFunction | DirectiveOptions };
-  components?: { [key: string]: Component<any, any, any, any> | AsyncComponent<any, any, any, any> };
+  components?: {
+    [key: string]:
+      | Component<any, any, any, any>
+      | AsyncComponent<any, any, any, any>;
+  };
   transitions?: { [key: string]: object };
   filters?: { [key: string]: Function };
 
@@ -126,7 +194,10 @@ export interface ComponentOptions<
   inheritAttrs?: boolean;
 }
 
-export interface FunctionalComponentOptions<Props = DefaultProps, PropDefs = PropsDefinition<Props>> {
+export interface FunctionalComponentOptions<
+  Props = DefaultProps,
+  PropDefs = PropsDefinition<Props>
+> {
   name?: string;
   props?: PropDefs;
   model?: {
@@ -135,10 +206,14 @@ export interface FunctionalComponentOptions<Props = DefaultProps, PropDefs = Pro
   };
   inject?: InjectOptions;
   functional: boolean;
-  render?(this: undefined, createElement: CreateElement, context: RenderContext<Props>): VNode | VNode[];
+  render?(
+    this: undefined,
+    createElement: CreateElement,
+    context: RenderContext<Props>
+  ): VNode | VNode[];
 }
 
-export interface RenderContext<Props=DefaultProps> {
+export interface RenderContext<Props = DefaultProps> {
   props: Props;
   children: VNode[];
   slots(): any;
@@ -146,16 +221,19 @@ export interface RenderContext<Props=DefaultProps> {
   parent: Vue;
   listeners: { [key: string]: Function | Function[] };
   scopedSlots: { [key: string]: NormalizedScopedSlot };
-  injections: any
+  injections: any;
 }
 
-export type Prop<T> = { (): T } | { new(...args: never[]): T & object } | { new(...args: string[]): Function }
+export type Prop<T> =
+  | { (): T }
+  | { new (...args: never[]): T & object }
+  | { new (...args: string[]): Function };
 
 export type PropType<T> = Prop<T> | Prop<T>[];
 
 export type PropValidator<T> = PropOptions<T> | PropType<T>;
 
-export interface PropOptions<T=any> {
+export interface PropOptions<T = any> {
   type?: PropType<T>;
   required?: boolean;
   default?: T | null | undefined | (() => T | null | undefined);
@@ -163,10 +241,12 @@ export interface PropOptions<T=any> {
 }
 
 export type RecordPropsDefinition<T> = {
-  [K in keyof T]: PropValidator<T[K]>
-}
+  [K in keyof T]: PropValidator<T[K]>;
+};
 export type ArrayPropsDefinition<T> = (keyof T)[];
-export type PropsDefinition<T> = ArrayPropsDefinition<T> | RecordPropsDefinition<T>;
+export type PropsDefinition<T> =
+  | ArrayPropsDefinition<T>
+  | RecordPropsDefinition<T>;
 
 export interface ComputedOptions<T> {
   get?(): T;
@@ -206,6 +286,8 @@ export interface DirectiveOptions {
 
 export type InjectKey = string | symbol;
 
-export type InjectOptions = {
-  [key: string]: InjectKey | { from?: InjectKey, default?: any }
-} | string[];
+export type InjectOptions =
+  | {
+      [key: string]: InjectKey | { from?: InjectKey; default?: any };
+    }
+  | string[];

--- a/types/test/async-component-test.ts
+++ b/types/test/async-component-test.ts
@@ -2,51 +2,51 @@ import Vue, { AsyncComponent, Component } from "../index";
 
 const a: AsyncComponent = () => ({
   component: new Promise<Component>((res, rej) => {
-    res({ template: "" });
-  }),
-});
+    res({ template: "" })
+  })
+})
 
 const b: AsyncComponent = () => ({
   // @ts-expect-error component has to be a Promise that resolves to a component
   component: () =>
     new Promise<Component>((res, rej) => {
-      res({ template: "" });
-    }),
-});
+      res({ template: "" })
+    })
+})
 
 const c: AsyncComponent = () =>
   new Promise<Component>((res, rej) => {
     res({
-      template: "",
-    });
-  });
+      template: ""
+    })
+  })
 
 const d: AsyncComponent = () =>
   new Promise<{ default: Component }>((res, rej) => {
     res({
       default: {
-        template: "",
-      },
-    });
-  });
+        template: ""
+      }
+    })
+  })
 
 const e: AsyncComponent = () => ({
   component: new Promise<{ default: Component }>((res, rej) => {
     res({
       default: {
-        template: "",
-      },
-    });
-  }),
-});
+        template: ""
+      }
+    })
+  })
+})
 
 Vue.component("async-compponent1", () => ({
   component: new Promise<Component>((res, rej) => {
     res({
-      template: "",
-    });
-  }),
-}));
+      template: ""
+    })
+  })
+}))
 
 Vue.component(
   "async-compponent2",
@@ -54,8 +54,8 @@ Vue.component(
     new Promise<{ default: Component }>((res, rej) => {
       res({
         default: {
-          template: "",
-        },
-      });
+          template: ""
+        }
+      })
     })
-);
+)

--- a/types/test/async-component-test.ts
+++ b/types/test/async-component-test.ts
@@ -40,22 +40,5 @@ const e: AsyncComponent = () => ({
   })
 })
 
-Vue.component("async-compponent1", () => ({
-  component: new Promise<Component>((res, rej) => {
-    res({
-      template: ""
-    })
-  })
-}))
-
-Vue.component(
-  "async-compponent2",
-  () =>
-    new Promise<{ default: Component }>((res, rej) => {
-      res({
-        default: {
-          template: ""
-        }
-      })
-    })
-)
+// Test that Vue.component accepts any AsyncComponent
+Vue.component("async-compponent1", a)

--- a/types/test/async-component-test.ts
+++ b/types/test/async-component-test.ts
@@ -1,0 +1,61 @@
+import Vue, { AsyncComponent, Component } from "../index";
+
+const a: AsyncComponent = () => ({
+  component: new Promise<Component>((res, rej) => {
+    res({ template: "" });
+  }),
+});
+
+const b: AsyncComponent = () => ({
+  // @ts-expect-error component has to be a Promise that resolves to a component
+  component: () =>
+    new Promise<Component>((res, rej) => {
+      res({ template: "" });
+    }),
+});
+
+const c: AsyncComponent = () =>
+  new Promise<Component>((res, rej) => {
+    res({
+      template: "",
+    });
+  });
+
+const d: AsyncComponent = () =>
+  new Promise<{ default: Component }>((res, rej) => {
+    res({
+      default: {
+        template: "",
+      },
+    });
+  });
+
+const e: AsyncComponent = () => ({
+  component: new Promise<{ default: Component }>((res, rej) => {
+    res({
+      default: {
+        template: "",
+      },
+    });
+  }),
+});
+
+Vue.component("async-compponent1", () => ({
+  component: new Promise<Component>((res, rej) => {
+    res({
+      template: "",
+    });
+  }),
+}));
+
+Vue.component(
+  "async-compponent2",
+  () =>
+    new Promise<{ default: Component }>((res, rej) => {
+      res({
+        default: {
+          template: "",
+        },
+      });
+    })
+);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No
- [x] Not sure if this is considered a breaking change 

If yes, please describe the impact and migration path for existing applications:


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
Look at this codeexample:
```ts
import { AsyncComponent, Component } from 'vue'
const a: AsyncComponent = () => ({
  component: new Promise<Component>((res, rej) => {
    res({})
  }),
})

const b: AsyncComponent = () => ({
  component: () =>
    new Promise<Component>((res, rej) => {
      res({})
    }),
})
```

The first example is like in the docs https://vuejs.org/v2/guide/components-dynamic-async.html#Handling-Loading-State and the second example should not work (I also looked at the implementation and I think this would not work).

The types are currently like such that the first example throws a type Error and the second throws no error. This PR fixes that.
