### PR TITLE
feat(types): only extract default prop types if prop options

### DIFF
--- a/types/test/v3/define-component-test.tsx
+++ b/types/test/v3/define-component-test.tsx
@@ -5,7 +5,8 @@ import {
   PropType,
   ref,
   reactive,
-  ComponentPublicInstance
+  ComponentPublicInstance,
+  DefineComponent
 } from '../../index'
 import { describe, test, expectType, expectError, IsUnion } from '../utils'
 
@@ -828,6 +829,21 @@ describe('defineComponent', () => {
     })
   })
 })
+
+describe('union props DefineComponent', () => {
+  type Props = { a: string, b: number } | { a: number }
+  const MyComponent = {} as DefineComponent<Props>
+  expectType<JSX.Element>(<MyComponent a="1" b={9} />)
+  expectType<JSX.Element>(<MyComponent a={0} />)
+  // @ts-expect-error
+  expectError(<MyComponent a="2" />)
+  // @ts-expect-error
+  expectError(<MyComponent a={2} b />)
+  // @ts-expect-error
+  expectError(<MyComponent b={2} />)
+})
+
+
 
 describe('emits', () => {
   // Note: for TSX inference, ideally we want to map emits to onXXX props,

--- a/types/v3-define-component.d.ts
+++ b/types/v3-define-component.d.ts
@@ -48,7 +48,7 @@ export type DefineComponent<
     E,
     Props,
     Defaults,
-    true
+    PropsOrPropOptions extends ComponentPropsOptions ? true : false
   > &
     Props
 > &


### PR DESCRIPTION
Only extract default prop types if prop options, this allows `DefineComponent` to be used as a public API for exposing component types with union types

Example cases are arguments external 3rd party components, or internal components. The default props only need to be extracted when using `defineComponent` when using `DefineComponent` type this is not necessary to do and breaks props that are unions.  

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
