### PR TITLE
chore: Improve npm package specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "unpkg": "dist/vue.js",
   "jsdelivr": "dist/vue.js",
   "typings": "types/index.d.ts",
+  "exports": {
+    "./dist/*": "./dist/*"
+  },
   "files": [
     "src",
     "dist/*.js",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

As the esm and npm exports fields are gradually standardized, more and more tools will implement specific functions, such as importmap, according to these specifications.

[jspm](https://jspm.org/) is a tool that automatically generates importmap. It mainly generates importmap source map through the exports field of package.json. 

https://ga.jspm.io/npm:vue@2.6.14/dist/vue.runtime.esm.js This is an example of it and we can access it. But if we need to use it in the browser, we need to visit https://ga.jspm.io/npm:vue@2.6.14/dist/vue.esm.browser.js. 

This is currently not possible, so we need to configure `{ "./dist/*": "./dist/*" } ` essed in [jspm](https://jspm.org/)
