### PR TITLE
refactor(observer): Hijack when taking value

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -153,11 +153,12 @@ export function defineReactive (
     val = obj[key]
   }
 
-  let childOb = !shallow && observe(val)
+  let childOb 
   Object.defineProperty(obj, key, {
     enumerable: true,
     configurable: true,
     get: function reactiveGetter () {
+      childOb = = !shallow && observe(val)
       const value = getter ? getter.call(obj) : val
       if (Dep.target) {
         dep.depend()

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -158,7 +158,7 @@ export function defineReactive (
     enumerable: true,
     configurable: true,
     get: function reactiveGetter () {
-      childOb = = !shallow && observe(val)
+      childOb = !shallow && observe(val)
       const value = getter ? getter.call(obj) : val
       if (Dep.target) {
         dep.depend()


### PR DESCRIPTION
Why is it necessary to recurse as soon as you get it? Can't you hijack the property when you get it