### PR TITLE
docs: make README top-level H1 to satisfy markdownlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Vue 2 has reached End of Life
+# Vue 2 has reached End of Life
 
 **You are looking at the now inactive repository for Vue 2. The actively maintained repository for the latest version of Vue is [vuejs/core](https://github.com/vuejs/core).**
 


### PR DESCRIPTION
Make the README's first line a top-level heading (#) so it complies with markdownlint rule MD041 (first-line-heading). This is a small documentation-only change that fixes linter warnings.