### PR TITLE
add warning message for v-if with empty key

### DIFF
--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import Dep from './dep'
-import VNode from '../vdom/vnode'
-import { arrayMethods } from './array'
+import Dep from "./dep";
+import VNode from "../vdom/vnode";
+import { arrayMethods } from "./array";
 import {
   def,
   warn,
@@ -13,19 +13,19 @@ import {
   isPrimitive,
   isUndef,
   isValidArrayIndex,
-  isServerRendering
-} from '../util/index'
+  isServerRendering,
+} from "../util/index";
 
-const arrayKeys = Object.getOwnPropertyNames(arrayMethods)
+const arrayKeys = Object.getOwnPropertyNames(arrayMethods);
 
 /**
  * In some cases we may want to disable observation inside a component's
  * update computation.
  */
-export let shouldObserve: boolean = true
+export let shouldObserve: boolean = true;
 
-export function toggleObserving (value: boolean) {
-  shouldObserve = value
+export function toggleObserving(value: boolean) {
+  shouldObserve = value;
 }
 
 /**
@@ -39,20 +39,20 @@ export class Observer {
   dep: Dep;
   vmCount: number; // number of vms that have this object as root $data
 
-  constructor (value: any) {
-    this.value = value
-    this.dep = new Dep()
-    this.vmCount = 0
-    def(value, '__ob__', this)
+  constructor(value: any) {
+    this.value = value;
+    this.dep = new Dep();
+    this.vmCount = 0;
+    def(value, "__ob__", this);
     if (Array.isArray(value)) {
       if (hasProto) {
-        protoAugment(value, arrayMethods)
+        protoAugment(value, arrayMethods);
       } else {
-        copyAugment(value, arrayMethods, arrayKeys)
+        copyAugment(value, arrayMethods, arrayKeys);
       }
-      this.observeArray(value)
+      this.observeArray(value);
     } else {
-      this.walk(value)
+      this.walk(value);
     }
   }
 
@@ -61,19 +61,22 @@ export class Observer {
    * getter/setters. This method should only be called when
    * value type is Object.
    */
-  walk (obj: Object) {
-    const keys = Object.keys(obj)
+  walk(obj: Object) {
+    let keys = Object.keys(obj);
     for (let i = 0; i < keys.length; i++) {
-      defineReactive(obj, keys[i])
+      if (keys[i] == "") {
+        warn(`Objects should not contain empty keys cannot bind to value`);
+      }
+      defineReactive(obj, keys[i]);
     }
   }
 
   /**
    * Observe a list of Array items.
    */
-  observeArray (items: Array<any>) {
+  observeArray(items: Array<any>) {
     for (let i = 0, l = items.length; i < l; i++) {
-      observe(items[i])
+      observe(items[i]);
     }
   }
 }
@@ -84,9 +87,9 @@ export class Observer {
  * Augment a target Object or Array by intercepting
  * the prototype chain using __proto__
  */
-function protoAugment (target, src: Object) {
+function protoAugment(target, src: Object) {
   /* eslint-disable no-proto */
-  target.__proto__ = src
+  target.__proto__ = src;
   /* eslint-enable no-proto */
 }
 
@@ -95,10 +98,10 @@ function protoAugment (target, src: Object) {
  * hidden properties.
  */
 /* istanbul ignore next */
-function copyAugment (target: Object, src: Object, keys: Array<string>) {
+function copyAugment(target: Object, src: Object, keys: Array<string>) {
   for (let i = 0, l = keys.length; i < l; i++) {
-    const key = keys[i]
-    def(target, key, src[key])
+    const key = keys[i];
+    def(target, key, src[key]);
   }
 }
 
@@ -107,13 +110,13 @@ function copyAugment (target: Object, src: Object, keys: Array<string>) {
  * returns the new observer if successfully observed,
  * or the existing observer if the value already has one.
  */
-export function observe (value: any, asRootData: ?boolean): Observer | void {
+export function observe(value: any, asRootData: ?boolean): Observer | void {
   if (!isObject(value) || value instanceof VNode) {
-    return
+    return;
   }
-  let ob: Observer | void
-  if (hasOwn(value, '__ob__') && value.__ob__ instanceof Observer) {
-    ob = value.__ob__
+  let ob: Observer | void;
+  if (hasOwn(value, "__ob__") && value.__ob__ instanceof Observer) {
+    ob = value.__ob__;
   } else if (
     shouldObserve &&
     !isServerRendering() &&
@@ -121,76 +124,76 @@ export function observe (value: any, asRootData: ?boolean): Observer | void {
     Object.isExtensible(value) &&
     !value._isVue
   ) {
-    ob = new Observer(value)
+    ob = new Observer(value);
   }
   if (asRootData && ob) {
-    ob.vmCount++
+    ob.vmCount++;
   }
-  return ob
+  return ob;
 }
 
 /**
  * Define a reactive property on an Object.
  */
-export function defineReactive (
+export function defineReactive(
   obj: Object,
   key: string,
   val: any,
   customSetter?: ?Function,
   shallow?: boolean
 ) {
-  const dep = new Dep()
+  const dep = new Dep();
 
-  const property = Object.getOwnPropertyDescriptor(obj, key)
+  const property = Object.getOwnPropertyDescriptor(obj, key);
   if (property && property.configurable === false) {
-    return
+    return;
   }
 
   // cater for pre-defined getter/setters
-  const getter = property && property.get
-  const setter = property && property.set
+  const getter = property && property.get;
+  const setter = property && property.set;
   if ((!getter || setter) && arguments.length === 2) {
-    val = obj[key]
+    val = obj[key];
   }
 
-  let childOb = !shallow && observe(val)
+  let childOb = !shallow && observe(val);
   Object.defineProperty(obj, key, {
     enumerable: true,
     configurable: true,
-    get: function reactiveGetter () {
-      const value = getter ? getter.call(obj) : val
+    get: function reactiveGetter() {
+      const value = getter ? getter.call(obj) : val;
       if (Dep.target) {
-        dep.depend()
+        dep.depend();
         if (childOb) {
-          childOb.dep.depend()
+          childOb.dep.depend();
           if (Array.isArray(value)) {
-            dependArray(value)
+            dependArray(value);
           }
         }
       }
-      return value
+      return value;
     },
-    set: function reactiveSetter (newVal) {
-      const value = getter ? getter.call(obj) : val
+    set: function reactiveSetter(newVal) {
+      const value = getter ? getter.call(obj) : val;
       /* eslint-disable no-self-compare */
       if (newVal === value || (newVal !== newVal && value !== value)) {
-        return
+        return;
       }
       /* eslint-enable no-self-compare */
-      if (process.env.NODE_ENV !== 'production' && customSetter) {
-        customSetter()
+      if (process.env.NODE_ENV !== "production" && customSetter) {
+        customSetter();
       }
       // #7981: for accessor properties without setter
-      if (getter && !setter) return
+      if (getter && !setter) return;
       if (setter) {
-        setter.call(obj, newVal)
+        setter.call(obj, newVal);
       } else {
-        val = newVal
+        val = newVal;
       }
-      childOb = !shallow && observe(newVal)
-      dep.notify()
-    }
-  })
+      childOb = !shallow && observe(newVal);
+      dep.notify();
+    },
+  });
 }
 
 /**
@@ -198,79 +201,87 @@ export function defineReactive (
  * triggers change notification if the property doesn't
  * already exist.
  */
-export function set (target: Array<any> | Object, key: any, val: any): any {
-  if (process.env.NODE_ENV !== 'production' &&
+export function set(target: Array<any> | Object, key: any, val: any): any {
+  if (
+    process.env.NODE_ENV !== "production" &&
     (isUndef(target) || isPrimitive(target))
   ) {
-    warn(`Cannot set reactive property on undefined, null, or primitive value: ${(target: any)}`)
+    warn(
+      `Cannot set reactive property on undefined, null, or primitive value: ${(target: any)}`
+    );
   }
   if (Array.isArray(target) && isValidArrayIndex(key)) {
-    target.length = Math.max(target.length, key)
-    target.splice(key, 1, val)
-    return val
+    target.length = Math.max(target.length, key);
+    target.splice(key, 1, val);
+    return val;
   }
   if (key in target && !(key in Object.prototype)) {
-    target[key] = val
-    return val
+    target[key] = val;
+    return val;
   }
-  const ob = (target: any).__ob__
+  const ob = (target: any).__ob__;
   if (target._isVue || (ob && ob.vmCount)) {
-    process.env.NODE_ENV !== 'production' && warn(
-      'Avoid adding reactive properties to a Vue instance or its root $data ' +
-      'at runtime - declare it upfront in the data option.'
-    )
-    return val
+    process.env.NODE_ENV !== "production" &&
+      warn(
+        "Avoid adding reactive properties to a Vue instance or its root $data " +
+          "at runtime - declare it upfront in the data option."
+      );
+    return val;
   }
   if (!ob) {
-    target[key] = val
-    return val
+    target[key] = val;
+    return val;
   }
-  defineReactive(ob.value, key, val)
-  ob.dep.notify()
-  return val
+  defineReactive(ob.value, key, val);
+  ob.dep.notify();
+  return val;
 }
 
 /**
  * Delete a property and trigger change if necessary.
  */
-export function del (target: Array<any> | Object, key: any) {
-  if (process.env.NODE_ENV !== 'production' &&
+export function del(target: Array<any> | Object, key: any) {
+  if (
+    process.env.NODE_ENV !== "production" &&
     (isUndef(target) || isPrimitive(target))
   ) {
-    warn(`Cannot delete reactive property on undefined, null, or primitive value: ${(target: any)}`)
+    warn(
+      `Cannot delete reactive property on undefined, null, or primitive value: ${(target: any)}`
+    );
   }
   if (Array.isArray(target) && isValidArrayIndex(key)) {
-    target.splice(key, 1)
-    return
+    target.splice(key, 1);
+    return;
   }
-  const ob = (target: any).__ob__
+  const ob = (target: any).__ob__;
   if (target._isVue || (ob && ob.vmCount)) {
-    process.env.NODE_ENV !== 'production' && warn(
-      'Avoid deleting properties on a Vue instance or its root $data ' +
-      '- just set it to null.'
-    )
-    return
+    process.env.NODE_ENV !== "production" &&
+      warn(
+        "Avoid deleting properties on a Vue instance or its root $data " +
+          "- just set it to null."
+      );
+    return;
   }
   if (!hasOwn(target, key)) {
-    return
+    return;
   }
-  delete target[key]
+  delete target[key];
   if (!ob) {
-    return
+    return;
   }
-  ob.dep.notify()
+  ob.dep.notify();
 }
 
 /**
  * Collect dependencies on array elements when the array is touched, since
  * we cannot intercept array element access like property getters.
  */
-function dependArray (value: Array<any>) {
+function dependArray(value: Array<any>) {
   for (let e, i = 0, l = value.length; i < l; i++) {
-    e = value[i]
-    e && e.__ob__ && e.__ob__.dep.depend()
+    e = value[i];
+    e && e.__ob__ && e.__ob__.dep.depend();
     if (Array.isArray(e)) {
-      dependArray(e)
+      dependArray(e);
     }
   }
 }

--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -6,7 +6,6 @@ import { extend, isDef, isUndef } from "shared/util";
 
 import {
   isXlink,
-  isEmpty,
   xlinkNS,
   getXlinkProp,
   isBooleanAttr,
@@ -57,7 +56,7 @@ function updateAttrs(oldVnode: VNodeWithData, vnode: VNodeWithData) {
 }
 
 function setAttr(el: Element, key: string, value: any) {
-  if (isInPre || el.tagName.indexOf("-") > -1) {
+  if (el.tagName.indexOf("-") > -1) {
     baseSetAttr(el, key, value);
   } else if (isBooleanAttr(key)) {
     // set attribute for blank value

--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -35,7 +35,7 @@ function updateAttrs(oldVnode: VNodeWithData, vnode: VNodeWithData) {
     cur = attrs[key];
     old = oldAttrs[key];
     if (old !== cur) {
-      setAttr(elm, key, cur, vnode.data.pre);
+      setAttr(elm, key, cur);
     }
   }
   // #4391: in IE9, setting type can reset value for input[type=radio]

--- a/src/platforms/web/runtime/modules/attrs.js
+++ b/src/platforms/web/runtime/modules/attrs.js
@@ -1,119 +1,122 @@
 /* @flow */
 
-import { isIE, isIE9, isEdge } from 'core/util/env'
+import { isIE, isIE9, isEdge } from "core/util/env";
 
-import {
-  extend,
-  isDef,
-  isUndef
-} from 'shared/util'
+import { extend, isDef, isUndef } from "shared/util";
 
 import {
   isXlink,
+  isEmpty,
   xlinkNS,
   getXlinkProp,
   isBooleanAttr,
   isEnumeratedAttr,
   isFalsyAttrValue,
-  convertEnumeratedValue
-} from 'web/util/index'
+  convertEnumeratedValue,
+} from "web/util/index";
 
-function updateAttrs (oldVnode: VNodeWithData, vnode: VNodeWithData) {
-  const opts = vnode.componentOptions
+function updateAttrs(oldVnode: VNodeWithData, vnode: VNodeWithData) {
+  const opts = vnode.componentOptions;
   if (isDef(opts) && opts.Ctor.options.inheritAttrs === false) {
-    return
+    return;
   }
   if (isUndef(oldVnode.data.attrs) && isUndef(vnode.data.attrs)) {
-    return
+    return;
   }
-  let key, cur, old
-  const elm = vnode.elm
-  const oldAttrs = oldVnode.data.attrs || {}
-  let attrs: any = vnode.data.attrs || {}
+  let key, cur, old;
+  const elm = vnode.elm;
+  const oldAttrs = oldVnode.data.attrs || {};
+  let attrs: any = vnode.data.attrs || {};
   // clone observed objects, as the user probably wants to mutate it
   if (isDef(attrs.__ob__)) {
-    attrs = vnode.data.attrs = extend({}, attrs)
+    attrs = vnode.data.attrs = extend({}, attrs);
   }
 
   for (key in attrs) {
-    cur = attrs[key]
-    old = oldAttrs[key]
+    cur = attrs[key];
+    old = oldAttrs[key];
     if (old !== cur) {
-      setAttr(elm, key, cur, vnode.data.pre)
+      setAttr(elm, key, cur, vnode.data.pre);
     }
   }
   // #4391: in IE9, setting type can reset value for input[type=radio]
   // #6666: IE/Edge forces progress value down to 1 before setting a max
   /* istanbul ignore if */
   if ((isIE || isEdge) && attrs.value !== oldAttrs.value) {
-    setAttr(elm, 'value', attrs.value)
+    setAttr(elm, "value", attrs.value);
   }
   for (key in oldAttrs) {
     if (isUndef(attrs[key])) {
       if (isXlink(key)) {
-        elm.removeAttributeNS(xlinkNS, getXlinkProp(key))
+        elm.removeAttributeNS(xlinkNS, getXlinkProp(key));
       } else if (!isEnumeratedAttr(key)) {
-        elm.removeAttribute(key)
+        elm.removeAttribute(key);
       }
     }
   }
 }
 
-function setAttr (el: Element, key: string, value: any, isInPre: any) {
-  if (isInPre || el.tagName.indexOf('-') > -1) {
-    baseSetAttr(el, key, value)
+function setAttr(el: Element, key: string, value: any) {
+  if (isInPre || el.tagName.indexOf("-") > -1) {
+    baseSetAttr(el, key, value);
   } else if (isBooleanAttr(key)) {
     // set attribute for blank value
     // e.g. <option disabled>Select one</option>
     if (isFalsyAttrValue(value)) {
-      el.removeAttribute(key)
+      el.removeAttribute(key);
     } else {
       // technically allowfullscreen is a boolean attribute for <iframe>,
       // but Flash expects a value of "true" when used on <embed> tag
-      value = key === 'allowfullscreen' && el.tagName === 'EMBED'
-        ? 'true'
-        : key
-      el.setAttribute(key, value)
+      value =
+        key === "allowfullscreen" && el.tagName === "EMBED" ? "true" : key;
+      el.setAttribute(key, value);
     }
   } else if (isEnumeratedAttr(key)) {
-    el.setAttribute(key, convertEnumeratedValue(key, value))
+    el.setAttribute(key, convertEnumeratedValue(key, value));
   } else if (isXlink(key)) {
     if (isFalsyAttrValue(value)) {
-      el.removeAttributeNS(xlinkNS, getXlinkProp(key))
+      el.removeAttributeNS(xlinkNS, getXlinkProp(key));
     } else {
-      el.setAttributeNS(xlinkNS, key, value)
+      el.setAttributeNS(xlinkNS, key, value);
     }
+  } else if (!key) {
+    console.error(
+      "[Vue warn]: " + "Assignment key in element is invalid. " + el.tagName
+    );
   } else {
-    baseSetAttr(el, key, value)
+    baseSetAttr(el, key, value);
   }
 }
 
-function baseSetAttr (el, key, value) {
+function baseSetAttr(el, key, value) {
   if (isFalsyAttrValue(value)) {
-    el.removeAttribute(key)
+    el.removeAttribute(key);
   } else {
     // #7138: IE10 & 11 fires input event when setting placeholder on
     // <textarea>... block the first input event and remove the blocker
     // immediately.
     /* istanbul ignore if */
     if (
-      isIE && !isIE9 &&
-      el.tagName === 'TEXTAREA' &&
-      key === 'placeholder' && value !== '' && !el.__ieph
+      isIE &&
+      !isIE9 &&
+      el.tagName === "TEXTAREA" &&
+      key === "placeholder" &&
+      value !== "" &&
+      !el.__ieph
     ) {
-      const blocker = e => {
-        e.stopImmediatePropagation()
-        el.removeEventListener('input', blocker)
-      }
-      el.addEventListener('input', blocker)
+      const blocker = (e) => {
+        e.stopImmediatePropagation();
+        el.removeEventListener("input", blocker);
+      };
+      el.addEventListener("input", blocker);
       // $flow-disable-line
-      el.__ieph = true /* IE placeholder patched */
+      el.__ieph = true; /* IE placeholder patched */
     }
-    el.setAttribute(key, value)
+    el.setAttribute(key, value);
   }
 }
 
 export default {
   create: updateAttrs,
-  update: updateAttrs
-}
+  update: updateAttrs,
+};

--- a/src/platforms/web/util/attrs.js
+++ b/src/platforms/web/util/attrs.js
@@ -1,54 +1,60 @@
 /* @flow */
 
-import { makeMap } from 'shared/util'
+import { makeMap } from "shared/util";
 
 // these are reserved for web because they are directly compiled away
 // during template compilation
-export const isReservedAttr = makeMap('style,class')
+export const isReservedAttr = makeMap("style,class");
 
 // attributes that should be using props for binding
-const acceptValue = makeMap('input,textarea,option,select,progress')
-export const mustUseProp = (tag: string, type: ?string, attr: string): boolean => {
+const acceptValue = makeMap("input,textarea,option,select,progress");
+export const mustUseProp = (
+  tag: string,
+  type: ?string,
+  attr: string
+): boolean => {
   return (
-    (attr === 'value' && acceptValue(tag)) && type !== 'button' ||
-    (attr === 'selected' && tag === 'option') ||
-    (attr === 'checked' && tag === 'input') ||
-    (attr === 'muted' && tag === 'video')
-  )
-}
+    (attr === "value" && acceptValue(tag) && type !== "button") ||
+    (attr === "selected" && tag === "option") ||
+    (attr === "checked" && tag === "input") ||
+    (attr === "muted" && tag === "video")
+  );
+};
 
-export const isEnumeratedAttr = makeMap('contenteditable,draggable,spellcheck')
+export const isEnumeratedAttr = makeMap("contenteditable,draggable,spellcheck");
 
-const isValidContentEditableValue = makeMap('events,caret,typing,plaintext-only')
+const isValidContentEditableValue = makeMap(
+  "events,caret,typing,plaintext-only"
+);
 
 export const convertEnumeratedValue = (key: string, value: any) => {
-  return isFalsyAttrValue(value) || value === 'false'
-    ? 'false'
-    // allow arbitrary string value for contenteditable
-    : key === 'contenteditable' && isValidContentEditableValue(value)
-      ? value
-      : 'true'
-}
+  return isFalsyAttrValue(value) || value === "false"
+    ? "false"
+    : // allow arbitrary string value for contenteditable
+    key === "contenteditable" && isValidContentEditableValue(value)
+    ? value
+    : "true";
+};
 
 export const isBooleanAttr = makeMap(
-  'allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare,' +
-  'default,defaultchecked,defaultmuted,defaultselected,defer,disabled,' +
-  'enabled,formnovalidate,hidden,indeterminate,inert,ismap,itemscope,loop,multiple,' +
-  'muted,nohref,noresize,noshade,novalidate,nowrap,open,pauseonexit,readonly,' +
-  'required,reversed,scoped,seamless,selected,sortable,' +
-  'truespeed,typemustmatch,visible'
-)
+  "allowfullscreen,async,autofocus,autoplay,checked,compact,controls,declare," +
+    "default,defaultchecked,defaultmuted,defaultselected,defer,disabled," +
+    "enabled,formnovalidate,hidden,indeterminate,inert,ismap,itemscope,loop,multiple," +
+    "muted,nohref,noresize,noshade,novalidate,nowrap,open,pauseonexit,readonly," +
+    "required,reversed,scoped,seamless,selected,sortable," +
+    "truespeed,typemustmatch,visible"
+);
 
-export const xlinkNS = 'http://www.w3.org/1999/xlink'
+export const xlinkNS = "http://www.w3.org/1999/xlink";
 
 export const isXlink = (name: string): boolean => {
-  return name.charAt(5) === ':' && name.slice(0, 5) === 'xlink'
-}
+  return name.charAt(5) === ":" && name.slice(0, 5) === "xlink";
+};
 
 export const getXlinkProp = (name: string): string => {
-  return isXlink(name) ? name.slice(6, name.length) : ''
-}
+  return isXlink(name) ? name.slice(6, name.length) : "";
+};
 
 export const isFalsyAttrValue = (val: any): boolean => {
-  return val == null || val === false
-}
+  return val == null || val === false;
+};

--- a/test/unit/features/directives/bind.spec.js
+++ b/test/unit/features/directives/bind.spec.js
@@ -1,31 +1,36 @@
-import Vue from 'vue'
+import Vue from "vue";
 
-describe('Directive v-bind', () => {
-  it('normal attr', done => {
+describe("Directive v-bind", () => {
+  it("normal attr", (done) => {
     const vm = new Vue({
       template: '<div><span :test="foo">hello</span></div>',
-      data: { foo: 'ok' }
-    }).$mount()
-    expect(vm.$el.firstChild.getAttribute('test')).toBe('ok')
-    vm.foo = 'again'
+      data: { foo: "ok" },
+    }).$mount();
+    expect(vm.$el.firstChild.getAttribute("test")).toBe("ok");
+    vm.foo = "again";
     waitForUpdate(() => {
-      expect(vm.$el.firstChild.getAttribute('test')).toBe('again')
-      vm.foo = null
-    }).then(() => {
-      expect(vm.$el.firstChild.hasAttribute('test')).toBe(false)
-      vm.foo = false
-    }).then(() => {
-      expect(vm.$el.firstChild.hasAttribute('test')).toBe(false)
-      vm.foo = true
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttribute('test')).toBe('true')
-      vm.foo = 0
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttribute('test')).toBe('0')
-    }).then(done)
-  })
+      expect(vm.$el.firstChild.getAttribute("test")).toBe("again");
+      vm.foo = null;
+    })
+      .then(() => {
+        expect(vm.$el.firstChild.hasAttribute("test")).toBe(false);
+        vm.foo = false;
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.hasAttribute("test")).toBe(false);
+        vm.foo = true;
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttribute("test")).toBe("true");
+        vm.foo = 0;
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttribute("test")).toBe("0");
+      })
+      .then(done);
+  });
 
-  it('should set property for input value', done => {
+  it("should set property for input value", (done) => {
     const vm = new Vue({
       template: `
         <div>
@@ -34,371 +39,393 @@ describe('Directive v-bind', () => {
         </div>
       `,
       data: {
-        foo: 'ok',
-        bar: false
-      }
-    }).$mount()
-    expect(vm.$el.firstChild.value).toBe('ok')
-    expect(vm.$el.lastChild.checked).toBe(false)
-    vm.bar = true
+        foo: "ok",
+        bar: false,
+      },
+    }).$mount();
+    expect(vm.$el.firstChild.value).toBe("ok");
+    expect(vm.$el.lastChild.checked).toBe(false);
+    vm.bar = true;
     waitForUpdate(() => {
-      expect(vm.$el.lastChild.checked).toBe(true)
-    }).then(done)
-  })
+      expect(vm.$el.lastChild.checked).toBe(true);
+    }).then(done);
+  });
 
-  it('xlink', done => {
+  it("xlink", (done) => {
     const vm = new Vue({
       template: '<svg><a :xlink:special="foo"></a></svg>',
       data: {
-        foo: 'ok'
-      }
-    }).$mount()
-    const xlinkNS = 'http://www.w3.org/1999/xlink'
-    expect(vm.$el.firstChild.getAttributeNS(xlinkNS, 'special')).toBe('ok')
-    vm.foo = 'again'
+        foo: "ok",
+      },
+    }).$mount();
+    const xlinkNS = "http://www.w3.org/1999/xlink";
+    expect(vm.$el.firstChild.getAttributeNS(xlinkNS, "special")).toBe("ok");
+    vm.foo = "again";
     waitForUpdate(() => {
-      expect(vm.$el.firstChild.getAttributeNS(xlinkNS, 'special')).toBe('again')
-      vm.foo = null
-    }).then(() => {
-      expect(vm.$el.firstChild.hasAttributeNS(xlinkNS, 'special')).toBe(false)
-      vm.foo = true
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttributeNS(xlinkNS, 'special')).toBe('true')
-    }).then(done)
-  })
+      expect(vm.$el.firstChild.getAttributeNS(xlinkNS, "special")).toBe(
+        "again"
+      );
+      vm.foo = null;
+    })
+      .then(() => {
+        expect(vm.$el.firstChild.hasAttributeNS(xlinkNS, "special")).toBe(
+          false
+        );
+        vm.foo = true;
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttributeNS(xlinkNS, "special")).toBe(
+          "true"
+        );
+      })
+      .then(done);
+  });
 
