### PR TITLE
Add "Support Ukraine" badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <p align="center"><a href="https://vuejs.org" target="_blank" rel="noopener noreferrer"><img width="100" src="https://vuejs.org/images/logo.png" alt="Vue logo"></a></p>
 
 <p align="center">
+  <a href="https://bank.gov.ua/en/news/all/natsionalniy-bank-vidkriv-spetsrahunok-dlya-zboru-koshtiv-na-potrebi-armiyi">
+    <img src="https://img.shields.io/badge/Support-Ukraine-blue?style=flat&logo=adguard" alt="Support Ukraine" />
+  </a>
   <a href="https://circleci.com/gh/vuejs/vue/tree/dev"><img src="https://img.shields.io/circleci/project/github/vuejs/vue/dev.svg?sanitize=true" alt="Build Status"></a>
   <a href="https://codecov.io/github/vuejs/vue?branch=dev"><img src="https://img.shields.io/codecov/c/github/vuejs/vue/dev.svg?sanitize=true" alt="Coverage Status"></a>
   <a href="https://npmcharts.com/compare/vue?minimal=true"><img src="https://img.shields.io/npm/dm/vue.svg?sanitize=true" alt="Downloads"></a>


### PR DESCRIPTION
## Summary

This Pull Request is aimed at helping Ukrainian Army get necessary funding in time of open-scale war with Russia by providing link to official international account created by National Bank of Ukraine.

## Changelog:

[General] [Added] - Add badge with link to National Bank of Ukraine's website

## Test Plan

Badge image: 
<img width="636" alt="155879304-107042dc-005c-4ea9-9967-dc05881c35e4" src="https://user-images.githubusercontent.com/40458927/155880515-33cc74b9-7559-4389-a1a0-406ed41328d4.png">


**What kind of change does this PR introduce?**

- [x] Other, please describe: Add "Support Ukraine" badge in README

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
