### PR TITLE
fix: allow keys from Object.prototype like 'constructor' etc as value in attribute 'key'

### DIFF
--- a/src/core/vdom/patch.ts
+++ b/src/core/vdom/patch.ts
@@ -557,7 +557,7 @@ export function createPatchFunction(backend) {
   }
 
   function checkDuplicateKeys(children) {
-    const seenKeys = {}
+    const seenKeys = Object.create(null)
     for (let i = 0; i < children.length; i++) {
       const vnode = children[i]
       const key = vnode.key


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When i use "constructor" as attribute "key", i have warning in console: - `[Vue warn]: Duplicate keys detected: 'constructor'. This may cause an update error.`

https://codesandbox.io/s/angry-stitch-kb2go1

It's behavior because of incorrect object creation inside `checkDuplicateKeys` function.

`const seenKeys = {}`  - mean make object with default prototype(Object.prototype).