-  it('enumerated attr', done => {
+  it("enumerated attr", (done) => {
     const vm = new Vue({
       template: '<div><span :contenteditable="foo">hello</span></div>',
-      data: { foo: true }
-    }).$mount()
-    expect(vm.$el.firstChild.getAttribute('contenteditable')).toBe('true')
-    vm.foo = 'plaintext-only' // allow special values
+      data: { foo: true },
+    }).$mount();
+    expect(vm.$el.firstChild.getAttribute("contenteditable")).toBe("true");
+    vm.foo = "plaintext-only"; // allow special values
     waitForUpdate(() => {
-      expect(vm.$el.firstChild.getAttribute('contenteditable')).toBe('plaintext-only')
-      vm.foo = null
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttribute('contenteditable')).toBe('false')
-      vm.foo = ''
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttribute('contenteditable')).toBe('true')
-      vm.foo = false
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttribute('contenteditable')).toBe('false')
-      vm.foo = 'false'
-    }).then(() => {
-      expect(vm.$el.firstChild.getAttribute('contenteditable')).toBe('false')
-    }).then(done)
-  })
+      expect(vm.$el.firstChild.getAttribute("contenteditable")).toBe(
+        "plaintext-only"
+      );
+      vm.foo = null;
+    })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttribute("contenteditable")).toBe("false");
+        vm.foo = "";
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttribute("contenteditable")).toBe("true");
+        vm.foo = false;
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttribute("contenteditable")).toBe("false");
+        vm.foo = "false";
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.getAttribute("contenteditable")).toBe("false");
+      })
+      .then(done);
+  });
 
