### PR TITLE
Make an original event context accessible as [$el] in events

### DIFF
--- a/src/compiler/codegen/events.js
+++ b/src/compiler/codegen/events.js
@@ -3,7 +3,7 @@
 const fnExpRE = /^([\w$_]+|\([^)]*?\))\s*=>|^function(?:\s+[\w$]+)?\s*\(/
 const fnInvokeRE = /\([^)]*?\);*$/
 const simplePathRE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\['[^']*?']|\["[^"]*?"]|\[\d+]|\[[A-Za-z_$][\w$]*])*$/
-const baseEvArgs = '$event, $el'
+const baseEvArgs = '$event,$el'
 
 // KeyboardEvent.keyCode aliases
 const keyCodes: { [key: string]: number | Array<number> } = {

--- a/src/compiler/codegen/events.js
+++ b/src/compiler/codegen/events.js
@@ -3,6 +3,7 @@
 const fnExpRE = /^([\w$_]+|\([^)]*?\))\s*=>|^function(?:\s+[\w$]+)?\s*\(/
 const fnInvokeRE = /\([^)]*?\);*$/
 const simplePathRE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\['[^']*?']|\["[^"]*?"]|\[\d+]|\[[A-Za-z_$][\w$]*])*$/
+const baseEvArgs = '$event, $el'
 
 // KeyboardEvent.keyCode aliases
 const keyCodes: { [key: string]: number | Array<number> } = {
@@ -114,7 +115,7 @@ function genHandler (handler: ASTElementHandler | Array<ASTElementHandler>): str
     if (__WEEX__ && handler.params) {
       return genWeexHandler(handler.params, handler.value)
     }
-    return `function($event){${
+    return `function(${baseEvArgs}){${
       isFunctionInvocation ? `return ${handler.value}` : handler.value
     }}` // inline statement
   } else {
@@ -158,7 +159,7 @@ function genHandler (handler: ASTElementHandler | Array<ASTElementHandler>): str
     if (__WEEX__ && handler.params) {
       return genWeexHandler(handler.params, code + handlerCode)
     }
-    return `function($event){${code}${handlerCode}}`
+    return `function(${baseEvArgs}){${code}${handlerCode}}`
   }
 }
 

--- a/src/platforms/web/runtime/modules/events.js
+++ b/src/platforms/web/runtime/modules/events.js
@@ -76,7 +76,7 @@ function add (
         // starting reference
         e.target.ownerDocument !== document
       ) {
-        return original.apply(this, arguments)
+        return original.apply(this, [...arguments, this])
       }
     }
   }

--- a/test/unit/modules/compiler/codegen.spec.js
+++ b/test/unit/modules/compiler/codegen.spec.js
@@ -4,6 +4,7 @@ import { generate } from 'compiler/codegen'
 import { isObject, extend } from 'shared/util'
 import { isReservedTag } from 'web/util/index'
 import { baseOptions } from 'web/compiler/options'
+const baseEvArgs = '$event,$el'
 
 function assertCodegen (template, generatedCode, ...args) {
   let staticRenderFnCodes = []
@@ -154,14 +155,14 @@ describe('codegen', () => {
   it('generate v-model directive', () => {
     assertCodegen(
       '<input v-model="test">',
-      `with(this){return _c('input',{directives:[{name:"model",rawName:"v-model",value:(test),expression:"test"}],domProps:{"value":(test)},on:{"input":function($event){if($event.target.composing)return;test=$event.target.value}}})}`
+      `with(this){return _c('input',{directives:[{name:"model",rawName:"v-model",value:(test),expression:"test"}],domProps:{"value":(test)},on:{"input":function(${baseEvArgs}){if($event.target.composing)return;test=$event.target.value}}})}`
     )
   })
 
   it('generate multiline v-model directive', () => {
     assertCodegen(
       '<input v-model="\n test \n">',
-      `with(this){return _c('input',{directives:[{name:"model",rawName:"v-model",value:(\n test \n),expression:"\\n test \\n"}],domProps:{"value":(\n test \n)},on:{"input":function($event){if($event.target.composing)return;\n test \n=$event.target.value}}})}`
+      `with(this){return _c('input',{directives:[{name:"model",rawName:"v-model",value:(\n test \n),expression:"\\n test \\n"}],domProps:{"value":(\n test \n)},on:{"input":function(${baseEvArgs}){if($event.target.composing)return;\n test \n=$event.target.value}}})}`
     )
   })
 
@@ -318,37 +319,37 @@ describe('codegen', () => {
   it('generate events with method call', () => {
     assertCodegen(
       '<input @input="onInput($event);">',
-      `with(this){return _c('input',{on:{"input":function($event){return onInput($event);}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){return onInput($event);}}})}`
     )
     // empty arguments
     assertCodegen(
       '<input @input="onInput();">',
-      `with(this){return _c('input',{on:{"input":function($event){return onInput();}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){return onInput();}}})}`
     )
     // without semicolon
     assertCodegen(
       '<input @input="onInput($event)">',
-      `with(this){return _c('input',{on:{"input":function($event){return onInput($event)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){return onInput($event)}}})}`
     )
     // multiple args
     assertCodegen(
       '<input @input="onInput($event, \'abc\', 5);">',
-      `with(this){return _c('input',{on:{"input":function($event){return onInput($event, 'abc', 5);}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){return onInput($event, 'abc', 5);}}})}`
     )
     // expression in args
     assertCodegen(
       '<input @input="onInput($event, 2+2);">',
-      `with(this){return _c('input',{on:{"input":function($event){return onInput($event, 2+2);}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){return onInput($event, 2+2);}}})}`
     )
     // tricky symbols in args
     assertCodegen(
       `<input @input="onInput(');[\\'());');">`,
-      `with(this){return _c('input',{on:{"input":function($event){onInput(');[\\'());');}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){onInput(');[\\'());');}}})}`
     )
     // function name including a `function` part (#9920)
     assertCodegen(
       '<input @input="functionName()">',
-      `with(this){return _c('input',{on:{"input":function($event){return functionName()}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){return functionName()}}})}`
     )
   })
 
@@ -356,64 +357,64 @@ describe('codegen', () => {
     // normal function
     assertCodegen(
       '<input @input="onInput1();onInput2()">',
-      `with(this){return _c('input',{on:{"input":function($event){onInput1();onInput2()}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){onInput1();onInput2()}}})}`
     )
     // function with multiple args
     assertCodegen(
       '<input @input="onInput1($event, \'text\');onInput2(\'text2\', $event)">',
-      `with(this){return _c('input',{on:{"input":function($event){onInput1($event, 'text');onInput2('text2', $event)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){onInput1($event, 'text');onInput2('text2', $event)}}})}`
     )
   })
 
   it('generate events with keycode', () => {
     assertCodegen(
       '<input @input.enter="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;return onInput.apply(null, arguments)}}})}`
     )
     // multiple keycodes (delete)
     assertCodegen(
       '<input @input.delete="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"delete",[8,46],$event.key,["Backspace","Delete","Del"]))return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"delete",[8,46],$event.key,["Backspace","Delete","Del"]))return null;return onInput.apply(null, arguments)}}})}`
     )
     // multiple keycodes (esc)
     assertCodegen(
       '<input @input.esc="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"esc",27,$event.key,["Esc","Escape"]))return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"esc",27,$event.key,["Esc","Escape"]))return null;return onInput.apply(null, arguments)}}})}`
     )
     // multiple keycodes (space)
     assertCodegen(
       '<input @input.space="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"space",32,$event.key,[" ","Spacebar"]))return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"space",32,$event.key,[" ","Spacebar"]))return null;return onInput.apply(null, arguments)}}})}`
     )
     // multiple keycodes (chained)
     assertCodegen(
       '<input @keydown.enter.delete="onInput">',
-      `with(this){return _c('input',{on:{"keydown":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter")&&_k($event.keyCode,"delete",[8,46],$event.key,["Backspace","Delete","Del"]))return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"keydown":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter")&&_k($event.keyCode,"delete",[8,46],$event.key,["Backspace","Delete","Del"]))return null;return onInput.apply(null, arguments)}}})}`
     )
     // number keycode
     assertCodegen(
       '<input @input.13="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if(!$event.type.indexOf('key')&&$event.keyCode!==13)return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&$event.keyCode!==13)return null;return onInput.apply(null, arguments)}}})}`
     )
     // custom keycode
     assertCodegen(
       '<input @input.custom="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"custom",undefined,$event.key,undefined))return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"custom",undefined,$event.key,undefined))return null;return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with generic modifiers', () => {
     assertCodegen(
       '<input @input.stop="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){$event.stopPropagation();return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){$event.stopPropagation();return onInput.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @input.prevent="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){$event.preventDefault();return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){$event.preventDefault();return onInput.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @input.self="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){if($event.target !== $event.currentTarget)return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){if($event.target !== $event.currentTarget)return null;return onInput.apply(null, arguments)}}})}`
     )
   })
 
