### PR TITLE
chore(compiler-sfc): remove useless vue-template-es2015-compiler

### DIFF
--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -29,7 +29,6 @@
     "postcss-selector-parser": "^6.0.10",
     "pug": "^3.0.2",
     "sass": "^1.52.3",
-    "stylus": "^0.58.1",
-    "vue-template-es2015-compiler": "^1.9.1"
+    "stylus": "^0.58.1"
   }
 }

--- a/packages/compiler-sfc/src/compileTemplate.ts
+++ b/packages/compiler-sfc/src/compileTemplate.ts
@@ -144,8 +144,7 @@ function actuallyCompile(
       errors
     }
   } else {
-    // transpile code with vue-template-es2015-compiler, which is a forked
-    // version of Buble that applies ES2015 transforms + stripping `with` usage
+    // stripping `with` usage
     let code =
       `var __render__ = ${prefixIdentifiers(
         `function render(${isFunctional ? `_c,_vm` : ``}){${render}\n}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,6 @@ importers:
       sass: ^1.52.3
       source-map: ^0.6.1
       stylus: ^0.58.1
-      vue-template-es2015-compiler: ^1.9.1
     dependencies:
       '@babel/parser': 7.18.4
       postcss: 8.4.14
@@ -138,7 +137,6 @@ importers:
       pug: 3.0.2
       sass: 1.52.3
       stylus: 0.58.1
-      vue-template-es2015-compiler: 1.9.1
 
   packages/server-renderer:
     specifiers:
@@ -6220,10 +6218,6 @@ packages:
   /void-elements/3.1.0:
     resolution: {integrity: sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /vue-template-es2015-compiler/1.9.1:
-    resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
     dev: true
 
   /w3c-hr-time/1.0.2:

--- a/test/unit/features/options/functional.spec.ts
+++ b/test/unit/features/options/functional.spec.ts
@@ -269,7 +269,6 @@ describe('Options functional', () => {
   })
 
   it('should work with render fns compiled from template', done => {
-    // code generated via vue-template-es2015-compiler
     const render = function (_h, _vm) {
       const _c = _vm._c
       return _c(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