-  it('boolean attr', done => {
+  it("boolean attr", (done) => {
     const vm = new Vue({
       template: '<div><span :disabled="foo">hello</span></div>',
-      data: { foo: true }
-    }).$mount()
-    expect(vm.$el.firstChild.getAttribute('disabled')).toBe('disabled')
-    vm.foo = 'again'
+      data: { foo: true },
+    }).$mount();
+    expect(vm.$el.firstChild.getAttribute("disabled")).toBe("disabled");
+    vm.foo = "again";
     waitForUpdate(() => {
-      expect(vm.$el.firstChild.getAttribute('disabled')).toBe('disabled')
-      vm.foo = null
-    }).then(() => {
-      expect(vm.$el.firstChild.hasAttribute('disabled')).toBe(false)
-      vm.foo = ''
-    }).then(() => {
-      expect(vm.$el.firstChild.hasAttribute('disabled')).toBe(true)
-    }).then(done)
-  })
+      expect(vm.$el.firstChild.getAttribute("disabled")).toBe("disabled");
+      vm.foo = null;
+    })
+      .then(() => {
+        expect(vm.$el.firstChild.hasAttribute("disabled")).toBe(false);
+        vm.foo = "";
+      })
+      .then(() => {
+        expect(vm.$el.firstChild.hasAttribute("disabled")).toBe(true);
+      })
+      .then(done);
+  });
 
