### PR TITLE
fix(ssr): fix compatibility with webpack@4 and webpack@5 for monorepos

### DIFF
--- a/packages/vue-server-renderer/server-plugin.js
+++ b/packages/vue-server-renderer/server-plugin.js
@@ -7,13 +7,11 @@ var isJS = function (file) { return /\.js(\?[^.]+)?$/.test(file); };
 var ref = require('chalk');
 var red = ref.red;
 var yellow = ref.yellow;
-var webpack = require('webpack');
 
 var prefix = "[vue-server-renderer-webpack-plugin]";
 var warn = exports.warn = function (msg) { return console.error(red((prefix + " " + msg + "\n"))); };
 var tip = exports.tip = function (msg) { return console.log(yellow((prefix + " " + msg + "\n"))); };
 
-var isWebpack5 = !!(webpack.version && webpack.version[0] > 4);
 
 var validate = function (compiler) {
   if (compiler.options.target !== 'node') {
@@ -41,6 +39,7 @@ var validate = function (compiler) {
 };
 
 var onEmit = function (compiler, name, stageName, hook) {
+  const isWebpack5 = !!compiler.webpack
   if (isWebpack5) {
     // Webpack >= 5.0.0
     compiler.hooks.compilation.tap(name, function (compilation) {
@@ -48,7 +47,7 @@ var onEmit = function (compiler, name, stageName, hook) {
         // Ignore child compilers
         return
       }
-      var stage = webpack.Compilation[stageName];
+      var stage = compiler.webpack.Compilation[stageName];
       compilation.hooks.processAssets.tapAsync({ name: name, stage: stage }, function (assets, cb) {
         hook(compilation, cb);
       });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The current webpack version detect logic is flaw in monorepo with webpack@4 and webpack@5, webpack expose its version by compiler.webpack.version since webpack@5.1.0(https://github.com/webpack/webpack/pull/11657 webpack@5.0.0 is the only exception), other webpack plugin meets the same problem, see https://github.com/webpack-contrib/mini-css-extract-plugin/pull/636 
