### PR TITLE
fix(keep-alive): avoid change reference of keep-alive's vnode on prev…

### DIFF
--- a/src/core/instance/lifecycle.ts
+++ b/src/core/instance/lifecycle.ts
@@ -281,7 +281,11 @@ export function updateChildComponent(
   vm.$options._parentVnode = parentVnode
   vm.$vnode = parentVnode // update vm's placeholder node without re-render
 
-  if (vm._vnode) {
+  // avoid change reference of keep-alive's vnode on prev _vnode
+  if (
+    vm._vnode &&
+    !(vm.$options._componentTag === 'keep-alive' && vm._vnode.tag)
+  ) {
     // update child tree's parent
     vm._vnode.parent = parentVnode
   }


### PR DESCRIPTION
fix #12827

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Avoid change reference of keep-alive's vnode on prev _vnode otherwise the new componet's vm will be referenced by older vm.