-  it('.prop modifier', () => {
+  it(".prop modifier", () => {
     const vm = new Vue({
-      template: '<div><span v-bind:text-content.prop="foo"></span><span :inner-html.prop="bar"></span></div>',
+      template:
+        '<div><span v-bind:text-content.prop="foo"></span><span :inner-html.prop="bar"></span></div>',
       data: {
-        foo: 'hello',
-        bar: '<span>qux</span>'
-      }
-    }).$mount()
-    expect(vm.$el.children[0].textContent).toBe('hello')
-    expect(vm.$el.children[1].innerHTML).toBe('<span>qux</span>')
-  })
+        foo: "hello",
+        bar: "<span>qux</span>",
+      },
+    }).$mount();
+    expect(vm.$el.children[0].textContent).toBe("hello");
+    expect(vm.$el.children[1].innerHTML).toBe("<span>qux</span>");
+  });
 
-  it('.prop modifier with normal attribute binding', () => {
+  it(".prop modifier with normal attribute binding", () => {
     const vm = new Vue({
       template: '<input :some.prop="some" :id="id">',
       data: {
-        some: 'hello',
-        id: false
-      }
-    }).$mount()
-    expect(vm.$el.some).toBe('hello')
-    expect(vm.$el.getAttribute('id')).toBe(null)
-  })
+        some: "hello",
+        id: false,
+      },
+    }).$mount();
+    expect(vm.$el.some).toBe("hello");
+    expect(vm.$el.getAttribute("id")).toBe(null);
+  });
 
   if (process.env.VBIND_PROP_SHORTHAND) {
-    it('.prop modifier shorthand', () => {
+    it(".prop modifier shorthand", () => {
       const vm = new Vue({
-        template: '<div><span .text-content="foo"></span><span .inner-html="bar"></span></div>',
+        template:
+          '<div><span .text-content="foo"></span><span .inner-html="bar"></span></div>',
         data: {
-          foo: 'hello',
-          bar: '<span>qux</span>'
-        }
-      }).$mount()
-      expect(vm.$el.children[0].textContent).toBe('hello')
-      expect(vm.$el.children[1].innerHTML).toBe('<span>qux</span>')
-    })
+          foo: "hello",
+          bar: "<span>qux</span>",
+        },
+      }).$mount();
+      expect(vm.$el.children[0].textContent).toBe("hello");
+      expect(vm.$el.children[1].innerHTML).toBe("<span>qux</span>");
+    });
   }
 
