### PR TITLE
fix(model): keep -0 to '-0'

### DIFF
--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { isDef, isUndef, extend, toNumber, isNumNegZero } from 'shared/util'
+import { isDef, isUndef, extend, toNumber } from 'shared/util'
 import { isSVG } from 'web/util/index'
 
 let svgContainer
@@ -44,7 +44,7 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
       // non-string values will be stringified
       elm._value = cur
       // avoid resetting cursor position when value is the same
-      const strCur = isNumNegZero(cur) ? '-0' : isUndef(cur) ? '' : String(cur)
+      const strCur = isUndef(cur) ? '' : String(cur)
       if (shouldUpdateValue(elm, strCur)) {
         elm.value = strCur
       }

--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { isDef, isUndef, extend, toNumber } from 'shared/util'
+import { isDef, isUndef, extend, toNumber, isNumNegZero } from 'shared/util'
 import { isSVG } from 'web/util/index'
 
 let svgContainer
@@ -44,7 +44,7 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
       // non-string values will be stringified
       elm._value = cur
       // avoid resetting cursor position when value is the same
-      const strCur = isUndef(cur) ? '' : String(cur)
+      const strCur = isNumNegZero(cur) ? '-0' : (isUndef(cur) ? '' : String(cur))
       if (shouldUpdateValue(elm, strCur)) {
         elm.value = strCur
       }

--- a/src/platforms/web/runtime/modules/dom-props.js
+++ b/src/platforms/web/runtime/modules/dom-props.js
@@ -44,7 +44,7 @@ function updateDOMProps (oldVnode: VNodeWithData, vnode: VNodeWithData) {
       // non-string values will be stringified
       elm._value = cur
       // avoid resetting cursor position when value is the same
-      const strCur = isNumNegZero(cur) ? '-0' : (isUndef(cur) ? '' : String(cur))
+      const strCur = isNumNegZero(cur) ? '-0' : isUndef(cur) ? '' : String(cur)
       if (shouldUpdateValue(elm, strCur)) {
         elm.value = strCur
       }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -8,10 +8,6 @@ export function isUndef (v: any): boolean %checks {
   return v === undefined || v === null
 }
 
-export function isNumNegZero (v: any): boolean %checks {
-  return 1/v === -Infinity
-}
-
 export function isDef (v: any): boolean %checks {
   return v !== undefined && v !== null
 }
@@ -100,7 +96,7 @@ export function toString (val: any): string {
  * If the conversion fails, return original string.
  */
 export function toNumber (val: string): number | string {
-  const n = isNumNegZero(val) ? '-0' : parseFloat(val)
+  const n = 1 / val === -Infinity ? '-0' : parseFloat(val)
   return isNaN(n) ? val : n
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -96,7 +96,7 @@ export function toString (val: any): string {
  * If the conversion fails, return original string.
  */
 export function toNumber (val: string): number | string {
-  const n = 1 / val === -Infinity ? '-0' : parseFloat(val)
+  const n = 1 / Number(val) === -Infinity ? '-0' : parseFloat(val)
   return isNaN(n) ? val : n
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -8,6 +8,10 @@ export function isUndef (v: any): boolean %checks {
   return v === undefined || v === null
 }
 
+export function isNumNegZero (v: any): boolean %checks {
+  return !isNaN(v) && Object.is(Number(v), -0)
+}
+
 export function isDef (v: any): boolean %checks {
   return v !== undefined && v !== null
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -96,6 +96,7 @@ export function toString (val: any): string {
 
 /**
  * Convert an input value to a number for persistence.
+ * Check for special case of signed zero.
  * If the conversion fails, return original string.
  */
 export function toNumber (val: string): number | string {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -9,7 +9,7 @@ export function isUndef (v: any): boolean %checks {
 }
 
 export function isNumNegZero (v: any): boolean %checks {
-  return !isNaN(v) && Object.is(Number(v), -0)
+  return !isNaN(v) && 1/Number(v) === -Infinity
 }
 
 export function isDef (v: any): boolean %checks {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -9,7 +9,7 @@ export function isUndef (v: any): boolean %checks {
 }
 
 export function isNumNegZero (v: any): boolean %checks {
-  return !isNaN(v) && 1/Number(v) === -Infinity
+  return 1/v === -Infinity
 }
 
 export function isDef (v: any): boolean %checks {

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -99,7 +99,7 @@ export function toString (val: any): string {
  * If the conversion fails, return original string.
  */
 export function toNumber (val: string): number | string {
-  const n = parseFloat(val)
+  const n = isNumNegZero(val) ? -0 : parseFloat(val)
   return isNaN(n) ? val : n
 }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -99,7 +99,7 @@ export function toString (val: any): string {
  * If the conversion fails, return original string.
  */
 export function toNumber (val: string): number | string {
-  const n = isNumNegZero(val) ? -0 : parseFloat(val)
+  const n = isNumNegZero(val) ? '-0' : parseFloat(val)
   return isNaN(n) ? val : n
 }
 


### PR DESCRIPTION
fix #11909

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In javascript, Number `-0` is legitimate value, this can be verified by checking `Number(-0) === -0`. However, before set a number value to input tag, Vue uses `String(value)` to convert the value to string but `String(-0)` will result in `0` rather than `-0`. 