### PR TITLE
fix: `inBrowser` needs to check existence of `document`

### DIFF
--- a/src/core/util/env.ts
+++ b/src/core/util/env.ts
@@ -2,7 +2,7 @@
 export const hasProto = '__proto__' in {}
 
 // Browser environment sniffing
-export const inBrowser = typeof window !== 'undefined'
+export const inBrowser = typeof window !== 'undefined' && typeof document !== 'undefined'
 export const UA = inBrowser && window.navigator.userAgent.toLowerCase()
 export const isIE = UA && /msie|trident/.test(UA)
 export const isIE9 = UA && UA.indexOf('msie 9.0') > 0


### PR DESCRIPTION
## Motivation

Use vuex+vue2 in chrome extension MV3 will be throw some env errors like: `document is not defined`.
Reason:
- In MV3, `document` object has moved to [Offscreen API](https://developer.chrome.com/docs/extensions/migrating/to-service-workers/#move-dom-and-window), alsot setting env to `VUE_ENV=server` will have not effect.
- In MV2 works fine

This PR can fix it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
