### PR TITLE
Merge the code of the event modifier

### DIFF
--- a/src/compiler/codegen/events.js
+++ b/src/compiler/codegen/events.js
@@ -37,19 +37,49 @@ const keyNames: { [key: string]: string | Array<string> } = {
 // #4868: modifiers that prevent the execution of the listener
 // need to explicitly return null so that we can determine whether to remove
 // the listener for .once
-const genGuard = condition => `if(${condition})return null;`
 
 const modifierCode: { [key: string]: string } = {
-  stop: '$event.stopPropagation();',
-  prevent: '$event.preventDefault();',
-  self: genGuard(`$event.target !== $event.currentTarget`),
-  ctrl: genGuard(`!$event.ctrlKey`),
-  shift: genGuard(`!$event.shiftKey`),
-  alt: genGuard(`!$event.altKey`),
-  meta: genGuard(`!$event.metaKey`),
-  left: genGuard(`'button' in $event && $event.button !== 0`),
-  middle: genGuard(`'button' in $event && $event.button !== 1`),
-  right: genGuard(`'button' in $event && $event.button !== 2`)
+  // stop and prevent return undefined
+  stop: '$event.stopPropagation()',
+  prevent: '$event.preventDefault()',
+  self: `$event.target !== $event.currentTarget`,
+  ctrl: `!$event.ctrlKey`,
+  shift: `!$event.shiftKey`,
+  alt: `!$event.altKey`,
+  meta: `!$event.metaKey`,
+  left: `('button' in $event && $event.button !== 0)`,
+  middle: `('button' in $event && $event.button !== 1)`,
+  right: `('button' in $event && $event.button !== 2)`
+}
+
+class modifierCodeMerger {
+  modifierCodeList: Array<string>;
+  stopAndPreventCount: number;
+
+  constructor () {
+    this.modifierCodeList = []
+    this.stopAndPreventCount = 0
+  }
+
+  pushCode (modifierCode: string) {
+    this.modifierCodeList.push(modifierCode)
+  }
+
+  unshiftCode (modifierCode: string) {
+    this.modifierCodeList.unshift(modifierCode)
+  }
+
+  isOnlyStopPrevent (): boolean {
+    return this.stopAndPreventCount === this.modifierCodeList.length
+  }
+
+  getMergeCode (): string {
+    if (!this.modifierCodeList.length) return '';
+    if (this.isOnlyStopPrevent()) {
+      return this.modifierCodeList.join(';') + ';'
+    }
+    return this.modifierCodeList.join('||')
+  }
 }
 
 export function genHandlers (
@@ -118,47 +148,57 @@ function genHandler (handler: ASTElementHandler | Array<ASTElementHandler>): str
       isFunctionInvocation ? `return ${handler.value}` : handler.value
     }}` // inline statement
   } else {
-    let code = ''
-    let genModifierCode = ''
     const keys = []
+    const codeMerger=new modifierCodeMerger();
     for (const key in handler.modifiers) {
       if (modifierCode[key]) {
-        genModifierCode += modifierCode[key]
+        codeMerger.pushCode(modifierCode[key]);
+        if (key === 'stop' || key === 'prevent') {
+          codeMerger.stopAndPreventCount++;
+          continue
+        }
         // left/right
         if (keyCodes[key]) {
           keys.push(key)
         }
       } else if (key === 'exact') {
-        const modifiers: ASTModifiers = (handler.modifiers: any)
-        genModifierCode += genGuard(
-          ['ctrl', 'shift', 'alt', 'meta']
-            .filter(keyModifier => !modifiers[keyModifier])
-            .map(keyModifier => `$event.${keyModifier}Key`)
-            .join('||')
-        )
+        const modifiers: ASTModifiers = (handler.modifiers: any);
+        ['ctrl', 'shift', 'alt', 'meta']
+          .forEach(keyModifier => modifiers[keyModifier] || codeMerger.pushCode(`$event.${keyModifier}Key`));
       } else {
         keys.push(key)
       }
     }
     if (keys.length) {
-      code += genKeyFilter(keys)
-    }
-    // Make sure modifiers like prevent and stop get executed after key filtering
-    if (genModifierCode) {
-      code += genModifierCode
+      // Make sure modifiers like prevent and stop get executed after key filtering
+      codeMerger.unshiftCode(genKeyFilter(keys))
     }
     const handlerCode = isMethodPath
-      ? `return ${handler.value}.apply(null, arguments)`
+      ? `${handler.value}.apply(null, arguments)`
       : isFunctionExpression
-        ? `return (${handler.value}).apply(null, arguments)`
+        ? `(${handler.value}).apply(null, arguments)`
         : isFunctionInvocation
-          ? `return ${handler.value}`
-          : handler.value
+          ? `${handler.value}`
+          : handler.value;
+    let code = '';
+    let guardCode = codeMerger.getMergeCode();
+    if (handlerCode !== '') {
+      if (guardCode) {
+        if(codeMerger.isOnlyStopPrevent()){
+          code += `${guardCode}return `
+        }else{
+          code += `return (${guardCode})?null:`
+        }
+      }
+      code += handlerCode
+    }else if (guardCode) {
+      code += guardCode
+    }
     /* istanbul ignore if */
     if (__WEEX__ && handler.params) {
-      return genWeexHandler(handler.params, code + handlerCode)
+      return genWeexHandler(handler.params, code)
     }
-    return `function($event){${code}${handlerCode}}`
+    return `function($event){${code}}`
   }
 }
 
@@ -167,8 +207,8 @@ function genKeyFilter (keys: Array<string>): string {
     // make sure the key filters only apply to KeyboardEvents
     // #9441: can't use 'keyCode' in $event because Chrome autofill fires fake
     // key events that do not have keyCode property...
-    `if(!$event.type.indexOf('key')&&` +
-    `${keys.map(genFilterCode).join('&&')})return null;`
+    `(!$event.type.indexOf('key')&&` +
+    `${keys.map(genFilterCode).join('&&')})`
   )
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Test Demo
```
       new Vue({
                el: '.aa',
                template: `
          <div>
            <button @click.ctrl.stop>click.ctrl.stop</button>
            <button @click.alt.shift.stop="foo">click.alt.shift.stop="foo"</button>
            <p>
                keyup.shift.stop.exact.k="foo"
                <input @keyup.shift.stop.exact.k="foo"/>
            </p>
          </div>
        `,
                methods: {
                    foo(e) {
                        console.log(e);
                    }
                }
            })
```
![This is an image](https://raw.githubusercontent.com/VICTORYGS/imageStorage/main/vue_event_before.png)

**The guard codes corresponding to all modifiers no longer need to be executed(if(...)return)  separately.**
![This is an image](https://raw.githubusercontent.com/VICTORYGS/imageStorage/main/vue_event_after.png)