### PR TITLE
fix(core - patch)：when before patch: old keys like [a, b, c ...] new …

### DIFF
--- a/src/core/vdom/patch.ts
+++ b/src/core/vdom/patch.ts
@@ -510,7 +510,10 @@ export function createPatchFunction(backend) {
           )
         } else {
           vnodeToMove = oldCh[idxInOld]
-          if (sameVnode(vnodeToMove, newStartVnode)) {
+          // when before patch: old keys like [a, b, c ...] new keys like [d, b, b, e, ....]
+          // when patch the second key "b" Vnode by new children
+          // the vnodeToMove will be undefined, so need add a condition for vnodeToMove
+          if (vnodeToMove && sameVnode(vnodeToMove, newStartVnode)) {
             patchVnode(
               vnodeToMove,
               newStartVnode,


### PR DESCRIPTION
…keys like [d, b, b, e, ....], when patch the second key "b" Vnode by new children, the vnodeToMove will be undefined, so need add a condition for vnodeToMove

fix an error when diff patch, when before patch: old keys like [a, b, c ...] new keys like [d, b, b, e, ....], when patch the second key "b" Vnode by new children, the vnodeToMove will be undefined, so need add a condition for vnodeToMove

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
