### PR TITLE
Feat/show important directive

### DIFF
--- a/packages/server-renderer/src/directives/show.ts
+++ b/packages/server-renderer/src/directives/show.ts
@@ -4,9 +4,9 @@ export default function show(node: VNodeWithData, dir: VNodeDirective) {
   if (!dir.value) {
     const style: any = node.data.style || (node.data.style = {})
     if (Array.isArray(style)) {
-      style.push({ display: 'none' })
+      style.push({ display: dir?.modifiers?.important ? 'none !important' : 'none' })
     } else {
-      style.display = 'none'
+      style.display = dir?.modifiers?.important ? 'none !important' : 'none'
     }
   }
 }

--- a/test/unit/features/directives/show.spec.ts
+++ b/test/unit/features/directives/show.spec.ts
@@ -8,6 +8,14 @@ describe('Directive v-show', () => {
     }).$mount()
     expect(vm.$el.firstChild.style.display).toBe('')
   })
+  
+  it('should check not show value is truthy with display none important', () => {
+    const vm = new Vue({
+      template: '<div><span v-show.important="foo">hello</span></div>',
+      data: { foo: false }
+    }).$mount()
+    expect(vm.$el.firstChild.style.display).toBe('none !important')
+  })
 
   it('should check show value is falsy', () => {
     const vm = new Vue({


### PR DESCRIPTION
Adding support for `important `modifier on `v-show` directive

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

The explanation to include this feature is when you have a component (from an external library or own component) and this component has a display flex (or other display property on CSS), the v-show directive doesn't work showing the content you are trying to hide/show. You can make a workaround, like switching the class with the condition used into the directive, but it could be easier for developers only add this modifier
