### PR TITLE
chore: exclude trivial refactors from `git blame` results

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# chore: move to typescript
+af9fc2bcff31d5baa413039818a9b3e011deccaf
+# workflow: remove eslint, apply prettier
+72aed6a149b94b5b929fb47370a7a6d4cb7491c5


### PR DESCRIPTION
See https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

Ideally, all style-only-commits should be put on this list.

The "move to typescript" is not trivial by itself, but most of the
additions/deletions are style changes. So I think it's safe and more
reader-friendly to exclude it.

Blame view before the PR:
https://github.com/vuejs/vue/blame/v2.7.0-alpha.4/src/platforms/web/runtime/transition-util.ts
After the PR:
https://github.com/sodatea/vue/blame/chore-better-git-blame/src/platforms/web/runtime/transition-util.ts

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
