### PR TITLE
chore(compiler-sfc): replace `substr` with `slice`

### DIFF
--- a/packages/compiler-sfc/src/templateCompilerModules/srcset.ts
+++ b/packages/compiler-sfc/src/templateCompilerModules/srcset.ts
@@ -38,7 +38,7 @@ function transform(
         }
 
         const imageCandidates: ImageCandidate[] = value
-          .slice(1, value.length - 2)
+          .slice(1, value.length - 1)
           .split(',')
           .map(s => {
             // The attribute value arrives here with all whitespace, except

--- a/packages/compiler-sfc/src/templateCompilerModules/srcset.ts
+++ b/packages/compiler-sfc/src/templateCompilerModules/srcset.ts
@@ -38,7 +38,7 @@ function transform(
         }
 
         const imageCandidates: ImageCandidate[] = value
-          .slice(1, value.length - 1)
+          .slice(1, -1)
           .split(',')
           .map(s => {
             // The attribute value arrives here with all whitespace, except

--- a/packages/compiler-sfc/src/templateCompilerModules/srcset.ts
+++ b/packages/compiler-sfc/src/templateCompilerModules/srcset.ts
@@ -38,7 +38,7 @@ function transform(
         }
 
         const imageCandidates: ImageCandidate[] = value
-          .substr(1, value.length - 2)
+          .slice(1, value.length - 2)
           .split(',')
           .map(s => {
             // The attribute value arrives here with all whitespace, except


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

The `substr` is deprecated. 
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
