### PR TITLE
fix(types): fix method-based emits with props

### DIFF
--- a/types/test/v3/setup-test.ts
+++ b/types/test/v3/setup-test.ts
@@ -104,3 +104,20 @@ const vm = new Vue({
 })
 
 vm.$mount('#app')
+
+// props + method-based emits + setup
+defineComponent({
+  props: {
+    foo: Number
+  },
+  emits: {
+    'update:foo'(value: number) {}
+  },
+  setup(_, { emit }) {
+    emit('update:foo', 123)
+    // @ts-expect-error
+    emit('update:foo', '123')
+    // @ts-expect-error
+    emit('bar')
+  }
+})

--- a/types/v3-component-options.d.ts
+++ b/types/v3-component-options.d.ts
@@ -147,10 +147,9 @@ export type ComponentOptionsWithProps<
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   Emits extends EmitsOptions = {},
   EmitsNames extends string = string,
-  Props = ExtractPropTypes<PropsOptions>,
   Defaults = ExtractDefaultPropTypes<PropsOptions>
 > = ComponentOptionsBase<
-  Props,
+  ExtractPropTypes<PropsOptions>,
   RawBindings,
   D,
   C,
@@ -164,7 +163,7 @@ export type ComponentOptionsWithProps<
   props?: PropsOptions
 } & ThisType<
     CreateComponentPublicInstance<
-      Props,
+      ExtractPropTypes<PropsOptions>,
       RawBindings,
       D,
       C,

--- a/types/v3-define-component.d.ts
+++ b/types/v3-define-component.d.ts
@@ -150,30 +150,17 @@ export function defineComponent<
   EmitsNames extends string = string,
   PropsOptions extends ComponentPropsOptions = ComponentPropsOptions
 >(
-  options: HasDefined<Props> extends true
-    ? { functional?: never } & ComponentOptionsWithProps<
-        PropsOptions,
-        RawBindings,
-        D,
-        C,
-        M,
-        Mixin,
-        Extends,
-        Emits,
-        EmitsNames,
-        Props
-      >
-    : { functional?: never } & ComponentOptionsWithProps<
-        PropsOptions,
-        RawBindings,
-        D,
-        C,
-        M,
-        Mixin,
-        Extends,
-        Emits,
-        EmitsNames
-      >
+  options: { functional?: never } & ComponentOptionsWithProps<
+    PropsOptions,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    Emits,
+    EmitsNames
+  >
 ): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, Emits>
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In v2.7 (for now I'm using, it's 2.7.14), when using `defineComponent` with `props`, method-based `emits` and `setup` like the code snippet below:

```ts
defineComponent({
  props: {
    foo: Number
  },
  emits: {
    'update:foo'(value: number) {}
  },
  setup(_, { emit }) {
    emit('update:foo', 123) // OK
    emit('update:foo', '123') // expect error, but passed
    emit('bar') // expect error, but passed
  }
})
```

the second and the third `emit` call in `setup` won't raise any TypeScript type-check errors.

However, if I change `emits` to using arrow functions like this:

```diff
defineComponent({
  props: {
    foo: Number
  },
  emits: {
-   'update:foo'(value: number) {}
+   'update:foo': (value: number) => {}
  },
  setup(_, { emit }) {
    emit('update:foo', 123) // OK
    emit('update:foo', '123') // error is raised as expected
    emit('bar') // error is raised as expected
  }
})
```

This PR fixes this by removing the `Props` generic from `ComponentOptionsWithProps`. In Overload 3 of `defineComponent`, `props` is always defined so there's no need to check if `props` is defined or not by using `HasDefined` type, then we inlined `ExtractPropTypes<PropsOptions>` (the default type of the removed `Props` generic).