### PR TITLE
fix: preserve nested pre whitespace

### DIFF
--- a/src/compiler/parser/index.ts
+++ b/src/compiler/parser/index.ts
@@ -109,7 +109,7 @@ export function parse(template: string, options: CompilerOptions): ASTElement {
   let root
   let currentParent
   let inVPre = false
-  let inPre = false
+  let inPre = 0
   let warned = false
 
   function warnOnce(msg, range) {
@@ -173,7 +173,7 @@ export function parse(template: string, options: CompilerOptions): ASTElement {
       inVPre = false
     }
     if (platformIsPreTag(element.tag)) {
-      inPre = false
+      inPre = Math.max(inPre - 1, 0)
     }
     // apply post-transforms
     for (let i = 0; i < postTransforms.length; i++) {
@@ -287,7 +287,7 @@ export function parse(template: string, options: CompilerOptions): ASTElement {
         }
       }
       if (platformIsPreTag(element.tag)) {
-        inPre = true
+        inPre += 1
       }
       if (inVPre) {
         processRawAttrs(element)

--- a/test/unit/modules/compiler/parser.spec.ts
+++ b/test/unit/modules/compiler/parser.spec.ts
@@ -1113,6 +1113,18 @@ describe('parser', () => {
     expect(pre2.children[0].text).toBe('\nabc')
   })
 
+  it(`preserve whitespace after nested <pre> tags with whitespace: 'condense'`, () => {
+    const options = extend({}, condenseOptions)
+    const ast = parse(
+      '<pre>1\n\n2\n\n<pre>aaa\nbbb\nc\n</pre>\n3\n</pre>',
+      options
+    )
+    expect(ast.tag).toBe('pre')
+    expect(ast.children[1].tag).toBe('pre')
+    expect(ast.children[2].type).toBe(3)
+    expect(ast.children[2].text).toBe('\n3\n')
+  })
+
   it(`keep first newline after unary tag in <pre> with whitespace: 'condense'`, () => {
     const options = extend({}, condenseOptions)
     const ast = parse('<pre>abc<input>\ndef</pre>', options)


### PR DESCRIPTION
Issue link: https://github.com/vuejs/vue/issues/12965

Summary:
- track nested <pre> depth so condense mode keeps whitespace inside the outer <pre>
- add regression coverage for nested <pre> with whitespace: 'condense'

Motivation:
- avoid trimming newlines after an inner <pre> closes inside an outer <pre>

Validation:
- pnpm test:unit -- test/unit/modules/compiler/parser.spec.ts