### PR TITLE
feat: allow passing directive definition directly to h()

### DIFF
--- a/packages/compiler-sfc/src/compileScript.ts
+++ b/packages/compiler-sfc/src/compileScript.ts
@@ -126,7 +126,12 @@ export function compileScript(
       )
   }
   if (options.babelParserPlugins) plugins.push(...options.babelParserPlugins)
-  if (isTS) plugins.push('typescript', 'decorators-legacy')
+  if (isTS) {
+    plugins.push('typescript')
+    if (plugins.includes('decorators')) {
+      plugins.push('decorators-legacy')
+    }
+  }
 
   if (!scriptSetup) {
     if (!script) {

--- a/src/core/vdom/modules/directives.ts
+++ b/src/core/vdom/modules/directives.ts
@@ -94,7 +94,7 @@ function normalizeDirectives(
     // $flow-disable-line
     return res
   }
-  let i, dir
+  let i: number, dir: VNodeDirective
   for (i = 0; i < dirs.length; i++) {
     dir = dirs[i]
     if (!dir.modifiers) {
@@ -103,7 +103,7 @@ function normalizeDirectives(
     }
     res[getRawDirName(dir)] = dir
     if (vm._setupState && vm._setupState.__sfc) {
-      dir.def = resolveAsset(vm, '_setupState', 'v-' + dir.name)
+      dir.def = dir.def || resolveAsset(vm, '_setupState', 'v-' + dir.name)
     }
     dir.def = dir.def || resolveAsset(vm.$options, 'directives', dir.name, true)
   }

--- a/types/vnode.d.ts
+++ b/types/vnode.d.ts
@@ -1,4 +1,5 @@
 import { Vue } from './vue'
+import { DirectiveFunction, DirectiveOptions } from './options'
 
 export type ScopedSlot = (props: any) => ScopedSlotReturnValue
 type ScopedSlotReturnValue =
@@ -86,4 +87,5 @@ export interface VNodeDirective {
   arg?: string
   oldArg?: string
   modifiers?: { [key: string]: boolean }
+  def?: DirectiveFunction | DirectiveOptions
 }


### PR DESCRIPTION
Components can be rendered without registering them in options.components:
```js
Vue.extend({
  render (h) {
    return h(MyComponent)
  }
})
```
But directives can't:
```js
Vue.extend({
  directives: { MyDirective },
  render (h) {
    return h(MyComponent, {
      directives: [{ name: 'my-directive' }]
    })
  }
})
```
This change allows you to do:
```js
Vue.extend({
  render (h) {
    return h(MyComponent, {
      directives: [{ def: MyDirective }]
    })
  }
})
```
This already mostly works in 2.7 beta, but there is no type definition and it is overwritten in `<script setup>` components
---
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)