### PR TITLE
Switch to `CIRCLE_PULL_REQUEST` from `CI_PULL_REQUEST`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
          name: report coverage stats for non-PRs
          command: |
-           if [[ -z $CI_PULL_REQUEST ]]; then
+           if [[ -z $CIRCLE_PULL_REQUEST ]]; then
              ./node_modules/.bin/codecov
            fi
 


### PR DESCRIPTION
`CI_PULL_REQUEST` has been deprecated in favor of `CIRCLE_PULL_REQUEST` as documented [here](https://github.com/vuejs/vue/blob/0603ff695d2f41286239298210113cbe2b209e28/.circleci/config.yml).

This prevents coverage reports from being uploaded to Codecov ([example](https://app.circleci.com/pipelines/github/vuejs/vue/781/workflows/04a4cdb5-79ff-4632-acdd-5374b2e04a66/jobs/18087))

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
