### PR TITLE
fix(server-renderer): provide __filename to vm for webpack

### DIFF
--- a/src/server/bundle-renderer/create-bundle-runner.js
+++ b/src/server/bundle-renderer/create-bundle-runner.js
@@ -63,7 +63,9 @@ function compileModule (files, basedir, runInNewContext) {
         return require(file)
       }
     }
-    compiledWrapper.call(m.exports, m.exports, r, m)
+
+    const _filename = '/' + filename;
+    compiledWrapper.call(m.exports, m.exports, r, m, _filename, path.dirname(_filename));
 
     const res = Object.prototype.hasOwnProperty.call(m.exports, 'default')
       ? m.exports.default


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Reasons:

- The virtual module is wrapped [here]( https://github.com/vuejs/vue/blob/7094fc081ade9208e9f759a9145ec34a28143bf1/src/server/bundle-renderer/create-bundle-runner.js#L34), which adds [the wrapper](https://nodejs.org/api/modules.html#modules_the_module_wrapper):
	  
  ```js
	  (function(exports, require, module, __filename, __dirname) {
	  // Module code actually lives in here
	  });
  ```
	  
  However, `__filename` and `__dirname` are not provided:
  https://github.com/vuejs/vue/blob/7094fc081ade9208e9f759a9145ec34a28143bf1/src/server/bundle-renderer/create-bundle-runner.js#L66

- When Webpack 5 builds for a Node.js target, it uses the following code. Because `__filename` is `undefined`, `require("url").pathToFileURL(__filename)` breaks. Notice this is with both `optimization.splitChunks` and `optimization.runtimeChunk` set to `false`, and there are no chunks -- proven by the `installedChunks` object below.

  ```js
  /******/ 	/* webpack/runtime/require chunk loading */
  /******/ 	(() => {
  /******/ 		__webpack_require__.b = require("url").pathToFileURL(__filename);
  /******/ 		
  /******/ 		// object to store loaded chunks
  /******/ 		// "1" means "loaded", otherwise not loaded yet
  /******/ 		var installedChunks = {
  /******/ 			"main": 1
  /******/ 		};
  /******/ 		
  /******/ 		// no on chunks loaded
  /******/ 		
  /******/ 		var installChunk = (chunk) => {
  /******/ 			var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
  /******/ 			for(var moduleId in moreModules) {
  /******/ 				if(__webpack_require__.o(moreModules, moduleId)) {
  /******/ 					__webpack_require__.m[moduleId] = moreModules[moduleId];
  /******/ 				}
  /******/ 			}
  /******/ 			if(runtime) runtime(__webpack_require__);
  /******/ 			for(var i = 0; i < chunkIds.length; i++)
  /******/ 				installedChunks[chunkIds[i]] = 1;
  /******/ 		
  /******/ 		};
  /******/ 		
  /******/ 		// require() chunk loading for javascript
  /******/ 		__webpack_require__.f.require = (chunkId, promises) => {
  /******/ 			// "1" is the signal for "already loaded"
  /******/ 			if(!installedChunks[chunkId]) {
  /******/ 				if(true) { // all chunks have JS
  /******/ 					installChunk(require("./" + __webpack_require__.u(chunkId)));
  /******/ 				} else installedChunks[chunkId] = 1;
  /******/ 			}
  /******/ 		};
  /******/ 		
  /******/ 		// no external install chunk
  /******/ 		
  /******/ 		// no HMR
  /******/ 		
  /******/ 		// no HMR manifest
  /******/ 	})();
  /******/ 	
  ```

  The error message:
   ```
   TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
      at validateString (internal/validators.js:124:11)
      at Object.resolve (path.js:980:7)
      at Object.pathToFileURL (internal/url.js:1411:25)
      at main.js:45690:51
      at main.js:45728:13
      at Object.<anonymous> (main.js:45800:12)
      at evaluateModule (/vue-server-renderer/build.dev.js:9351:21)
      at /vue-server-renderer/build.dev.js:9409:18
      at new Promise (<anonymous>)
      at /vue-server-renderer/build.dev.js:9401:14
      at Object.renderToString (/vue-server-renderer/build.dev.js:9577:9)
      at /vue-just-ssr/lib/init-server.js:41:39
      at call (/connect/index.js:239:7)
      at next (/connect/index.js:183:5)
      at middleware (/webpack-hot-middleware/middleware.js:38:48)
      at call (/connect/index.js:239:7) {
   code: 'ERR_INVALID_ARG_TYPE'
   }
   ```
  