### PR TITLE
Removed unnecessary period for consistency in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,7 @@ In addition, the following features are explicitly **NOT** ported:
 - ❌ Top-level `await` in `<script setup>` (Vue 2 does not support async component initialization)
 - ❌ TypeScript syntax in template expressions (incompatible w/ Vue 2 parser)
 - ❌ Reactivity transform (still experimental)
-- ❌ `expose` option is not supported for options components (but `defineExpose()` is supported in `<script setup>`).
+- ❌ `expose` option is not supported for options components (but `defineExpose()` is supported in `<script setup>`)
 
 ### TypeScript Changes
 


### PR DESCRIPTION
Removed a period at the end of a specific line in the README to maintain consistency with similar lines. All other lines of this type did not include a period, and this correction ensures uniform formatting and readability.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
