### PR TITLE
fix(types): Make SetupBindings optional (fix #12726, #12717)

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -100,7 +100,7 @@ export type CombinedVueInstance<
   Methods,
   Computed,
   Props,
-  SetupBindings
+  SetupBindings = {}
 > = Data &
   Methods &
   Computed &
@@ -114,7 +114,7 @@ export type ExtendedVue<
   Methods,
   Computed,
   Props,
-  SetupBindings
+  SetupBindings = {}
 > = VueConstructor<
   CombinedVueInstance<Instance, Data, Methods, Computed, Props, SetupBindings> &
     Vue


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR makes the `SetupBindings` parameter optional on types `ExtendedVue` and `CombinedVueInstance`.
See 
- https://github.com/vuejs/vue/issues/12726
- https://github.com/vuejs/vue/issues/12717

Steps to repro:
```
git clone git@github.com:jf-paradis/demo-vue-issues.git
cd demo-vue-issues
npm install
npm run test
```