### PR TITLE
Add Vue context to computed options type (fix #10878)

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -41,7 +41,7 @@ export type AsyncComponentFactory<Data=DefaultData<never>, Methods=DefaultMethod
  * to infer from the shape of `Accessors<Computed>` and work backwards.
  */
 export type Accessors<T> = {
-  [K in keyof T]: (() => T[K]) | ComputedOptions<T[K]>
+  [K in keyof T]: ((vm: Vue) => T[K]) | ComputedOptions<T[K]>
 }
 
 type DataDef<Data, Props, V> = Data | ((this: Readonly<Props> & V) => Data)


### PR DESCRIPTION
Vue passes the Vue object as the first parameter, which is useful for arrow functions. This change reflects that in the types.

Fixes #10878

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
