### PR TITLE
Transform component's children to its default slot contents (fix #12232)

### DIFF
--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -720,15 +720,16 @@ function processSlotContent (el) {
   // FIXME maybeComponent() is not smart enough to ensure this is in fact a component.
   //  Due to this, we end up by using slots in plain HTML tags, which is completely wrong.
   //  NOTE: this only happends when the tag is not lowercase, as it's not detected as a reserved tag.
-  if(maybeComponent(el) && el.children) {
+  if(!el.slotScope && !el.slotTarget && el.children && maybeComponent(el)) {
     const implicitDefaultSlotChildren = el.children.filter((c: any) => !c.slotScope)
 
     if(implicitDefaultSlotChildren.length) {
       // TODO add necessary checks and warnings
       // add the component's children to its default slot
       const slots = el.scopedSlots || (el.scopedSlots = {})
-      const slotContainer = slots.default = createASTElement('template', [], el)
-      slotContainer.slotTarget = '"default"'
+      const name = '"default"'
+      const slotContainer = slots[name] = createASTElement('template', [], el)
+      slotContainer.slotTarget = name
       slotContainer.slotTargetDynamic = false
       implicitDefaultSlotChildren.forEach((c: any) => c.parent = slotContainer)
       slotContainer.children = implicitDefaultSlotChildren

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -46,6 +46,15 @@ const decodeHTMLCached = cached(he.decode)
 
 export const emptySlotScopeToken = `_empty_`
 
+const vueBuiltinComponents = [
+  'transition',
+  'Transition',
+  'transition-group',
+  'TransitionGroup',
+  'keep-alive',
+  'KeepAlive'
+]
+
 // configurable state
 export let warn: any
 let delimiters
@@ -714,7 +723,7 @@ function processSlotContent (el) {
     }
   }
 
-  if(!el.slotScope && !el.slotTarget && el.children && maybeComponent(el)) {
+  if(isCandidateForImplicitDefaultSlot(el)) {
     const implicitDefaultSlotChildren = el.children.filter((c: any) => !c.slotScope)
 
     if(implicitDefaultSlotChildren.length) {
@@ -752,6 +761,15 @@ function getSlotName (binding) {
     ? { name: name.slice(1, -1), dynamic: true }
     // static name
     : { name: `"${name}"`, dynamic: false }
+}
+
+function isCandidateForImplicitDefaultSlot(el) {
+  return !el.slotScope
+    && !el.slotTarget
+    && el.children
+    && el.children.length > 0
+    && maybeComponent(el)
+    && !vueBuiltinComponents.includes(el.tag);
 }
 
 // handle <slot/> outlets

--- a/src/compiler/parser/index.js
+++ b/src/compiler/parser/index.js
@@ -714,17 +714,10 @@ function processSlotContent (el) {
     }
   }
 
-  // FIXME check those children are not templates with slots (with all the different syntaxes...)
-  //  Maybe we are lucky and the compiler has already processed those nodes, so we can check their "slotTarget" property
-  // implicit default slot
-  // FIXME maybeComponent() is not smart enough to ensure this is in fact a component.
-  //  Due to this, we end up by using slots in plain HTML tags, which is completely wrong.
-  //  NOTE: this only happends when the tag is not lowercase, as it's not detected as a reserved tag.
   if(!el.slotScope && !el.slotTarget && el.children && maybeComponent(el)) {
     const implicitDefaultSlotChildren = el.children.filter((c: any) => !c.slotScope)
 
     if(implicitDefaultSlotChildren.length) {
-      // TODO add necessary checks and warnings
       // add the component's children to its default slot
       const slots = el.scopedSlots || (el.scopedSlots = {})
       const name = '"default"'
@@ -736,7 +729,6 @@ function processSlotContent (el) {
       slotContainer.slotScope = emptySlotScopeToken
       // remove children as they are returned from scopedSlots now
       el.children = []
-      // TODO review this
       // mark el non-plain as it has a scoped slot
       el.plain = false
     }

--- a/test/unit/modules/compiler/parser.spec.js
+++ b/test/unit/modules/compiler/parser.spec.js
@@ -48,11 +48,14 @@ describe('parser', () => {
   it('camelCase element', () => {
     const ast = parse('<MyComponent><p>hello world</p></MyComponent>', baseOptions)
     expect(ast.tag).toBe('MyComponent')
-    expect(ast.plain).toBe(true)
-    expect(ast.children[0].tag).toBe('p')
-    expect(ast.children[0].plain).toBe(true)
-    expect(ast.children[0].children[0].text).toBe('hello world')
-    expect(ast.children[0].parent).toBe(ast)
+    expect(ast.plain).toBe(false)
+    expect(ast.children.length).toBe(0)
+    expect(ast.scopedSlots.default.tag).toBe('template')
+    expect(ast.scopedSlots.default.parent).toBe(ast)
+    expect(ast.scopedSlots.default.children[0].tag).toBe('p')
+    expect(ast.scopedSlots.default.children[0].plain).toBe(true)
+    expect(ast.scopedSlots.default.children[0].children[0].text).toBe('hello world')
+    expect(ast.scopedSlots.default.children[0].parent).toBe(ast.scopedSlots.default)
   })
 
   it('forbidden element', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

HTML tags written using some uppercase letters (i.e. `<H1>` or `<Span>`) will stop rendering their children. This happens because those tags are considered components by the `maybeComponent()` function, so after applying these changes their children will be considered the contents of its default slot. As native HTML tags doesn't have slots, they won't be rendered. This is explained in more detail in the attached video.

The recommendation in this case is to write the standard HTML tags always in lowercase (in fact, in Vue 3 a "failed to resolve component" warning is displayed when an uppercase tag is used, even when it's still rendered).

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

https://user-images.githubusercontent.com/9889025/149219636-254a6ebf-7f56-4d76-9de6-d8eed439a1e0.mp4

*P.S.: I just realized I didn't show the fixed version working as expected in the video (I forgot to modify the input during the demo). If you find it necessary, I can upload another video showing it :slightly_smiling_face: thank you very much!*