### PR TITLE
chore(compiler-sfc): specify prettier version (fix #13052)

### DIFF
--- a/packages/compiler-sfc/package.json
+++ b/packages/compiler-sfc/package.json
@@ -30,5 +30,8 @@
     "pug": "^3.0.2",
     "sass": "^1.52.3",
     "stylus": "^0.58.1"
+  },
+  "optionalDependencies": {
+    "prettier": "^1.18.2 || ^2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,10 @@ importers:
       source-map:
         specifier: ^0.6.1
         version: 0.6.1
+    optionalDependencies:
+      prettier:
+        specifier: ^1.18.2 || ^2.0.0
+        version: 2.7.1
     devDependencies:
       '@babel/types':
         specifier: ^7.19.4
@@ -5098,7 +5102,6 @@ packages:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
 
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}


### PR DESCRIPTION
close: #13052

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

`@vue/compiler-sfc` optionally uses Prettier and it is not compatible with Prettier v3.

But `prettier` is not listed in the `package.json`.

It wasn't a problem with Prettier v2 because prettier is [optional dependency of `component-compiler-utils`](https://github.com/vuejs/component-compiler-utils/blob/82a37174990e31eaec609887a0ec262f06b454dd/package.json#L69). So Prettier is installed anyway and everything works.

But if some project has `Prettier@3`, then `@vue/compiler-sfc` uses project's prettier and fails.

There was the same issue early in [component-compiler-utils](https://github.com/vuejs/component-compiler-utils). See:
- https://github.com/vuejs/component-compiler-utils/commit/aea1b79765f0f6d688e64b7698d5ff62862002d1
- https://github.com/vuejs/component-compiler-utils/pull/89

This PR specifies Prettier as an `optionalDependency` of `@vue/compiler-sfc`. With specified dependency, it will use `prettier@2` even if a project has `prettier@3`.

P.S. I used the same versions as it was in the `component-compiler-utils`. It seems it has the same code.

**Alternative solution:** make `@vue/compiler-sfc` compatible with both `Prettier@"1 || 2"` and `Prettier@3`. The problem is that it will make the compile function async.