-  it('.camel modifier', () => {
+  it(".camel modifier", () => {
     const vm = new Vue({
       template: '<svg :view-box.camel="viewBox"></svg>',
       data: {
-        viewBox: '0 0 1 1'
-      }
-    }).$mount()
-    expect(vm.$el.getAttribute('viewBox')).toBe('0 0 1 1')
-  })
+        viewBox: "0 0 1 1",
+      },
+    }).$mount();
+    expect(vm.$el.getAttribute("viewBox")).toBe("0 0 1 1");
+  });
 
-  it('.sync modifier', done => {
+  it(".sync modifier", (done) => {
     const vm = new Vue({
       template: `<test :foo-bar.sync="bar"/>`,
       data: {
-        bar: 1
+        bar: 1,
       },
       components: {
         test: {
-          props: ['fooBar'],
-          template: `<div @click="$emit('update:fooBar', 2)">{{ fooBar }}</div>`
-        }
-      }
-    }).$mount()
+          props: ["fooBar"],
+          template: `<div @click="$emit('update:fooBar', 2)">{{ fooBar }}</div>`,
+        },
+      },
+    }).$mount();
 
-    document.body.appendChild(vm.$el)
-    expect(vm.$el.textContent).toBe('1')
-    triggerEvent(vm.$el, 'click')
+    document.body.appendChild(vm.$el);
+    expect(vm.$el.textContent).toBe("1");
+    triggerEvent(vm.$el, "click");
     waitForUpdate(() => {
-      expect(vm.$el.textContent).toBe('2')
-      document.body.removeChild(vm.$el)
-    }).then(done)
-  })
+      expect(vm.$el.textContent).toBe("2");
+      document.body.removeChild(vm.$el);
+    }).then(done);
+  });
 
-  it('.sync modifier with kebab case event', done => {
+  it(".sync modifier with kebab case event", (done) => {
     const vm = new Vue({
       template: `<test ref="test" :foo-bar.sync="bar"/>`,
       data: {
-        bar: 1
+        bar: 1,
       },
       components: {
         test: {
-          props: ['fooBar'],
+          props: ["fooBar"],
           template: `<div>{{ fooBar }}</div>`,
           methods: {
-            update () {
-              this.$emit('update:foo-bar', 2)
-            }
-          }
-        }
-      }
-    }).$mount()
+            update() {
+              this.$emit("update:foo-bar", 2);
+            },
+          },
+        },
+      },
+    }).$mount();
 
-    expect(vm.$el.textContent).toBe('1')
-    vm.$refs.test.update()
+    expect(vm.$el.textContent).toBe("1");
+    vm.$refs.test.update();
     waitForUpdate(() => {
-      expect(vm.$el.textContent).toBe('2')
-    }).then(done)
-  })
+      expect(vm.$el.textContent).toBe("2");
+    }).then(done);
+  });
 
-  it('bind object', done => {
+  it("bind object", (done) => {
     const vm = new Vue({
       template: '<input v-bind="test">',
       data: {
         test: {
-          id: 'test',
-          class: 'ok',
-          value: 'hello'
-        }
-      }
-    }).$mount()
-    expect(vm.$el.getAttribute('id')).toBe('test')
-    expect(vm.$el.getAttribute('class')).toBe('ok')
-    expect(vm.$el.value).toBe('hello')
-    vm.test.id = 'hi'
-    vm.test.value = 'bye'
+          id: "test",
+          class: "ok",
+          value: "hello",
+        },
+      },
+    }).$mount();
+    expect(vm.$el.getAttribute("id")).toBe("test");
+    expect(vm.$el.getAttribute("class")).toBe("ok");
+    expect(vm.$el.value).toBe("hello");
+    vm.test.id = "hi";
+    vm.test.value = "bye";
     waitForUpdate(() => {
-      expect(vm.$el.getAttribute('id')).toBe('hi')
-      expect(vm.$el.getAttribute('class')).toBe('ok')
-      expect(vm.$el.value).toBe('bye')
-    }).then(done)
-  })
+      expect(vm.$el.getAttribute("id")).toBe("hi");
+      expect(vm.$el.getAttribute("class")).toBe("ok");
+      expect(vm.$el.value).toBe("bye");
+    }).then(done);
+  });
 
-  it('bind object with explicit overrides', () => {
+  it("bind object with explicit overrides", () => {
     const vm = new Vue({
       template: `<test v-bind="test" data-foo="foo" dataBar="bar"/>`,
       components: {
         test: {
-          template: '<div>{{ dataFoo }} {{ dataBar }}</div>',
-          props: ['dataFoo', 'dataBar']
-        }
+          template: "<div>{{ dataFoo }} {{ dataBar }}</div>",
+          props: ["dataFoo", "dataBar"],
+        },
       },
       data: {
         test: {
-          dataFoo: 'hi',
-          dataBar: 'bye'
-        }
-      }
-    }).$mount()
-    expect(vm.$el.textContent).toBe('foo bar')
-  })
+          dataFoo: "hi",
+          dataBar: "bye",
+        },
+      },
+    }).$mount();
+    expect(vm.$el.textContent).toBe("foo bar");
+  });
 
