### PR TITLE
fix(v3): include key in inject() warning message

### DIFF
--- a/src/v3/apiInject.ts
+++ b/src/v3/apiInject.ts
@@ -66,6 +66,5 @@ export function inject(
       warn(`injection "${String(key)}" not found.`)
     }
   } else if (__DEV__) {
-    warn(`inject() can only be used inside setup() or functional components.`)
-  }
+    warn(`inject(${String(key)}) can only be used inside setup() or functional components.`)
 }


### PR DESCRIPTION
Improves the warning message in the inject() function to include the key being injected.

This addresses issue #13287 where users were unable to identify which inject() call was failing without the key information in the warning message.

Changes made:
- Modified src/v3/apiInject.ts line 69 to include the injected key in the warning message
- The warning now displays: inject(<key>) can only be used inside setup() or functional components.
- This matches the pattern used in the error message on line 66

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
