### PR TITLE
Allow inferring types from Vue.set(object, ...) pattern

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -91,7 +91,7 @@ export interface VueConstructor<V extends Vue = Vue> {
 
   nextTick<T>(callback: (this: T) => void, context?: T): void;
   nextTick(): Promise<void>
-  set<T>(object: object, key: string | number, value: T): T;
+  set<Obj, Key extends keyof Obj, Val extends Obj[Key]>(object: Obj, key: Key, value: Val): Val;
   set<T>(array: T[], key: number, value: T): T;
   delete(object: object, key: string | number): void;
   delete<T>(array: T[], key: number): void;


### PR DESCRIPTION
Right now it's not possible to infer the type when doing Vue.set this is because Vue assumes it to be a generic object. But with a small change we can allow these types to be inferred in a clear and consistent way similar to how it's array inference works.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