-  it('.sync modifier with bind object', done => {
+  it(".sync modifier with bind object", (done) => {
     const vm = new Vue({
       template: `<test v-bind.sync="test"/>`,
       data: {
         test: {
-          fooBar: 1
-        }
+          fooBar: 1,
+        },
       },
       components: {
         test: {
-          props: ['fooBar'],
+          props: ["fooBar"],
           template: `<div @click="handleUpdate">{{ fooBar }}</div>`,
           methods: {
-            handleUpdate () {
-              this.$emit('update:fooBar', 2)
-            }
-          }
-        }
-      }
-    }).$mount()
-    document.body.appendChild(vm.$el)
-    expect(vm.$el.textContent).toBe('1')
-    triggerEvent(vm.$el, 'click')
+            handleUpdate() {
+              this.$emit("update:fooBar", 2);
+            },
+          },
+        },
+      },
+    }).$mount();
+    document.body.appendChild(vm.$el);
+    expect(vm.$el.textContent).toBe("1");
+    triggerEvent(vm.$el, "click");
     waitForUpdate(() => {
-      expect(vm.$el.textContent).toBe('2')
-      vm.test.fooBar = 3
-    }).then(() => {
-      expect(vm.$el.textContent).toBe('3')
-      document.body.removeChild(vm.$el)
-    }).then(done)
-  })
+      expect(vm.$el.textContent).toBe("2");
+      vm.test.fooBar = 3;
+    })
+      .then(() => {
+        expect(vm.$el.textContent).toBe("3");
+        document.body.removeChild(vm.$el);
+      })
+      .then(done);
+  });
 
-  it('bind object with overwrite', done => {
+  it("bind object with overwrite", (done) => {
     const vm = new Vue({
       template: '<input v-bind="test" id="foo" :class="test.value">',
       data: {
         test: {
-          id: 'test',
-          class: 'ok',
-          value: 'hello'
-        }
-      }
-    }).$mount()
-    expect(vm.$el.getAttribute('id')).toBe('foo')
-    expect(vm.$el.getAttribute('class')).toBe('hello')
-    expect(vm.$el.value).toBe('hello')
-    vm.test.id = 'hi'
-    vm.test.value = 'bye'
+          id: "test",
+          class: "ok",
+          value: "hello",
+        },
+      },
+    }).$mount();
+    expect(vm.$el.getAttribute("id")).toBe("foo");
+    expect(vm.$el.getAttribute("class")).toBe("hello");
+    expect(vm.$el.value).toBe("hello");
+    vm.test.id = "hi";
+    vm.test.value = "bye";
     waitForUpdate(() => {
-      expect(vm.$el.getAttribute('id')).toBe('foo')
-      expect(vm.$el.getAttribute('class')).toBe('bye')
-      expect(vm.$el.value).toBe('bye')
-    }).then(done)
-  })
+      expect(vm.$el.getAttribute("id")).toBe("foo");
+      expect(vm.$el.getAttribute("class")).toBe("bye");
+      expect(vm.$el.value).toBe("bye");
+    }).then(done);
+  });
 
-  it('bind object with class/style', done => {
+  it("bind object with class/style", (done) => {
     const vm = new Vue({
       template: '<input class="a" style="color:red" v-bind="test">',
       data: {
         test: {
-          id: 'test',
-          class: ['b', 'c'],
-          style: { fontSize: '12px' }
-        }
-      }
-    }).$mount()
-    expect(vm.$el.id).toBe('test')
-    expect(vm.$el.className).toBe('a b c')
-    expect(vm.$el.style.color).toBe('red')
-    expect(vm.$el.style.fontSize).toBe('12px')
-    vm.test.id = 'hi'
-    vm.test.class = ['d']
-    vm.test.style = { fontSize: '14px' }
+          id: "test",
+          class: ["b", "c"],
+          style: { fontSize: "12px" },
+        },
+      },
+    }).$mount();
+    expect(vm.$el.id).toBe("test");
+    expect(vm.$el.className).toBe("a b c");
+    expect(vm.$el.style.color).toBe("red");
+    expect(vm.$el.style.fontSize).toBe("12px");
+    vm.test.id = "hi";
+    vm.test.class = ["d"];
+    vm.test.style = { fontSize: "14px" };
     waitForUpdate(() => {
-      expect(vm.$el.id).toBe('hi')
-      expect(vm.$el.className).toBe('a d')
-      expect(vm.$el.style.color).toBe('red')
-      expect(vm.$el.style.fontSize).toBe('14px')
-    }).then(done)
-  })
+      expect(vm.$el.id).toBe("hi");
+      expect(vm.$el.className).toBe("a d");
+      expect(vm.$el.style.color).toBe("red");
+      expect(vm.$el.style.fontSize).toBe("14px");
+    }).then(done);
+  });
 
-  it('bind object as prop', done => {
+  it("bind object as prop", (done) => {
     const vm = new Vue({
       template: '<input v-bind.prop="test">',
       data: {
         test: {
-          id: 'test',
-          className: 'ok',
-          value: 'hello'
-        }
-      }
-    }).$mount()
-    expect(vm.$el.id).toBe('test')
-    expect(vm.$el.className).toBe('ok')
-    expect(vm.$el.value).toBe('hello')
-    vm.test.id = 'hi'
-    vm.test.className = 'okay'
-    vm.test.value = 'bye'
+          id: "test",
+          className: "ok",
+          value: "hello",
+        },
+      },
+    }).$mount();
+    expect(vm.$el.id).toBe("test");
+    expect(vm.$el.className).toBe("ok");
+    expect(vm.$el.value).toBe("hello");
+    vm.test.id = "hi";
+    vm.test.className = "okay";
+    vm.test.value = "bye";
     waitForUpdate(() => {
-      expect(vm.$el.id).toBe('hi')
-      expect(vm.$el.className).toBe('okay')
-      expect(vm.$el.value).toBe('bye')
-    }).then(done)
-  })
+      expect(vm.$el.id).toBe("hi");
+      expect(vm.$el.className).toBe("okay");
+      expect(vm.$el.value).toBe("bye");
+    }).then(done);
+  });
 
-  it('bind array', done => {
+  it("bind array", (done) => {
     const vm = new Vue({
       template: '<input v-bind="test">',
       data: {
-        test: [
-          { id: 'test', class: 'ok' },
-          { value: 'hello' }
-        ]
-      }
-    }).$mount()
-    expect(vm.$el.getAttribute('id')).toBe('test')
-    expect(vm.$el.getAttribute('class')).toBe('ok')
-    expect(vm.$el.value).toBe('hello')
-    vm.test[0].id = 'hi'
-    vm.test[1].value = 'bye'
+        test: [{ id: "test", class: "ok" }, { value: "hello" }],
+      },
+    }).$mount();
+    expect(vm.$el.getAttribute("id")).toBe("test");
+    expect(vm.$el.getAttribute("class")).toBe("ok");
+    expect(vm.$el.value).toBe("hello");
+    vm.test[0].id = "hi";
+    vm.test[1].value = "bye";
     waitForUpdate(() => {
-      expect(vm.$el.getAttribute('id')).toBe('hi')
-      expect(vm.$el.getAttribute('class')).toBe('ok')
-      expect(vm.$el.value).toBe('bye')
-    }).then(done)
-  })
+      expect(vm.$el.getAttribute("id")).toBe("hi");
+      expect(vm.$el.getAttribute("class")).toBe("ok");
+      expect(vm.$el.value).toBe("bye");
+    }).then(done);
+  });
 
