### PR TITLE
types(compiler): add missing start/end fields

### DIFF
--- a/packages/vue-template-compiler/types/index.d.ts
+++ b/packages/vue-template-compiler/types/index.d.ts
@@ -71,6 +71,8 @@ export interface ASTElementHandler {
   value: string;
   params?: any[];
   modifiers: ASTModifiers | undefined;
+  start?: number;
+  end?: number;
 }
 
 export interface ASTElementHandlers {
@@ -83,6 +85,8 @@ export interface ASTDirective {
   value: string;
   arg: string | undefined;
   modifiers: ASTModifiers | undefined;
+  start?: number;
+  end?: number;
 }
 
 export type ASTNode = ASTElement | ASTText | ASTExpression;
@@ -95,6 +99,9 @@ export interface ASTElement {
   parent: ASTElement | undefined;
   children: ASTNode[];
 
+  start?: number;
+  end?: number;
+  
   processed?: true;
 
   static?: boolean;
@@ -173,6 +180,8 @@ export interface ASTExpression {
   static?: boolean;
   // 2.4 ssr optimization
   ssrOptimizability?: SSROptimizability;
+  start?: number;
+  end?: number;
 }
 
 export interface ASTText {
@@ -182,6 +191,8 @@ export interface ASTText {
   isComment?: boolean;
   // 2.4 ssr optimization
   ssrOptimizability?: SSROptimizability;
+  start?: number;
+  end?: number;
 }
 
 /*


### PR DESCRIPTION
Add start/end fields existing in `flow/compiler.js` but not here.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR is to complement start/end fields existing in `flow/compiler.js` but not in `vue-template-compiler/types/index.d.ts`.