### PR TITLE
Fix some URLs in warn messages which link to v2 doc site

### DIFF
--- a/examples/todomvc/app.js
+++ b/examples/todomvc/app.js
@@ -55,7 +55,7 @@ var app = new Vue({
   },
 
   // computed properties
-  // https://vuejs.org/guide/computed.html
+  // https://v2.vuejs.org/v2/guide/computed.html
   computed: {
     filteredTodos: function () {
       return filters[this.visibility](this.todos)
@@ -129,7 +129,7 @@ var app = new Vue({
 
   // a custom directive to wait for the DOM to be updated
   // before focusing on the input field.
-  // https://vuejs.org/guide/custom-directive.html
+  // https://v2.vuejs.org/v2/guide/custom-directive.html
   directives: {
     'todo-focus': function (el, binding) {
       if (binding.value) {

--- a/packages/vue-server-renderer/build.dev.js
+++ b/packages/vue-server-renderer/build.dev.js
@@ -5157,7 +5157,7 @@ function genFor (
     state.warn(
       "<" + (el.tag) + " v-for=\"" + alias + " in " + exp + "\">: component lists rendered with " +
       "v-for should have explicit keys. " +
-      "See https://vuejs.org/guide/list.html#key for more info.",
+      "See https://v2.vuejs.org/v2/guide/list.html#Maintaining-State for more info.",
       el.rawAttrsMap['v-for'],
       true /* tip */
     );

--- a/packages/vue-template-compiler/browser.js
+++ b/packages/vue-template-compiler/browser.js
@@ -4444,7 +4444,7 @@
       state.warn(
         "<" + (el.tag) + " v-for=\"" + alias + " in " + exp + "\">: component lists rendered with " +
         "v-for should have explicit keys. " +
-        "See https://vuejs.org/guide/list.html#key for more info.",
+        "See https://v2.vuejs.org/v2/guide/list.html#Maintaining-State for more info.",
         el.rawAttrsMap['v-for'],
         true /* tip */
       );

--- a/packages/weex-template-compiler/build.js
+++ b/packages/weex-template-compiler/build.js
@@ -3489,7 +3489,7 @@ function genFor (
     state.warn(
       "<" + (el.tag) + " v-for=\"" + alias + " in " + exp + "\">: component lists rendered with " +
       "v-for should have explicit keys. " +
-      "See https://vuejs.org/guide/list.html#key for more info.",
+      "See https://v2.vuejs.org/v2/guide/list.html#Maintaining-State for more info.",
       el.rawAttrsMap['v-for'],
       true /* tip */
     );

--- a/packages/weex-vue-framework/factory.js
+++ b/packages/weex-vue-framework/factory.js
@@ -2010,7 +2010,7 @@ if (process.env.NODE_ENV !== 'production') {
       'referenced during render. Make sure that this property is reactive, ' +
       'either in the data option, or for class-based components, by ' +
       'initializing the property. ' +
-      'See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.',
+      'See: https://v2.vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties',
       target
     );
   };
@@ -2020,7 +2020,7 @@ if (process.env.NODE_ENV !== 'production') {
       "Property \"" + key + "\" must be accessed with \"$data." + key + "\" because " +
       'properties starting with "$" or "_" are not proxied in the Vue instance to ' +
       'prevent conflicts with Vue internals. ' +
-      'See: https://vuejs.org/v2/api/#data',
+      'See: https://v2.vuejs.org/v2/api/#data',
       target
     );
   };
@@ -4900,7 +4900,7 @@ function initData (vm) {
     data = {};
     process.env.NODE_ENV !== 'production' && warn(
       'data functions should return an object:\n' +
-      'https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
+      'https://v2.vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
       vm
     );
   }

--- a/src/compiler/codegen/index.js
+++ b/src/compiler/codegen/index.js
@@ -204,7 +204,7 @@ export function genFor (
     state.warn(
       `<${el.tag} v-for="${alias} in ${exp}">: component lists rendered with ` +
       `v-for should have explicit keys. ` +
-      `See https://vuejs.org/guide/list.html#key for more info.`,
+      `See https://v2.vuejs.org/v2/guide/list.html#Maintaining-State for more info.`,
       el.rawAttrsMap['v-for'],
       true /* tip */
     )

--- a/src/core/instance/proxy.js
+++ b/src/core/instance/proxy.js
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
       'referenced during render. Make sure that this property is reactive, ' +
       'either in the data option, or for class-based components, by ' +
       'initializing the property. ' +
-      'See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.',
+      'See: https://v2.vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties',
       target
     )
   }
@@ -29,7 +29,7 @@ if (process.env.NODE_ENV !== 'production') {
       `Property "${key}" must be accessed with "$data.${key}" because ` +
       'properties starting with "$" or "_" are not proxied in the Vue instance to ' +
       'prevent conflicts with Vue internals. ' +
-      'See: https://vuejs.org/v2/api/#data',
+      'See: https://v2.vuejs.org/v2/api/#data',
       target
     )
   }

--- a/src/core/instance/state.js
+++ b/src/core/instance/state.js
@@ -119,7 +119,7 @@ function initData (vm: Component) {
     data = {}
     process.env.NODE_ENV !== 'production' && warn(
       'data functions should return an object:\n' +
-      'https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
+      'https://v2.vuejs.org/v2/guide/components.html#data-Must-Be-a-Function',
       vm
     )
   }

--- a/src/platforms/web/runtime/index.js
+++ b/src/platforms/web/runtime/index.js
@@ -67,7 +67,7 @@ if (inBrowser) {
       console[console.info ? 'info' : 'log'](
         `You are running Vue in development mode.\n` +
         `Make sure to turn on production mode when deploying for production.\n` +
-        `See more tips at https://vuejs.org/guide/deployment.html`
+        `See more tips at https://v2.vuejs.org/v2/guide/deployment.html`
       )
     }
   }, 0)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Some links currently are broken like:

- https://vuejs.org/guide/computed.html (should be https://v2.vuejs.org/v2/guide/computed.html)
- https://vuejs.org/guide/list.html#key (should be https://v2.vuejs.org/v2/guide/list.html#Maintaining-State)

Some links still working. However, for consistency, I also updated them as well.

Thanks.