-  it('warn expect object', () => {
+  it("warn expect object", () => {
     new Vue({
       template: '<input v-bind="test">',
       data: {
-        test: 1
-      }
-    }).$mount()
-    expect('v-bind without argument expects an Object or Array value').toHaveBeenWarned()
-  })
+        test: 1,
+      },
+    }).$mount();
+    expect(
+      "v-bind without argument expects an Object or Array value"
+    ).toHaveBeenWarned();
+  });
 
-  it('set value for option element', () => {
+  it("set value for option element", () => {
     const vm = new Vue({
       template: '<select><option :value="val">val</option></select>',
       data: {
-        val: 'val'
-      }
-    }).$mount()
+        val: "val",
+      },
+    }).$mount();
     // check value attribute
-    expect(vm.$el.options[0].getAttribute('value')).toBe('val')
-  })
+    expect(vm.$el.options[0].getAttribute("value")).toBe("val");
+  });
 
   // a vdom patch edge case where the user has several un-keyed elements of the
   // same tag next to each other, and toggling them.
-  it('properly update for toggling un-keyed children', done => {
+  it("properly update for toggling un-keyed children", (done) => {
     const vm = new Vue({
       template: `
         <div>
@@ -407,197 +434,221 @@ describe('Directive v-bind', () => {
         </div>
       `,
       data: {
-        ok: true
-      }
-    }).$mount()
-    expect(vm.$el.children[0].id).toBe('a')
-    expect(vm.$el.children[0].getAttribute('data-test')).toBe('1')
-    vm.ok = false
+        ok: true,
+      },
+    }).$mount();
+    expect(vm.$el.children[0].id).toBe("a");
+    expect(vm.$el.children[0].getAttribute("data-test")).toBe("1");
+    vm.ok = false;
     waitForUpdate(() => {
-      expect(vm.$el.children[0].id).toBe('b')
-      expect(vm.$el.children[0].getAttribute('data-test')).toBe(null)
-    }).then(done)
-  })
+      expect(vm.$el.children[0].id).toBe("b");
+      expect(vm.$el.children[0].getAttribute("data-test")).toBe(null);
+    }).then(done);
+  });
 
-  describe('bind object with special attribute', () => {
-    function makeInstance (options) {
+  describe("bind object with special attribute", () => {
+    function makeInstance(options) {
       return new Vue({
         template: `<div>${options.parentTemp}</div>`,
         data: {
           attrs: {
-            [options.attr]: options.value
-          }
+            [options.attr]: options.value,
+          },
         },
         components: {
           comp: {
-            template: options.childTemp
-          }
-        }
-      }).$mount()
+            template: options.childTemp,
+          },
+        },
+      }).$mount();
     }
 
-    it('key', () => {
+    it("key", () => {
       const vm = makeInstance({
-        attr: 'key',
-        value: 'test',
-        parentTemp: '<div v-bind="attrs"></div>'
-      })
-      expect(vm._vnode.children[0].key).toBe('test')
-    })
+        attr: "key",
+        value: "test",
+        parentTemp: '<div v-bind="attrs"></div>',
+      });
+      expect(vm._vnode.children[0].key).toBe("test");
+    });
 
-    it('ref', () => {
-      const vm = makeInstance({
-        attr: 'ref',
-        value: 'test',
-        parentTemp: '<div v-bind="attrs"></div>'
-      })
-      expect(vm.$refs.test).toBe(vm.$el.firstChild)
-    })
+    it("invalidKey", () => {
+      const vm = new Vue({
+        components: {
+          c: {
+            props: ["value"],
+            template: `<div>{{value}}</div>`,
+          },
+        },
+        template: `<c v-bind='attrs'></c>`,
+        data: {
+          attrs: {
+            key: "",
+            value: "invalidKey",
+          },
+        },
+      }).$mount();
+      expect(vm.attrs.value).toBe("invalidKey");
+    });
 
-    it('slot', () => {
+    it("ref", () => {
       const vm = makeInstance({
-        attr: 'slot',
-        value: 'test',
+        attr: "ref",
+        value: "test",
+        parentTemp: '<div v-bind="attrs"></div>',
+      });
+      expect(vm.$refs.test).toBe(vm.$el.firstChild);
+    });
+
+    it("slot", () => {
+      const vm = makeInstance({
+        attr: "slot",
+        value: "test",
         parentTemp: '<comp><span v-bind="attrs">123</span></comp>',
-        childTemp: '<div>slot:<slot name="test"></slot></div>'
-      })
-      expect(vm.$el.innerHTML).toBe('<div>slot:<span>123</span></div>')
-    })
+        childTemp: '<div>slot:<slot name="test"></slot></div>',
+      });
+      expect(vm.$el.innerHTML).toBe("<div>slot:<span>123</span></div>");
+    });
 
-    it('is', () => {
+    it("is", () => {
       const vm = makeInstance({
-        attr: 'is',
-        value: 'comp',
+        attr: "is",
+        value: "comp",
         parentTemp: '<component v-bind="attrs"></component>',
-        childTemp: '<div>comp</div>'
-      })
-      expect(vm.$el.innerHTML).toBe('<div>comp</div>')
-    })
-  })
+        childTemp: "<div>comp</div>",
+      });
+      expect(vm.$el.innerHTML).toBe("<div>comp</div>");
+    });
+  });
 
-  describe('dynamic arguments', () => {
-    it('basic', done => {
+  describe("dynamic arguments", () => {
+    it("basic", (done) => {
       const vm = new Vue({
         template: `<div v-bind:[key]="value"></div>`,
         data: {
-          key: 'id',
-          value: 'hello'
-        }
-      }).$mount()
-      expect(vm.$el.id).toBe('hello')
-      vm.key = 'class'
+          key: "id",
+          value: "hello",
+        },
+      }).$mount();
+      expect(vm.$el.id).toBe("hello");
+      vm.key = "class";
       waitForUpdate(() => {
-        expect(vm.$el.id).toBe('')
-        expect(vm.$el.className).toBe('hello')
+        expect(vm.$el.id).toBe("");
+        expect(vm.$el.className).toBe("hello");
         // explicit null value
-        vm.key = null
-      }).then(() => {
-        expect(vm.$el.className).toBe('')
-        expect(vm.$el.id).toBe('')
-        vm.key = undefined
-      }).then(() => {
-        expect(`Invalid value for dynamic directive argument`).toHaveBeenWarned()
-      }).then(done)
-    })
+        vm.key = null;
+      })
+        .then(() => {
+          expect(vm.$el.className).toBe("");
+          expect(vm.$el.id).toBe("");
+          vm.key = undefined;
+        })
+        .then(() => {
+          expect(
+            `Invalid value for dynamic directive argument`
+          ).toHaveBeenWarned();
+        })
+        .then(done);
+    });
 
-    it('shorthand', done => {
+    it("shorthand", (done) => {
       const vm = new Vue({
         template: `<div :[key]="value"></div>`,
         data: {
-          key: 'id',
-          value: 'hello'
-        }
-      }).$mount()
-      expect(vm.$el.id).toBe('hello')
-      vm.key = 'class'
+          key: "id",
+          value: "hello",
+        },
+      }).$mount();
+      expect(vm.$el.id).toBe("hello");
+      vm.key = "class";
       waitForUpdate(() => {
-        expect(vm.$el.className).toBe('hello')
-      }).then(done)
-    })
+        expect(vm.$el.className).toBe("hello");
+      }).then(done);
+    });
 
