### PR TITLE
fix(types): backport fix for `withDefaults` when used together with generics

### DIFF
--- a/types/test/setup-helpers-test.ts
+++ b/types/test/setup-helpers-test.ts
@@ -98,6 +98,40 @@ describe('defineProps w/ runtime declaration', () => {
   props2.baz
 })
 
+describe('defineProps w/ generic type declaration + withDefaults', <T extends number, TA extends {
+  a: string
+}, TString extends string>() => {
+  const res = withDefaults(
+    defineProps<{
+      n?: number
+      bool?: boolean
+
+      generic1?: T[] | { x: T }
+      generic2?: { x: T }
+      generic3?: TString
+      generic4?: TA
+    }>(),
+    {
+      n: 123,
+
+      generic1: () => [123, 33] as T[],
+      generic2: () => ({ x: 123 } as { x: T }),
+
+      generic3: () => 'test' as TString,
+      generic4: () => ({ a: 'test' } as TA)
+    }
+  )
+
+  res.n + 1
+
+  expectType<T[] | { x: T }>(res.generic1)
+  expectType<{ x: T }>(res.generic2)
+  expectType<TString>(res.generic3)
+  expectType<TA>(res.generic4)
+
+  expectType<boolean>(res.bool)
+})
+
 describe('defineEmits w/ type declaration', () => {
   const emit = defineEmits<(e: 'change') => void>()
   emit('change')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

There's a potential breaking change: defaults using a generic type must be declared via `() => T` instead of `T`even if they're primitive types.

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included


**Other information:**


This PR is nothing but a backport of https://github.com/vuejs/core/pull/8335 by @pikax to the Vue 2 codebase, fixing support for generics when using the `withDefaults`helper since we're relying on it to ease our migration from Vue 2 to Vue 3. I take no merit whatsoever besides taking the time to apply it to the Vue 2 codebase and test if it works.

Please let me know if it can be merged!
