### PR TITLE
fix: #10435 update the observer dep to support a Set based implementation

### DIFF
--- a/src/core/observer/dep.js
+++ b/src/core/observer/dep.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import type Watcher from './watcher'
-import { remove } from '../util/index'
+import { isNative, remove } from '../util/index'
 import config from '../config'
 
 let uid = 0
@@ -10,57 +10,113 @@ let uid = 0
  * A dep is an observable that can have multiple
  * directives subscribing to it.
  */
-export default class Dep {
-  static target: ?Watcher;
+declare interface Dep {
   id: number;
-  subs: Array<Watcher>;
-
-  constructor () {
-    this.id = uid++
-    this.subs = []
-  }
-
-  addSub (sub: Watcher) {
-    this.subs.push(sub)
-  }
-
-  removeSub (sub: Watcher) {
-    remove(this.subs, sub)
-  }
-
-  depend () {
-    if (Dep.target) {
-      Dep.target.addDep(this)
-    }
-  }
-
-  notify () {
-    // stabilize the subscriber list first
-    const subs = this.subs.slice()
-    if (process.env.NODE_ENV !== 'production' && !config.async) {
-      // subs aren't sorted in scheduler if not running async
-      // we need to sort them now to make sure they fire in correct
-      // order
-      subs.sort((a, b) => a.id - b.id)
-    }
-    for (let i = 0, l = subs.length; i < l; i++) {
-      subs[i].update()
-    }
-  }
+  constructor(): void;
+  addSub (sub: Watcher): void;
+  removeSub (sub: Watcher): void;
+  depend (): void;
+  notify (): void;
 }
+
+let DepImpl
+
+if (typeof Set !== 'undefined' && isNative(Set)) {
+  class SetDep implements Dep {
+    static target: ?Watcher
+    id: number
+    subs: Set
+
+    constructor () {
+      this.id = uid++
+      this.subs = new Set()
+    }
+
+    addSub (sub: Watcher) {
+      this.subs.add(sub)
+    }
+
+    removeSub (sub: Watcher) {
+      this.subs.delete(sub)
+    }
+
+    depend () {
+      if (SetDep.target) {
+        SetDep.target.addDep(this)
+      }
+    }
+
+    notify () {
+      // stabilize the subscriber list first
+      let subs = Array.from(this.subs)
+      if (process.env.NODE_ENV !== 'production' && !config.async) {
+        // subs aren't sorted in scheduler if not running async
+        // we need to sort them now to make sure they fire in correct
+        // order
+        subs.sort((a, b) => a.id - b.id)
+      }
+      for (let i = 0, l = subs.length; i < l; i++) {
+        subs[i].update()
+      }
+    }
+  }
+  DepImpl = SetDep
+} else {
+  class ArrayDep implements Dep {
+    static target: ?Watcher
+    id: number
+    subs: Array<Watcher>
+
+    constructor () {
+      this.id = uid++
+      this.subs = []
+    }
+
+    addSub (sub: Watcher) {
+      this.subs.push(sub)
+    }
+
+    removeSub (sub: Watcher) {
+      remove(this.subs, sub)
+    }
+
+    depend () {
+      if (ArrayDep.target) {
+        ArrayDep.target.addDep(this)
+      }
+    }
+
+    notify () {
+      // stabilize the subscriber list first
+      const subs = this.subs.slice()
+      if (process.env.NODE_ENV !== 'production' && !config.async) {
+        // subs aren't sorted in scheduler if not running async
+        // we need to sort them now to make sure they fire in correct
+        // order
+        subs.sort((a, b) => a.id - b.id)
+      }
+      for (let i = 0, l = subs.length; i < l; i++) {
+        subs[i].update()
+      }
+    }
+  }
+  DepImpl = ArrayDep
+}
+
+export default (DepImpl: Class<Dep>)
 
 // The current target watcher being evaluated.
 // This is globally unique because only one watcher
 // can be evaluated at a time.
-Dep.target = null
+DepImpl.target = null
 const targetStack = []
 
 export function pushTarget (target: ?Watcher) {
   targetStack.push(target)
-  Dep.target = target
+  DepImpl.target = target
 }
 
 export function popTarget () {
   targetStack.pop()
-  Dep.target = targetStack[targetStack.length - 1]
+  DepImpl.target = targetStack[targetStack.length - 1]
 }

--- a/test/unit/modules/observer/dep.spec.js
+++ b/test/unit/modules/observer/dep.spec.js
@@ -9,7 +9,7 @@ describe('Dep', () => {
 
   describe('instance', () => {
     it('should be created with correct properties', () => {
-      expect(dep.subs.length).toBe(0)
+      expect(dep.subs.size).toBe(0)
       expect(new Dep().id).toBe(dep.id + 1)
     })
   })
@@ -17,16 +17,16 @@ describe('Dep', () => {
   describe('addSub()', () => {
     it('should add sub', () => {
       dep.addSub(null)
-      expect(dep.subs.length).toBe(1)
-      expect(dep.subs[0]).toBe(null)
+      expect(dep.subs.size).toBe(1)
+      expect(dep.subs.values().next().value).toBe(null)
     })
   })
 
   describe('removeSub()', () => {
     it('should remove sub', () => {
-      dep.subs.push(null)
+      dep.subs.add(null)
       dep.removeSub(null)
-      expect(dep.subs.length).toBe(0)
+      expect(dep.subs.size).toBe(0)
     })
   })
 
@@ -55,9 +55,9 @@ describe('Dep', () => {
 
   describe('notify()', () => {
     it('should notify subs', () => {
-      dep.subs.push(jasmine.createSpyObj('SUB', ['update']))
+      dep.subs.add(jasmine.createSpyObj('SUB', ['update']))
       dep.notify()
-      expect(dep.subs[0].update).toHaveBeenCalled()
+      expect(dep.subs.values().next().value.update).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

This PR introduces a performance improvement for component destruction.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The issue that this PR aims to fix documents the observed performance issue and explains it pretty well.

At this moment in time upgrading to Vue 3 is not currently an option for me, getting some resolution to this issue would be awesome, hence the PR.

The PR aims to maintain compatibility with ES5 based browsers, but where the Set is supported then it would favour that.

