### PR TITLE
$refs can also contain CreateComponentPublicInstance

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -14,6 +14,7 @@ import { VNode, VNodeData, VNodeChildren, NormalizedScopedSlot } from './vnode'
 import { PluginFunction, PluginObject } from './plugin'
 import { DefineComponent } from './v3-define-component'
 import { nextTick } from './v3-generated'
+import { CreateComponentPublicInstance } from 'v3-component-public-instance'
 
 export interface CreateElement {
   (
@@ -56,7 +57,7 @@ export interface Vue<
   // Vue 2 only or shared
   readonly $el: Element
   readonly $refs: {
-    [key: string]: Vue | Element | (Vue | Element)[] | undefined
+    [key: string]: Vue | Element | (Vue | Element)[] | undefined | CreateComponentPublicInstance
   }
   readonly $slots: { [key: string]: VNode[] | undefined }
   readonly $scopedSlots: { [key: string]: NormalizedScopedSlot | undefined }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -14,7 +14,7 @@ import { VNode, VNodeData, VNodeChildren, NormalizedScopedSlot } from './vnode'
 import { PluginFunction, PluginObject } from './plugin'
 import { DefineComponent } from './v3-define-component'
 import { nextTick } from './v3-generated'
-import { CreateComponentPublicInstance } from 'v3-component-public-instance'
+import { ComponentPublicInstance } from 'v3-component-public-instance'
 
 export interface CreateElement {
   (
@@ -57,7 +57,12 @@ export interface Vue<
   // Vue 2 only or shared
   readonly $el: Element
   readonly $refs: {
-    [key: string]: Vue | Element | (Vue | Element)[] | undefined | CreateComponentPublicInstance
+    [key: string]:
+      | Vue
+      | Element
+      | ComponentPublicInstance
+      | (Vue | Element | ComponentPublicInstance)[]
+      | undefined
   }
   readonly $slots: { [key: string]: VNode[] | undefined }
   readonly $scopedSlots: { [key: string]: NormalizedScopedSlot | undefined }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

`$refs` in Vue's previous instance can also contain references to the new `defineComponent` style components. This fixes an issue where if you are referencing a `defineComponent` component inside a `vue-class-component` it throws errors about mismatching `$refs` type