### PR TITLE
fix(core): add prop name to invalid prop type warning message (fix #12454)

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -122,7 +122,7 @@ function assertProp (
       type = [type]
     }
     for (let i = 0; i < type.length && !valid; i++) {
-      const assertedType = assertType(value, type[i], vm)
+      const assertedType = assertType(value, type[i], name, vm)
       expectedTypes.push(assertedType.expectedType || '')
       valid = assertedType.valid
     }
@@ -149,7 +149,7 @@ function assertProp (
 
 const simpleCheckRE = /^(String|Number|Boolean|Function|Symbol|BigInt)$/
 
-function assertType (value: any, type: Function, vm: ?Component): {
+function assertType (value: any, type: Function, name: string, vm: ?Component): {
   valid: boolean;
   expectedType: string;
 } {
@@ -170,7 +170,7 @@ function assertType (value: any, type: Function, vm: ?Component): {
     try {
       valid = value instanceof type
     } catch (e) {
-      warn('Invalid prop type: "' + String(type) + '" is not a constructor', vm);
+      warn(`Invalid prop "${name}" type: "${String(type)}" is not a constructor`, vm);
       valid = false;
     }
   }

--- a/test/unit/features/options/props.spec.js
+++ b/test/unit/features/options/props.spec.js
@@ -575,7 +575,7 @@ describe('Options props', () => {
       }
     }).$mount()
     expect(
-      'Invalid prop type: "String" is not a constructor'
+      'Invalid prop "a" type: "String" is not a constructor'
     ).toHaveBeenWarned()
   })
 


### PR DESCRIPTION
Previously, the "Invalid prop type" warning message returned by the property validator did not
include the name of the offending property. In certain scenarios this obscurity can make it
difficult to identify the source of the issue. To address this, I have added the name of the
offending property to the output as suggested in #12454.

fix #12454

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
