### PR TITLE
feat(compiler):add console warning about 'this.' used in templates

### DIFF
--- a/src/compiler/error-detector.js
+++ b/src/compiler/error-detector.js
@@ -34,6 +34,7 @@ function checkNode (node: ASTNode, warn: Function) {
         const value = node.attrsMap[name]
         if (value) {
           const range = node.rawAttrsMap[name]
+          warnThisInTemplate(name,value,warn,range)
           if (name === 'v-for') {
             checkFor(node, `v-for="${value}"`, warn, range)
           } else if (name === 'v-slot' || name[0] === '#') {
@@ -124,5 +125,18 @@ function checkFunctionParameterExpression (exp: string, text: string, warn: Func
       `  Raw expression: ${text.trim()}\n`,
       range
     )
+  }
+}
+
+function warnThisInTemplate(name, value, warn, range){
+  let exp=(name + "=\"" + value + "\"");
+  if (name === 'v-for') {
+    exp=("v-for=\"" + value + "\"")
+  }
+  if (value.indexOf('this.')!==-1) {
+    warn(
+      "avoid using `this` in template" + " " + exp,
+      range
+    );
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
Add console warning about 'this.' used in templates.
**Other information:**
