### PR TITLE
fix: add missing export (`onBeforeUnmount`) from `vue.runtime.mjs`

### DIFF
--- a/dist/vue.runtime.mjs
+++ b/dist/vue.runtime.mjs
@@ -49,6 +49,7 @@ export const {
   onMounted,
   onBeforeUpdate,
   onUpdated,
+  onBeforeUnmount,
   onUnmounted,
   onErrorCaptured,
   onActivated,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

`onBeforeUnmount` was omitted in `dist/vue.runtime.mjs` - see https://github.com/vuejs/vue/issues/12626#issuecomment-1179171109

resolves https://github.com/nuxt/bridge/issues/393