@@ -421,81 +422,81 @@ describe('codegen', () => {
   it('generate events with generic modifiers and keycode correct order', () => {
     assertCodegen(
       '<input @keydown.enter.prevent="onInput">',
-      `with(this){return _c('input',{on:{"keydown":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;$event.preventDefault();return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"keydown":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;$event.preventDefault();return onInput.apply(null, arguments)}}})}`
     )
 
     assertCodegen(
       '<input @keydown.enter.stop="onInput">',
-      `with(this){return _c('input',{on:{"keydown":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;$event.stopPropagation();return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"keydown":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;$event.stopPropagation();return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with mouse event modifiers', () => {
     assertCodegen(
       '<input @click.ctrl="onClick">',
-      `with(this){return _c('input',{on:{"click":function($event){if(!$event.ctrlKey)return null;return onClick.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"click":function(${baseEvArgs}){if(!$event.ctrlKey)return null;return onClick.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @click.shift="onClick">',
-      `with(this){return _c('input',{on:{"click":function($event){if(!$event.shiftKey)return null;return onClick.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"click":function(${baseEvArgs}){if(!$event.shiftKey)return null;return onClick.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @click.alt="onClick">',
-      `with(this){return _c('input',{on:{"click":function($event){if(!$event.altKey)return null;return onClick.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"click":function(${baseEvArgs}){if(!$event.altKey)return null;return onClick.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @click.meta="onClick">',
-      `with(this){return _c('input',{on:{"click":function($event){if(!$event.metaKey)return null;return onClick.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"click":function(${baseEvArgs}){if(!$event.metaKey)return null;return onClick.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @click.exact="onClick">',
-      `with(this){return _c('input',{on:{"click":function($event){if($event.ctrlKey||$event.shiftKey||$event.altKey||$event.metaKey)return null;return onClick.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"click":function(${baseEvArgs}){if($event.ctrlKey||$event.shiftKey||$event.altKey||$event.metaKey)return null;return onClick.apply(null, arguments)}}})}`
     )
     assertCodegen(
       '<input @click.ctrl.exact="onClick">',
-      `with(this){return _c('input',{on:{"click":function($event){if(!$event.ctrlKey)return null;if($event.shiftKey||$event.altKey||$event.metaKey)return null;return onClick.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"click":function(${baseEvArgs}){if(!$event.ctrlKey)return null;if($event.shiftKey||$event.altKey||$event.metaKey)return null;return onClick.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with multiple modifiers', () => {
     assertCodegen(
       '<input @input.stop.prevent.self="onInput">',
-      `with(this){return _c('input',{on:{"input":function($event){$event.stopPropagation();$event.preventDefault();if($event.target !== $event.currentTarget)return null;return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){$event.stopPropagation();$event.preventDefault();if($event.target !== $event.currentTarget)return null;return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with capture modifier', () => {
     assertCodegen(
       '<input @input.capture="onInput">',
-      `with(this){return _c('input',{on:{"!input":function($event){return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"!input":function(${baseEvArgs}){return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with once modifier', () => {
     assertCodegen(
       '<input @input.once="onInput">',
-      `with(this){return _c('input',{on:{"~input":function($event){return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"~input":function(${baseEvArgs}){return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with capture and once modifier', () => {
     assertCodegen(
       '<input @input.capture.once="onInput">',
-      `with(this){return _c('input',{on:{"~!input":function($event){return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"~!input":function(${baseEvArgs}){return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with once and capture modifier', () => {
     assertCodegen(
       '<input @input.once.capture="onInput">',
-      `with(this){return _c('input',{on:{"~!input":function($event){return onInput.apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"~!input":function(${baseEvArgs}){return onInput.apply(null, arguments)}}})}`
     )
   })
 
   it('generate events with inline statement', () => {
     assertCodegen(
       '<input @input="current++">',
-      `with(this){return _c('input',{on:{"input":function($event){current++}}})}`
+      `with(this){return _c('input',{on:{"input":function(${baseEvArgs}){current++}}})}`
     )
   })
 
@@ -538,7 +539,7 @@ describe('codegen', () => {
     // with modifiers
     assertCodegen(
       `<input @keyup.enter="e=>current++">`,
-      `with(this){return _c('input',{on:{"keyup":function($event){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;return (e=>current++).apply(null, arguments)}}})}`
+      `with(this){return _c('input',{on:{"keyup":function(${baseEvArgs}){if(!$event.type.indexOf('key')&&_k($event.keyCode,"enter",13,$event.key,"Enter"))return null;return (e=>current++).apply(null, arguments)}}})}`
     )
   })
 
@@ -563,7 +564,7 @@ describe('codegen', () => {
   it('generate multiple event handlers', () => {
     assertCodegen(
       '<input @input="current++" @input.stop="onInput">',
-      `with(this){return _c('input',{on:{"input":[function($event){current++},function($event){$event.stopPropagation();return onInput.apply(null, arguments)}]}})}`
+      `with(this){return _c('input',{on:{"input":[function(${baseEvArgs}){current++},function(${baseEvArgs}){$event.stopPropagation();return onInput.apply(null, arguments)}]}})}`
     )
   })
 

--- a/test/weex/compiler/v-model.spec.js
+++ b/test/weex/compiler/v-model.spec.js
@@ -1,12 +1,13 @@
 import { compile } from '../../../packages/weex-template-compiler'
 import { strToRegExp } from '../helpers/index'
+const baseEvArgs = '$event,$el'
 
 describe('compile v-model', () => {
   it('should compile modelable native component', () => {
     const { render, staticRenderFns, errors } = compile(`<div><input v-model="x" /></div>`)
     expect(render).not.toBeUndefined()
     expect(render).toMatch(strToRegExp(`attrs:{"value":(x)}`))
-    expect(render).toMatch(strToRegExp(`on:{"input":function($event){x=$event.target.attr.value}}`))
+    expect(render).toMatch(strToRegExp(`on:{"input":function(${baseEvArgs}){x=$event.target.attr.value}}`))
     expect(staticRenderFns).toEqual([])
     expect(errors).toEqual([])
   })
@@ -23,7 +24,7 @@ describe('compile v-model', () => {
     const { render, staticRenderFns, errors } = compile(`<div><input v-model.trim="x" /></div>`)
     expect(render).not.toBeUndefined()
     expect(render).toMatch(strToRegExp(`attrs:{"value":(x)}`))
-    expect(render).toMatch(strToRegExp(`on:{"input":function($event){x=$event.target.attr.value.trim()}}`))
+    expect(render).toMatch(strToRegExp(`on:{"input":function(${baseEvArgs}){x=$event.target.attr.value.trim()}}`))
     expect(staticRenderFns).toEqual([])
     expect(errors).toEqual([])
   })
@@ -33,8 +34,8 @@ describe('compile v-model', () => {
     expect(render).not.toBeUndefined()
     expect(render).toMatch(strToRegExp(`attrs:{"value":(x)}`))
     expect(render).toMatch(strToRegExp(`attrs:{"value":(y)}`))
-    expect(render).toMatch(strToRegExp(`on:{"change":function($event){x=$event.target.attr.value.trim()}}`))
-    expect(render).toMatch(strToRegExp(`on:{"change":function($event){y=$event.target.attr.value.trim()}}`))
+    expect(render).toMatch(strToRegExp(`on:{"change":function(${baseEvArgs}){x=$event.target.attr.value.trim()}}`))
+    expect(render).toMatch(strToRegExp(`on:{"change":function(${baseEvArgs}){y=$event.target.attr.value.trim()}}`))
     expect(staticRenderFns).toEqual([])
     expect(errors).toEqual([])
   })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**PR details:**
Currently we don't have direct access to the original event context i.e. an element upon which event has been applied. This feature is kind of an alternative for `ref` but not complete replacement, of course, And I think people would like to use it.

**Usage of this feature:**
- `<div id="item" @click="handler($el)"></div>` 
- Where `$el` is the respective element i.e. `#item`.