### PR TITLE
chore(warn): include key name in inject() usage warning

### DIFF
--- a/src/v3/apiInject.ts
+++ b/src/v3/apiInject.ts
@@ -66,6 +66,7 @@ export function inject(
       warn(`injection "${String(key)}" not found.`)
     }
   } else if (__DEV__) {
-    warn(`inject() can only be used inside setup() or functional components.`)
+    const keyName = key ? String(key) : 'unknown'
+    warn(`inject(${keyName}) can only be used inside setup() or functional components.`)
   }
-}
+}  


### PR DESCRIPTION
- This PR improves the developer warning message in inject() when used outside setup() or functional components.

**Before:**

 inject() can only be used inside setup() or functional components.

**After:**

 inject("userStore") can only be used inside setup() or functional components.

- This makes it easier for developers to identify which injection key caused the warning.

- solves issue #13287 