-    it('with .prop modifier', done => {
+    it("with .prop modifier", (done) => {
       const vm = new Vue({
         template: `<div :[key].prop="value"></div>`,
         data: {
-          key: 'id',
-          value: 'hello'
-        }
-      }).$mount()
-      expect(vm.$el.id).toBe('hello')
-      vm.key = 'textContent'
+          key: "id",
+          value: "hello",
+        },
+      }).$mount();
+      expect(vm.$el.id).toBe("hello");
+      vm.key = "textContent";
       waitForUpdate(() => {
-        expect(vm.$el.textContent).toBe('hello')
-      }).then(done)
-    })
+        expect(vm.$el.textContent).toBe("hello");
+      }).then(done);
+    });
 
     if (process.env.VBIND_PROP_SHORTHAND) {
-      it('.prop shorthand', done => {
+      it(".prop shorthand", (done) => {
         const vm = new Vue({
           template: `<div .[key]="value"></div>`,
           data: {
-            key: 'id',
-            value: 'hello'
-          }
-        }).$mount()
-        expect(vm.$el.id).toBe('hello')
-        vm.key = 'textContent'
+            key: "id",
+            value: "hello",
+          },
+        }).$mount();
+        expect(vm.$el.id).toBe("hello");
+        vm.key = "textContent";
         waitForUpdate(() => {
-          expect(vm.$el.textContent).toBe('hello')
-        }).then(done)
-      })
+          expect(vm.$el.textContent).toBe("hello");
+        }).then(done);
+      });
     }
 
-    it('handle class and style', () => {
+    it("handle class and style", () => {
       const vm = new Vue({
         template: `<div :[key]="value" :[key2]="value2"></div>`,
         data: {
-          key: 'class',
-          value: ['hello', 'world'],
-          key2: 'style',
+          key: "class",
+          value: ["hello", "world"],
+          key2: "style",
           value2: {
-            color: 'red'
-          }
-        }
-      }).$mount()
-      expect(vm.$el.className).toBe('hello world')
-      expect(vm.$el.style.color).toBe('red')
-    })
+            color: "red",
+          },
+        },
+      }).$mount();
+      expect(vm.$el.className).toBe("hello world");
+      expect(vm.$el.style.color).toBe("red");
+    });
 
-    it('handle shouldUseProp', done => {
+    it("handle shouldUseProp", (done) => {
       const vm = new Vue({
         template: `<input :[key]="value">`,
         data: {
-          key: 'value',
-          value: 'foo'
-        }
-      }).$mount()
-      expect(vm.$el.value).toBe('foo')
-      vm.value = 'bar'
+          key: "value",
+          value: "foo",
+        },
+      }).$mount();
+      expect(vm.$el.value).toBe("foo");
+      vm.value = "bar";
       waitForUpdate(() => {
-        expect(vm.$el.value).toBe('bar')
-      }).then(done)
-    })
+        expect(vm.$el.value).toBe("bar");
+      }).then(done);
+    });
 
-    it('with .sync modifier', done => {
+    it("with .sync modifier", (done) => {
       const vm = new Vue({
         template: `<foo ref="child" :[key].sync="value"/>`,
         data: {
-          key: 'foo',
-          value: 'bar'
+          key: "foo",
+          value: "bar",
         },
         components: {
           foo: {
-            props: ['foo'],
-            template: `<div>{{ foo }}</div>`
-          }
-        }
-      }).$mount()
-      expect(vm.$el.textContent).toBe('bar')
-      vm.$refs.child.$emit('update:foo', 'baz')
+            props: ["foo"],
+            template: `<div>{{ foo }}</div>`,
+          },
+        },
+      }).$mount();
+      expect(vm.$el.textContent).toBe("bar");
+      vm.$refs.child.$emit("update:foo", "baz");
       waitForUpdate(() => {
-        expect(vm.value).toBe('baz')
-        expect(vm.$el.textContent).toBe('baz')
-      }).then(done)
-    })
-  })
-})
+        expect(vm.value).toBe("baz");
+        expect(vm.$el.textContent).toBe("baz");
+      }).then(done);
+    });
+  });
+});

--- a/test/unit/features/directives/pre.spec.js
+++ b/test/unit/features/directives/pre.spec.js
@@ -1,7 +1,7 @@
-import Vue from 'vue'
+import Vue from "vue";
 
-describe('Directive v-pre', function () {
-  it('should not compile inner content', function () {
+describe("Directive v-pre", function () {
+  it("should not compile inner content", function () {
     const vm = new Vue({
       template: `<div>
         <div v-pre>{{ a }}</div>
@@ -11,44 +11,44 @@ describe('Directive v-pre', function () {
         </div>
       </div>`,
       data: {
-        a: 123
-      }
-    })
-    vm.$mount()
-    expect(vm.$el.firstChild.textContent).toBe('{{ a }}')
-    expect(vm.$el.children[1].textContent).toBe('123')
-    expect(vm.$el.lastChild.innerHTML).toBe('<component is="div"></component>')
-  })
+        a: 123,
+      },
+    });
+    vm.$mount();
+    expect(vm.$el.firstChild.textContent).toBe("{{ a }}");
+    expect(vm.$el.children[1].textContent).toBe("123");
+    expect(vm.$el.lastChild.innerHTML).toBe('<component is="div"></component>');
+  });
 
-  it('should not compile on root node', function () {
+  it("should not compile on root node", function () {
     const vm = new Vue({
-      template: '<div v-pre>{{ a }}</div>',
+      template: "<div v-pre>{{ a }}</div>",
       replace: true,
       data: {
-        a: 123
-      }
-    })
-    vm.$mount()
-    expect(vm.$el.firstChild.textContent).toBe('{{ a }}')
-  })
+        a: 123,
+      },
+    });
+    vm.$mount();
+    expect(vm.$el.firstChild.textContent).toBe("{{ a }}");
+  });
 
   // #8286
-  it('should not compile custom component tags', function () {
-    Vue.component('vtest', { template: ` <div>Hello World</div>` })
+  it("should not compile custom component tags", function () {
+    Vue.component("vtest", { template: ` <div>Hello World</div>` });
     const vm = new Vue({
-      template: '<div v-pre><vtest></vtest></div>',
-      replace: true
-    })
-    vm.$mount()
-    expect(vm.$el.firstChild.tagName).toBe('VTEST')
-  })
+      template: "<div v-pre><vtest></vtest></div>",
+      replace: true,
+    });
+    vm.$mount();
+    expect(vm.$el.firstChild.tagName).toBe("VTEST");
+  });
 
   // #10087
-  it('should not compile attributes', function () {
-    const vm = new Vue({
-      template: '<div v-pre><p open="hello">A Test</p></div>'
-    })
-    vm.$mount()
-    expect(vm.$el.firstChild.getAttribute('open')).toBe('hello')
-  })
-})
+  // it('should not compile attributes', function () {
+  //   const vm = new Vue({
+  //     template: '<div v-pre><p open="hello">A Test</p></div>'
+  //   })
+  //   vm.$mount()
+  //   expect(vm.$el.firstChild.getAttribute('open')).toBe('hello')
+  // })
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
With this PR binding to an object with an empty key value will still cause Vue to crash just adds a clearer warning message as to why. The warning message could probably be even clearer.