### PR TITLE
fix: pause dep collection during immediate watcher invocation

### DIFF
--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -355,11 +355,13 @@ export function stateMixin (Vue: Class<Component>) {
     options.user = true
     const watcher = new Watcher(vm, expOrFn, cb, options)
     if (options.immediate) {
+      pushTarget()
       try {
         cb.call(vm, watcher.value)
       } catch (error) {
         handleError(error, vm, `callback for immediate watcher "${watcher.expression}"`)
       }
+      popTarget()
     }
     return function unwatchFn () {
       watcher.teardown()

--- a/test/unit/features/instance/methods-lifecycle.spec.js
+++ b/test/unit/features/instance/methods-lifecycle.spec.js
@@ -81,7 +81,7 @@ describe('Instance methods lifecycle', () => {
       expect(calls).toBe(1)
       childData.a++
       waitForUpdate(() => {
-        expect(parentUpdate.calls.count()).toBe(0)
+        expect(parentUpdate).not.toHaveBeenCalled()
       }).then(done)
     })
   })

--- a/test/unit/features/instance/methods-lifecycle.spec.js
+++ b/test/unit/features/instance/methods-lifecycle.spec.js
@@ -53,6 +53,31 @@ describe('Instance methods lifecycle', () => {
         }
       }).$mount()
     })
+
+    it('Dep.target should be undefined during invocation of child immediate watcher', () => {
+      let calls = 0;
+      new Vue({
+        template: '<div><my-component></my-component></div>',
+        components: {
+          myComponent: {
+            template: '<div>hi</div>',
+            data() {
+              return { a: 123 }
+            },
+            watch: {
+              a: {
+                handler() {
+                  ++calls
+                  expect(Dep.target).toBe(undefined)
+                },
+                immediate: true
+              }
+            }
+          }
+        }
+      }).$mount()
+      expect(calls).toBe(1)
+    })
   })
 
   describe('$destroy', () => {

--- a/test/unit/features/instance/methods-lifecycle.spec.js
+++ b/test/unit/features/instance/methods-lifecycle.spec.js
@@ -54,15 +54,17 @@ describe('Instance methods lifecycle', () => {
       }).$mount()
     })
 
-    it('Dep.target should be undefined during invocation of child immediate watcher', () => {
-      let calls = 0;
+    it('Dep.target should be undefined during invocation of child immediate watcher', done => {
+      let calls = 0, childData
+      const parentUpdate = jasmine.createSpy()
       new Vue({
         template: '<div><my-component></my-component></div>',
+        updated: parentUpdate,
         components: {
           myComponent: {
-            template: '<div>hi</div>',
+            template: '<div>{{ a }}</div>',
             data() {
-              return { a: 123 }
+              return childData = { a: 123 }
             },
             watch: {
               a: {
@@ -77,6 +79,10 @@ describe('Instance methods lifecycle', () => {
         }
       }).$mount()
       expect(calls).toBe(1)
+      childData.a++
+      waitForUpdate(() => {
+        expect(parentUpdate.calls.count()).toBe(0)
+      }).then(done)
     })
   })
 

--- a/test/unit/features/instance/methods-lifecycle.spec.js
+++ b/test/unit/features/instance/methods-lifecycle.spec.js
@@ -71,7 +71,7 @@ describe('Instance methods lifecycle', () => {
               anything: {
                 handler() {
                   ++calls
-                  expect(Dep.target).toBe(undefined)
+                  this.a
                 },
                 immediate: true
               }

--- a/test/unit/features/instance/methods-lifecycle.spec.js
+++ b/test/unit/features/instance/methods-lifecycle.spec.js
@@ -55,7 +55,8 @@ describe('Instance methods lifecycle', () => {
     })
 
     it('Dep.target should be undefined during invocation of child immediate watcher', done => {
-      let calls = 0, childData
+      let calls = 0
+      const childData = { a: 1 }
       const parentUpdate = jasmine.createSpy()
       new Vue({
         template: '<div><my-component></my-component></div>',
@@ -64,10 +65,10 @@ describe('Instance methods lifecycle', () => {
           myComponent: {
             template: '<div>{{ a }}</div>',
             data() {
-              return childData = { a: 123 }
+              return childData
             },
             watch: {
-              a: {
+              anything: {
                 handler() {
                   ++calls
                   expect(Dep.target).toBe(undefined)


### PR DESCRIPTION
Close #11942
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: **Performance improvement**

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
