### PR TITLE
fix: type augmentation and compiler-sfc types w/moduleResolution: bundler (fix #13106)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   ],
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": {
         "node": "./dist/vue.runtime.mjs",
         "default": "./dist/vue.runtime.esm.js"
       },
-      "require": "./dist/vue.runtime.common.js",
-      "types": "./types/index.d.ts"
+      "require": "./dist/vue.runtime.common.js"
     },
     "./compiler-sfc": {
       "types": "./compiler-sfc/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "types": "./types/index.d.ts"
     },
     "./compiler-sfc": {
+      "types": "./compiler-sfc/index.d.ts",
       "import": "./compiler-sfc/index.mjs",
       "require": "./compiler-sfc/index.js"
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "require": "./compiler-sfc/index.js"
     },
     "./dist/*": "./dist/*",
-    "./types/*": "./types/*",
+    "./types/*": ["./types/*.d.ts", "./types/*"],
     "./package.json": "./package.json"
   },
   "sideEffects": false,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Each commit contains a pretty lengthy description to try to make things as clear as possible. Rather than reproduce that here, the short version is that this PR contains two bug fixes:
1) Fixes #13106 which deals with type augmentation being broken in the ecosystem when enabling the "moduleResolution": "bundler" typescript option. This is due to the export map requiring full filenames with extensions, even though they are almost never provided as such
2) Fixes an issue with the types being unavailable from a `"type": "module"` context when using "moduleResolution": "bundler" | "node16"